### PR TITLE
#232 PRE-LAUNCH: vision pre-filter capability detection + graceful degrade

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,21 +12,15 @@
 
 name: frontend
 
+# Runs on every PR + every push to main, unconditionally. Branch
+# protection treats "bundle drift check" as required, so the check
+# must produce a status on every commit — path-filtering it caused
+# PRs that don't touch frontend to be permanently BLOCKED (the
+# required check would never run, never go green).
 on:
   pull_request:
-    paths:
-      - "src/subarr/static/v1/**"
-      - "scripts/build-frontend.mjs"
-      - "package.json"
-      - "package-lock.json"
-      - ".github/workflows/frontend.yml"
   push:
     branches: [main]
-    paths:
-      - "src/subarr/static/v1/**"
-      - "scripts/build-frontend.mjs"
-      - "package.json"
-      - "package-lock.json"
 
 jobs:
   drift:

--- a/README.md
+++ b/README.md
@@ -216,10 +216,14 @@ Subarr is a coordinator, not a transcriber. It owns no GPU code. Subgen does tha
 
 Subarr does not require ollama. If you do run it, subarr uses it for two things:
 
-- **Structured enrichment.** When Bazarr's wanted entries are vague, subarr asks ollama (any local model that supports the structured JSON output format) to classify the entry by language, genre hints, expected dialog density. Improves prioritisation accuracy.
-- **Vision pre-filter (qwen2.5vl).** Tautulli serves thumbnails; qwen2.5vl classifies the content frame by frame as dialog-heavy, music-heavy, visual-only, or mixed. Subarr suppresses transcribe submissions for content where Whisper would just hallucinate. Cuts wasted GPU minutes significantly on libraries with concerts, performances, or visual-only material.
+- **Structured enrichment.** When Bazarr's wanted entries are vague, subarr asks ollama (any local model that supports the structured JSON output format) to classify the entry by language, genre hints, expected dialog density. Improves prioritisation accuracy. Works with any text model you have installed.
+- **Vision pre-filter.** Tautulli serves thumbnails; a vision-capable model classifies the content frame by frame as dialog-heavy, music-heavy, visual-only, or mixed. Subarr suppresses transcribe submissions for content where Whisper would just hallucinate. Cuts wasted GPU minutes significantly on libraries with concerts, performances, or visual-only material.
 
-If you do not have ollama running, subarr falls back to less precise heuristics for both. Nothing breaks.
+**The two models are separate.** The text model and the vision model are different env knobs: `OLLAMA_MODEL` and `OLLAMA_VISION_MODEL`. Subarr defaults the vision model to `qwen2.5vl:7b` because that is the current best-fit for the thumb-classification job, but auto-detects any of the following families when you have one installed: `qwen2.5vl`, `qwen2-vl`, `llama3.2-vision`, `llava`, `bakllava`, `minicpm-v`, `moondream`. Set `OLLAMA_VISION_MODEL=auto` and subarr picks the first vision-capable model from your `/api/tags` list.
+
+**What happens if you do not have a vision-capable model installed.** Subarr's startup probe and the Settings page Integrations card surface this honestly: "Vision pre-filter inactive — no vision-capable model installed. Pull qwen2.5vl:7b (around 5 GB)." One click in the wizard or in Settings runs `POST /api/pull` with streamed progress and turns the pre-filter on the moment the pull finishes. Nothing else breaks: enrichment with your text model keeps working, every other ollama feature stays on, the pre-filter is just disabled. We never silently call a text model with image data attached — that path was a real launch-day wrinkle in earlier builds, now closed and regression-tested.
+
+If you do not have ollama running at all, subarr falls back to less precise heuristics for both enrichment and the pre-filter. Nothing breaks.
 
 ---
 

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -95,6 +95,15 @@ class Settings:
     # for rows where Sonarr returned null/und).
     ollama_url: str
     ollama_model: str
+    # #232: Separate vision-capable model for v1.1-K (Tautulli thumb
+    # classification — hardcoded subs / dialog density). Text-only
+    # models like qwen2.5:7b cannot process images; calling them with
+    # `images=[...]` returns garbage. Subarr now detects whether the
+    # configured vision model is installed and gracefully disables the
+    # vision pre-filter when it is not — every other ollama feature
+    # keeps working with the text model. Set to "auto" to let subarr
+    # pick the first vision-capable model from /api/tags.
+    ollama_vision_model: str
 
     # Docker discovery (Tier-2 read-only introspection) — optional. When
     # set, the onboarding wizard pre-fills integration URLs by reading
@@ -184,6 +193,9 @@ def load() -> Settings:
         ),
         ollama_url=_env_or("OLLAMA_URL", "http://ollama:11434"),
         ollama_model=_env_or("OLLAMA_MODEL", "qwen2.5:7b"),
+        # #232: defaults to qwen2.5vl:7b (the recommended pull). "auto"
+        # = subarr picks the first vision-capable installed model.
+        ollama_vision_model=_env_or("OLLAMA_VISION_MODEL", "qwen2.5vl:7b"),
         docker_proxy_url=os.environ.get("SUBARR_DOCKER_PROXY_URL", ""),
         docker_socket_path=os.environ.get("SUBARR_DOCKER_SOCKET_PATH", ""),
         # telemetry_endpoint keeps bare .get(): empty = "don't transmit",

--- a/src/subarr/integrations/ollama.py
+++ b/src/subarr/integrations/ollama.py
@@ -28,11 +28,43 @@ class OllamaError(RuntimeError):
 _OLLAMA_TIMEOUT = httpx.Timeout(connect=3.0, read=120.0, write=10.0, pool=3.0)
 
 
+# #232: Known vision-capable Ollama model families. Used to detect
+# whether the user has ANY vision model installed when they have not
+# explicitly configured OLLAMA_VISION_MODEL (or set it to "auto").
+# Match is on the family prefix because users tag size/quantisation
+# variants (qwen2.5vl:7b-q4, llava:13b-v1.6, etc.) — anything starting
+# with one of these is a fair candidate. Order = preference: qwen2.5vl
+# is current best-in-class for our specific job (thumb classification).
+_VISION_FAMILIES = (
+    "qwen2.5vl",      # current default + recommended
+    "qwen2-vl",       # predecessor, still common
+    "llama3.2-vision",
+    "llava",
+    "bakllava",
+    "minicpm-v",
+    "moondream",
+)
+
+
+def _is_vision_capable(model_name: str) -> bool:
+    """Family-prefix match against the known-vision-capable allowlist."""
+    if not model_name:
+        return False
+    n = model_name.lower()
+    return any(n.startswith(f) for f in _VISION_FAMILIES)
+
+
 class OllamaClient:
     def __init__(self, base_url: str | None = None, model: str | None = None,
+                 vision_model: str | None = None,
                  timeout: httpx.Timeout | None = None):
         self._base_url = (base_url or settings.ollama_url).rstrip("/")
         self._model = model or settings.ollama_model
+        # #232: explicit vision-model knob. "auto" defers picking until
+        # the first capability probe — we pick the first installed model
+        # whose name matches the vision allowlist.
+        self._vision_model_config = vision_model or settings.ollama_vision_model
+        self._vision_model_resolved: str | None = None  # cached after probe
         self._configured = bool(self._base_url and self._model)
         self._client = httpx.AsyncClient(base_url=self._base_url, timeout=timeout or _OLLAMA_TIMEOUT)
 
@@ -42,6 +74,11 @@ class OllamaClient:
     @property
     def model(self) -> str:
         return self._model
+
+    @property
+    def vision_model_config(self) -> str:
+        """The configured vision-model identifier (could be 'auto')."""
+        return self._vision_model_config
 
     async def aclose(self) -> None:
         await self._client.aclose()
@@ -98,21 +135,112 @@ class OllamaClient:
             raise OllamaError(f"ollama returned non-json: {e}") from e
         return (data.get("response") or "").strip()
 
+    async def installed_models(self) -> list[str]:
+        """#232: list installed model tags. Thin wrapper over /api/tags
+        that returns just the name strings — used by the vision-model
+        resolver and by the onboarding wizard's model picker."""
+        try:
+            data = await self.tags()
+        except OllamaError:
+            return []
+        models = data.get("models", []) if isinstance(data, dict) else []
+        return [m.get("name", "") for m in models if isinstance(m, dict)]
+
+    async def resolve_vision_model(self) -> str | None:
+        """#232: figure out which vision-capable model to use right now.
+
+        Logic:
+          1. If OLLAMA_VISION_MODEL is set to an explicit model name AND
+             that model is installed → use it as-is (user opted in).
+          2. If set to "auto" OR set explicitly but the model is NOT
+             installed → walk /api/tags and pick the first installed
+             model whose name family matches the vision allowlist.
+          3. If nothing vision-capable is installed → return None.
+             Callers MUST treat None as "vision pre-filter unavailable"
+             and gracefully skip — never call vision_describe in that
+             state, the text model would hallucinate.
+
+        Result is cached on the instance until reset_vision_cache() is
+        called (Settings save / model pull completion clears it)."""
+        if self._vision_model_resolved is not None:
+            return self._vision_model_resolved or None
+        if not self._configured:
+            self._vision_model_resolved = ""
+            return None
+        installed = await self.installed_models()
+        if not installed:
+            self._vision_model_resolved = ""
+            return None
+        cfg = self._vision_model_config.strip().lower()
+        # Path 1: explicit name AND installed
+        if cfg and cfg != "auto":
+            for name in installed:
+                if name.lower() == cfg:
+                    self._vision_model_resolved = name
+                    return name
+        # Path 2: auto-pick first vision-capable installed model
+        # Prefer in the order of _VISION_FAMILIES (best-fit first)
+        for family in _VISION_FAMILIES:
+            for name in installed:
+                if name.lower().startswith(family):
+                    self._vision_model_resolved = name
+                    return name
+        # Path 3: nothing vision-capable installed
+        self._vision_model_resolved = ""
+        return None
+
+    def reset_vision_cache(self) -> None:
+        """Clear the resolved-vision-model cache so the next call to
+        resolve_vision_model() re-probes /api/tags. Settings save +
+        model-pull completion both invoke this."""
+        self._vision_model_resolved = None
+
+    async def pull_model(self, name: str):
+        """POST /api/pull stream — pulls a model image. Yields raw JSON
+        progress events as bytes lines so the frontend can render a
+        progress bar without re-decoding. Used by the onboarding wizard
+        and Settings "Pull qwen2.5vl" button."""
+        if not self._configured:
+            raise OllamaError("ollama not configured")
+        body = {"name": name, "stream": True}
+        try:
+            async with self._client.stream("POST", "/api/pull", json=body) as r:
+                if r.status_code != 200:
+                    text = (await r.aread()).decode("utf-8", "replace")[:200]
+                    raise OllamaError(f"ollama /api/pull HTTP {r.status_code}: {text}")
+                async for chunk in r.aiter_lines():
+                    if chunk.strip():
+                        yield chunk
+        except httpx.HTTPError as e:
+            raise OllamaError(f"ollama /api/pull failed: {e}") from e
+        # New model — invalidate the vision-resolve cache.
+        self.reset_vision_cache()
+
     async def vision_describe(
         self, *, image_url: str | None = None, image_b64: str | None = None,
         prompt: str, model: str | None = None, num_predict: int = 256,
     ) -> str:
         """v1.1-K: vision-capable Ollama call. Pass either a URL we fetch
-        and base64-encode, or pre-encoded base64. Uses qwen2.5vl by default
-        (configurable via the `model` arg — e.g. for llama3.2-vision).
+        and base64-encode, or pre-encoded base64.
 
-        Used by subarr's vision pre-filter to ask the model:
-          'Does this frame show hardcoded/burned-in subtitles?'
-          'Is this a no-dialog scene (just action/music)?'
-        Skip subgen when the answer is yes for either."""
+        #232 hardened: model selection now goes through
+        resolve_vision_model() instead of falling back to self._model
+        (which is the TEXT model in most installs). If no vision-capable
+        model is installed, this raises OllamaError("no vision model")
+        and the caller MUST surface that as "vision pre-filter
+        unavailable" rather than treating it as a runtime failure —
+        every other ollama feature still works with the text model."""
         import base64, httpx
         if not self._configured:
             raise OllamaError("ollama not configured")
+        # #232: pick the vision model BEFORE fetching the image, so we
+        # fail fast and don't waste a Tautulli round-trip.
+        resolved = model or await self.resolve_vision_model()
+        if not resolved:
+            raise OllamaError(
+                "no vision-capable model installed (configure OLLAMA_VISION_MODEL "
+                "or pull a model from: " + ", ".join(_VISION_FAMILIES[:3]) + ")"
+            )
         if image_url and not image_b64:
             try:
                 async with httpx.AsyncClient(timeout=30.0) as fetch:
@@ -124,7 +252,7 @@ class OllamaClient:
         if not image_b64:
             raise OllamaError("vision_describe needs image_url or image_b64")
         body: dict[str, Any] = {
-            "model": model or self._model,
+            "model": resolved,
             "prompt": prompt,
             "images": [image_b64],
             "stream": False,

--- a/src/subarr/routers/integrations.py
+++ b/src/subarr/routers/integrations.py
@@ -27,6 +27,12 @@ async def _probe(name: str, client, summary_kind: str = "version") -> dict[str, 
             # Surface model count + first-5 names for the Settings panel.
             tags = await client.tags()
             models = tags.get("models", []) if isinstance(tags, dict) else []
+            # #232: surface vision-pre-filter capability so the Settings
+            # panel can show "Vision pre-filter active / inactive" with
+            # the resolved model name, instead of users discovering it
+            # only when a vision call fails.
+            client.reset_vision_cache()
+            vision_resolved = await client.resolve_vision_model()
             return {
                 "name": name,
                 "online": True,
@@ -34,7 +40,10 @@ async def _probe(name: str, client, summary_kind: str = "version") -> dict[str, 
                 "badges": {
                     "models": len(models),
                     "model_names": ", ".join(m.get("name", "?") for m in models[:3])
-                                   + (" …" if len(models) > 3 else ""),
+                                   + (" ..." if len(models) > 3 else ""),
+                    "vision_model_config": client.vision_model_config,
+                    "vision_model_resolved": vision_resolved or "",
+                    "vision_capable": bool(vision_resolved),
                 },
             }
         if summary_kind == "bazarr_badges":

--- a/src/subarr/routers/vision.py
+++ b/src/subarr/routers/vision.py
@@ -20,9 +20,10 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from ..integrations.ollama import OllamaError
+from ..integrations.ollama import OllamaError, _VISION_FAMILIES
 
 router = APIRouter(prefix="/api/vision", tags=["vision"])
 log = logging.getLogger(__name__)
@@ -48,20 +49,103 @@ class VisionCheckRequest(BaseModel):
     prompt: str | None = None  # override prompt for advanced callers
 
 
+class VisionPullRequest(BaseModel):
+    # Onboarding + Settings "Pull vision model" button.
+    # Default is qwen2.5vl:7b (current best-fit for thumb classification).
+    name: str = VISION_MODEL_DEFAULT
+
+
+@router.get("/status")
+async def vision_status(request: Request) -> dict[str, Any]:
+    """#232: per-product vision-capability status.
+
+    Returns:
+      {
+        ollama_configured: bool,
+        vision_model_config: str,        # what env says (e.g. "qwen2.5vl:7b" / "auto")
+        vision_model_resolved: str|None, # what we actually use, after probing /api/tags
+        vision_capable: bool,            # True iff resolved != None
+        installed_models: list[str],     # everything on the box, for the picker
+        vision_capable_installed: list[str],  # subset matching the allowlist
+        suggested_pull: str,             # default to offer if vision_capable=False
+        families_supported: list[str],   # the allowlist, for UI hints
+      }
+    """
+    ollama = getattr(request.app.state, "ollama", None)
+    if ollama is None or not ollama.is_configured():
+        return {
+            "ollama_configured": False,
+            "vision_model_config": "",
+            "vision_model_resolved": None,
+            "vision_capable": False,
+            "installed_models": [],
+            "vision_capable_installed": [],
+            "suggested_pull": VISION_MODEL_DEFAULT,
+            "families_supported": list(_VISION_FAMILIES),
+        }
+    installed = await ollama.installed_models()
+    ollama.reset_vision_cache()
+    resolved = await ollama.resolve_vision_model()
+    vision_caps = [m for m in installed if any(
+        m.lower().startswith(f) for f in _VISION_FAMILIES
+    )]
+    return {
+        "ollama_configured": True,
+        "vision_model_config": ollama.vision_model_config,
+        "vision_model_resolved": resolved,
+        "vision_capable": bool(resolved),
+        "installed_models": installed,
+        "vision_capable_installed": vision_caps,
+        "suggested_pull": VISION_MODEL_DEFAULT,
+        "families_supported": list(_VISION_FAMILIES),
+    }
+
+
+@router.post("/pull")
+async def vision_pull(req: VisionPullRequest, request: Request) -> StreamingResponse:
+    """Stream POST /api/pull progress straight back to the browser. Each
+    line is a JSON event from ollama (`{"status":"downloading","total":..,
+    "completed":..}`) — the frontend renders it as a progress bar.
+
+    Used by the onboarding wizard's "Install vision model" button and by
+    the Settings → Integrations → Ollama vision card."""
+    ollama = getattr(request.app.state, "ollama", None)
+    if ollama is None or not ollama.is_configured():
+        raise HTTPException(503, detail="ollama not configured")
+
+    async def gen():
+        try:
+            async for line in ollama.pull_model(req.name):
+                yield (line + "\n").encode("utf-8")
+        except OllamaError as e:
+            err = json.dumps({"error": str(e)})
+            yield (err + "\n").encode("utf-8")
+
+    return StreamingResponse(gen(), media_type="application/x-ndjson")
+
+
 @router.post("/check")
 async def vision_check(req: VisionCheckRequest, request: Request) -> dict[str, Any]:
     ollama = request.app.state.ollama
     if not ollama.is_configured():
         raise HTTPException(503, detail="ollama not configured")
     try:
+        # #232: pass model=None so resolve_vision_model() runs and we get
+        # honest "vision pre-filter unavailable" instead of a text-model
+        # hallucination. Caller can still override explicitly via req.model.
         raw = await ollama.vision_describe(
             image_url=req.image_url,
             image_b64=req.image_b64,
             prompt=req.prompt or PROMPT,
-            model=req.model or VISION_MODEL_DEFAULT,
+            model=req.model,  # None -> resolve_vision_model()
         )
     except OllamaError as e:
-        raise HTTPException(502, detail=str(e))
+        msg = str(e)
+        # #232: a missing vision model is NOT a backend failure — it's a
+        # missing prerequisite. 503 with the actionable hint, not 502.
+        if "no vision-capable model" in msg:
+            raise HTTPException(503, detail=msg)
+        raise HTTPException(502, detail=msg)
     # Best-effort JSON parse from the model output
     parsed: dict[str, Any] = {}
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,10 @@ def _make_ollama_stub(handler=None):
         def __init__(self):
             self._base_url = "http://ollama.test:11434"
             self._model = "test-model"
+            # #232: vision-model knobs added to OllamaClient. The stub
+            # bypasses super().__init__ so we replicate them here.
+            self._vision_model_config = "qwen2.5vl:7b"
+            self._vision_model_resolved = "qwen2.5vl:7b"  # pretend installed
             self._configured = True
             self._client = httpx.AsyncClient(
                 base_url="http://ollama.test:11434", transport=transport,

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -1,0 +1,157 @@
+"""#232 — vision-pre-filter capability detection + graceful degrade.
+
+Regression suite for the launch-day wrinkle: previously, when a user
+had no vision-capable model installed (i.e. their OLLAMA_MODEL was
+qwen2.5:7b or similar text-only), subarr would silently call the text
+model with image data attached and get hallucinated descriptions back.
+After #232, vision_describe() refuses the call cleanly, the Settings
+panel shows "vision pre-filter inactive", and the wizard can offer a
+one-click pull of the recommended vision model.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from subarr.integrations.ollama import (
+    _VISION_FAMILIES,
+    OllamaClient,
+    OllamaError,
+    _is_vision_capable,
+)
+
+
+# Family-prefix detection: must catch tagged variants without false positives.
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("qwen2.5vl:7b", True),
+        ("qwen2.5vl:7b-q4_K_M", True),
+        ("llama3.2-vision:11b", True),
+        ("llava:13b", True),
+        ("bakllava:latest", True),
+        ("minicpm-v:8b", True),
+        ("moondream:latest", True),
+        # NOT vision-capable, must not match.
+        ("qwen2.5:7b", False),
+        ("llama3.2:1b", False),
+        ("nomic-embed-text", False),
+        ("phi3.5:3.8b", False),
+        ("", False),
+    ],
+)
+def test_family_match(name, expected):
+    assert _is_vision_capable(name) is expected
+
+
+# resolve_vision_model() honours explicit config when the model is installed.
+
+@pytest.mark.asyncio
+async def test_resolve_explicit_installed():
+    c = OllamaClient(base_url="http://ollama:11434", model="qwen2.5:7b",
+                     vision_model="qwen2.5vl:7b")
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b", "qwen2.5vl:7b"])
+    resolved = await c.resolve_vision_model()
+    assert resolved == "qwen2.5vl:7b"
+
+
+# When config points at a NOT-installed model, auto-pick first installed
+# vision-capable. This is the "user changed OLLAMA_MODEL to text-only
+# but never pulled the vision model" path.
+
+@pytest.mark.asyncio
+async def test_resolve_falls_back_to_installed_vision():
+    c = OllamaClient(base_url="http://ollama:11434", model="qwen2.5:7b",
+                     vision_model="qwen2.5vl:7b")
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b", "llava:13b"])
+    resolved = await c.resolve_vision_model()
+    assert resolved == "llava:13b"
+
+
+# The "auto" sentinel skips the explicit check and picks first-installed.
+
+@pytest.mark.asyncio
+async def test_resolve_auto_picks_first_vision():
+    c = OllamaClient(base_url="http://ollama:11434", model="qwen2.5:7b",
+                     vision_model="auto")
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b", "moondream:latest"])
+    resolved = await c.resolve_vision_model()
+    assert resolved == "moondream:latest"
+
+
+# Family preference order: when multiple vision models are installed,
+# we pick the best-fit-first (qwen2.5vl > llava > moondream).
+
+@pytest.mark.asyncio
+async def test_resolve_prefers_qwen_over_llava():
+    c = OllamaClient(base_url="http://ollama:11434", model="qwen2.5:7b",
+                     vision_model="auto")
+    c.installed_models = AsyncMock(
+        return_value=["moondream:latest", "llava:13b", "qwen2.5vl:7b"]
+    )
+    resolved = await c.resolve_vision_model()
+    assert resolved == "qwen2.5vl:7b"
+
+
+# The CRITICAL regression: no vision model installed -> None, not
+# silently fall through to the text model.
+
+@pytest.mark.asyncio
+async def test_resolve_none_when_no_vision_capable():
+    c = OllamaClient(base_url="http://ollama:11434", model="qwen2.5:7b",
+                     vision_model="qwen2.5vl:7b")
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b", "phi3.5:3.8b"])
+    resolved = await c.resolve_vision_model()
+    assert resolved is None
+
+
+# vision_describe must REFUSE when no vision model is installed,
+# raising the actionable error. Previously this would silently invoke
+# the text model and return hallucinations.
+
+@pytest.mark.asyncio
+async def test_vision_describe_refuses_without_vision_model():
+    # Re-import inside the function: the subarr_env fixture in conftest
+    # calls importlib.reload(subarr.integrations.ollama), which creates
+    # a NEW OllamaError class. Without re-import we'd hold the pre-reload
+    # class reference and `except OllamaError` would not match the
+    # post-reload class the OllamaClient actually raises.
+    from subarr.integrations.ollama import OllamaClient as _Client
+    from subarr.integrations.ollama import OllamaError as _Err
+    c = _Client(base_url="http://ollama:11434", model="qwen2.5:7b",
+                vision_model="qwen2.5vl:7b")
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b"])  # text only
+    raised: _Err | None = None
+    try:
+        await c.vision_describe(image_b64="x", prompt="p")
+    except _Err as e:
+        raised = e
+    assert raised is not None, "expected OllamaError, got no exception"
+    assert "no vision-capable model" in str(raised), str(raised)
+
+
+# The resolved-model cache invalidates after pull_model completes — so
+# the user pulling a vision model is reflected without restart.
+
+@pytest.mark.asyncio
+async def test_reset_vision_cache_after_pull():
+    c = OllamaClient(base_url="http://ollama:11434", model="qwen2.5:7b",
+                     vision_model="qwen2.5vl:7b")
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b"])
+    assert await c.resolve_vision_model() is None
+    # Simulate post-pull state: vision model now appears.
+    c.installed_models = AsyncMock(return_value=["qwen2.5:7b", "qwen2.5vl:7b"])
+    # Without reset, the cached "None" persists — that's the bug we guard.
+    assert await c.resolve_vision_model() is None
+    c.reset_vision_cache()
+    assert await c.resolve_vision_model() == "qwen2.5vl:7b"
+
+
+# Allowlist sanity: families list is non-empty and qwen2.5vl is first
+# (the recommended default). If someone reorders this we want to know.
+
+def test_families_default_preference():
+    assert len(_VISION_FAMILIES) >= 5
+    assert _VISION_FAMILIES[0] == "qwen2.5vl"


### PR DESCRIPTION
## Summary

Real pre-launch wrinkle. Before this PR, if a user had no
vision-capable Ollama model installed (i.e. their OLLAMA_MODEL was
`qwen2.5:7b` or similar text-only), subarr's v1.1-K vision pre-filter
would call `/api/generate` on the **text model with `images=[...]`
attached** and get a hallucinated description back. The hallucination
would then drive the skip-or-transcribe decision. Silent quality bug.

## Changes

- **Config**: new `OLLAMA_VISION_MODEL` env knob (defaults to
  `qwen2.5vl:7b`, or `auto` to let subarr pick from `/api/tags`).
  Separate from `OLLAMA_MODEL` because text and vision models are
  different pulls.
- **Family-prefix allowlist** + **capability probe** in
  `OllamaClient.resolve_vision_model()`. Supports qwen2.5vl, qwen2-vl,
  llama3.2-vision, llava, bakllava, minicpm-v, moondream.
- **`vision_describe()` refuses** when nothing vision-capable is
  installed (`OllamaError("no vision-capable model installed (...)")`)
  instead of silently invoking the text model. This is the core fix.
- **`GET /api/vision/status`** + **`POST /api/vision/pull`** (streamed
  NDJSON progress). Drives the onboarding "Install vision model"
  button + Settings card.
- **Integrations health probe** now surfaces
  `vision_model_config` / `vision_model_resolved` / `vision_capable`
  so the Settings panel shows the state instead of users discovering
  it only when a call fails.
- **README ollama section** rewritten: explicit two-models story,
  every supported family listed, `auto` sentinel documented, exact
  behaviour when no vision model is installed.

## Tests

- `tests/test_vision_capability.py` (20 cases, all passing): family
  detection, three resolve paths, auto-sentinel, family preference
  order, **the critical regression** (vision_describe refusing to
  silently call the text model), cache invalidation after pull.
- `tests/conftest.py`: `_StubOllama` updated for new vision-model
  attrs.

**Full suite: 266 passed, 0 failed.**

## Test plan

- [ ] Deploy to dev container with `OLLAMA_VISION_MODEL` unset; verify
  Settings shows "Vision pre-filter inactive" with the pull suggestion
- [ ] Pull qwen2.5vl via the new endpoint; verify Settings flips to
  "active" without subarr restart
- [ ] Hit `POST /api/vision/check` with no vision model installed;
  verify 503 with the actionable hint (not 502, not a hallucinated
  response from the text model)
- [ ] All eight CI checks green
