### PR TITLE
launch-prep: README restructure (259 lines), tone-gate CI, 3 issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/compat_question.yml
+++ b/.github/ISSUE_TEMPLATE/compat_question.yml
@@ -1,0 +1,45 @@
+name: Compat mode question
+description: Questions about running subarr with vanilla subgen, or which subarr-subgen patches are needed for what.
+title: "[compat] "
+labels: ["compat-mode", "question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The compat-mode story is one of the most-asked questions at launch. Use this template if your question is about: "do I have to swap to subarr-subgen?", "which features need which subgen patch?", "what works on vanilla subgen?", or "can I run both side by side?".
+
+        For bugs in an existing install, use the bug-report template instead.
+
+  - type: input
+    id: subgen-version
+    attributes:
+      label: What subgen image are you running?
+      placeholder: "mccloud/subgen:latest, or ghcr.io/coaxk/subarr-subgen:v4.7, or unsure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: detected-mode
+    attributes:
+      label: What does subarr's Settings → Integrations → Subgen show?
+      options:
+        - "Compat mode (vanilla detected)"
+        - "Full feature set (subarr-subgen detected)"
+        - "Subgen unreachable"
+        - "Not yet installed / haven't checked"
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What you're trying to do, and what you're unsure about.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Any context that might matter
+      description: Compose snippet, current Bazarr setup, library size, language mix, GPU vs CPU. Optional but speeds up the answer.

--- a/.github/ISSUE_TEMPLATE/provider_leaderboard_data.yml
+++ b/.github/ISSUE_TEMPLATE/provider_leaderboard_data.yml
@@ -1,0 +1,67 @@
+name: Provider leaderboard data point
+description: Share what's working (or not) on your install. Feeds v1.1 global provider leaderboard design.
+title: "[provider data] "
+labels: ["v1.1", "provider-leaderboard"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        v1.1 ships a global provider success leaderboard built from aggregated telemetry. The shape of the rankings depends on what real installs see in the wild. Sharing your numbers here helps tune the metric.
+
+        **Do NOT paste full Bazarr logs or anything with usernames / paths.** Just the per-provider success rate as Bazarr reports it.
+
+  - type: input
+    id: bazarr-version
+    attributes:
+      label: Bazarr version
+      placeholder: "1.5.6"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lang-mix
+    attributes:
+      label: Primary library languages
+      multiple: true
+      options:
+        - English
+        - French
+        - German
+        - Spanish
+        - Italian
+        - Portuguese
+        - Russian
+        - Japanese
+        - Korean
+        - Chinese (Mandarin/Cantonese)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: top-providers
+    attributes:
+      label: Your top 3 providers by success rate
+      description: |
+        Format: provider · success % · sample size (e.g. last 30 days)
+
+        Example:
+        - OpenSubtitles · 78% · 412 attempts
+        - Subscene · 64% · 287 attempts
+        - Addic7ed · 51% · 92 attempts
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: bottom-providers
+    attributes:
+      label: Your bottom providers (the ones you tolerate but don't trust)
+      description: Same format. Optional.
+      render: markdown
+
+  - type: textarea
+    id: surprises
+    attributes:
+      label: Any per-language surprises?
+      description: "E.g. 'OpenSubtitles is 89% for English but 11% for Japanese on my anime library'. These are the most useful data points."

--- a/.github/ISSUE_TEMPLATE/whisper_tuning_question.yml
+++ b/.github/ISSUE_TEMPLATE/whisper_tuning_question.yml
@@ -1,0 +1,58 @@
+name: Whisper kwargs / tuning question
+description: Questions about per-language Whisper kwargs, initial_prompt, or upcoming tuning lab.
+title: "[whisper] "
+labels: ["whisper", "v1.1-tuning-lab"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Per-language Whisper kwargs are one of the trickiest parts of running subgen well. v1.1 ships an in-app tuning lab and a crowdsourced "best kwargs by language" recommendation pulled from opt-in telemetry. Until that lands, this template captures your question so the answer feeds the tuning lab's defaults.
+
+  - type: input
+    id: language
+    attributes:
+      label: Language affected
+      placeholder: "Japanese / French / Spanish / ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: content-type
+    attributes:
+      label: Content type
+      options:
+        - Anime
+        - TV drama / scripted
+        - Documentary
+        - Music-heavy / concert / performance
+        - Sports commentary
+        - Mixed / hard to say
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-kwargs
+    attributes:
+      label: Current kwargs (if you've tuned them)
+      description: Paste your `SUBGEN_KWARGS_LANG_XX` env var, or "I haven't touched the defaults".
+      render: bash
+
+  - type: textarea
+    id: observed-problem
+    attributes:
+      label: What you're seeing
+      description: |
+        Concrete example better than vague description. E.g.:
+
+        - "Whisper repeats the same phrase 8x at the end of every Japanese anime file"
+        - "Opening titles get hallucinated as random English text before the dialog starts"
+        - "Songs in the middle of episodes get transcribed as gibberish"
+    validations:
+      required: true
+
+  - type: textarea
+    id: subgen-version
+    attributes:
+      label: Subgen + Whisper version
+      placeholder: "subarr-subgen v4.7, whisper-large-v3"

--- a/.github/workflows/tone-gate.yml
+++ b/.github/workflows/tone-gate.yml
@@ -1,0 +1,90 @@
+# Tone gate — fails the build if launch-sensitive marketing copy uses
+# phrasing that locked synthesis decision §6 explicitly disallowed.
+#
+# The whole product story rests on "subarr stands BESIDE Bazarr". Any
+# language that reads as a Bazarr-killer gets screencapped on r/bazarr
+# within hours and the launch dies. This gate is a copy-level CI check
+# so well-meaning future edits can't quietly drift back into dunk
+# phrasing.
+#
+# Scope: README.md + landing-asset copy. Code comments and tests are
+# intentionally NOT scanned — they are not user-facing.
+#
+# Adding a banned phrase here: edit the BANNED array below + open a PR.
+# Adding an allowed exception: prefix the offending line with the
+# tone-allow marker comment `<!-- tone-allow: <reason> -->` on the
+# preceding line.
+
+name: tone-gate
+
+on:
+  pull_request:
+    paths:
+      - README.md
+      - .github/workflows/tone-gate.yml
+  push:
+    branches: [main]
+    paths:
+      - README.md
+
+jobs:
+  scan:
+    name: scan for tone tripwires
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: scan
+        run: |
+          set -e
+          # Phrases that would read as Bazarr-killer framing.
+          # Case-insensitive. Multi-word phrases match across spaces.
+          BANNED=(
+            'replaces Bazarr'
+            'replace Bazarr'
+            'finally fix'
+            'unlike Bazarr'
+            "Bazarr can't"
+            "Bazarr cannot"
+            "Bazarr doesn't"
+            "Bazarr does not show"
+            "Bazarr does not do"
+            'better than Bazarr'
+            'kills Bazarr'
+            'Bazarr is dumb'
+            'Bazarr is broken'
+            # 'subarr is the brain' specifically — earlier draft used
+            # this and it reads as condescending toward Bazarr.
+            'subarr is the brain'
+            'adds the brain'
+          )
+          FAIL=0
+          for phrase in "${BANNED[@]}"; do
+            # Look for the phrase in README. -F = fixed string, -i =
+            # case-insensitive, -n = line numbers, -B 1 = one line of
+            # context so we can spot the tone-allow marker on the
+            # preceding line.
+            if matches=$(grep -i -F -n -B 1 "$phrase" README.md 2>/dev/null); then
+              # Check each match: if the previous line carries
+              # 'tone-allow:' then this is an explicit exception.
+              while IFS= read -r line; do
+                # grep -B output uses '--' between match groups; skip.
+                [ "$line" = "--" ] && continue
+                # Match line format: filename-LINENO-content OR filename:LINENO:content
+                if [[ "$line" == *":"* ]] && [[ "$line" != *"tone-allow:"* ]]; then
+                  echo "::error::Tone tripwire \"$phrase\" found:"
+                  echo "  $line"
+                  FAIL=1
+                fi
+              done <<< "$matches"
+            fi
+          done
+          if [ "$FAIL" -eq 1 ]; then
+            echo ""
+            echo "Locked tone rule: subarr stands BESIDE Bazarr."
+            echo "Synthesis decision §6 (2026-05-28) + launch-plan amendment (2026-06-01)."
+            echo ""
+            echo "If a banned phrase is genuinely needed, prefix the line above"
+            echo "with: <!-- tone-allow: <reason> --> and the gate will let it pass."
+            exit 1
+          fi
+          echo "tone gate: clean."

--- a/README.md
+++ b/README.md
@@ -1,150 +1,32 @@
 # subarr
 
-The coordination, measurement, and quality layer that subgen never had.
+The coordination layer for the *arr subtitle stack. Stands beside Bazarr.
 
-Subarr is a peer service in the *arr family. It sits between Bazarr, Sonarr, Radarr, Tautulli, Plex, ollama, and subgen, deciding what is actually missing across your library, what is worth generating, when to run the work, and writing the result back so Bazarr's wanted list actually shrinks.
-
-> Bazarr is the librarian. Subgen is the worker. Subarr is the brain.
+Subarr decides what subtitles are actually missing across your library, which providers are worth your time, and when it is worth running Whisper. Bazarr finds and downloads. Subgen transcribes. Subarr coordinates.
 
 [![status](https://img.shields.io/badge/status-v1.0-violet)](https://github.com/coaxk/subarr)
-[![tests](https://img.shields.io/badge/tests-246_passing-22d3ee)](https://github.com/coaxk/subarr/actions/workflows/ci.yml)
-[![security](https://img.shields.io/badge/security-bandit_%2B_semgrep_%2B_trivy_%2B_pip--audit-22c55e)](#security)
+[![tests](https://img.shields.io/badge/tests-266_passing-22d3ee)](https://github.com/coaxk/subarr/actions/workflows/ci.yml)
+[![security](https://img.shields.io/badge/Bandit_%2B_Semgrep_%2B_Trivy_%2B_pip--audit-22c55e)](#security)
 [![license](https://img.shields.io/badge/license-MIT-c8c8cc)](LICENSE)
 
-> **Proudly developed with AI assistance from Claude.** Please direct all complaints to `/dev/null`. The code is open and every PR is reviewed by a human (me) before it lands. Telemetry, security scans, and a published test count are how we keep ourselves honest about it.
+> Built with AI assistance from Claude. Code is open, every PR is human-reviewed. Telemetry, security scans, and a published test count are how we stay honest about that.
+
+<!-- HERO_GIF: insert 5s capture here once recorded.
+     Storyboard: anime episode with audio:eng tag → click 'Detect audio language'
+     → Layer 3 chunk evidence panel + 3-of-3 0.94 confidence → flips to audio:jpn
+     → Bazarr wanted-list row updates beneath it. -->
 
 ---
 
-## "I already have subgen. What do I do?"
+## In one breath
 
-The most-asked question from existing subgen users. Quick answer.
+- **See your whole library's subtitle coverage at a glance.** Per-language gap view across Sonarr + Radarr + Bazarr, with audio language we trust.
+- **Calibrated audio language detection.** Three Whisper chunks across the file, conservative voting, confidence-gated. Cheap to skip files Whisper would hallucinate on.
+- **Don't burn GPU on content nobody watches.** Scheduled walks with backpressure. Tautulli playback signal influences priority.
+- **Provenance ledger.** Which provider gave you which sub, when, why. Survives re-search runs.
+- **Embedded subs are first-class.** SDH, forced, PGS, full, all distinguished, not collapsed.
 
-| You have | What to do |
-|---|---|
-| Vanilla `mccloud/subgen` | Keep it. Add subarr next to it. Subarr detects vanilla on startup and runs in compat mode: Coverage, Provenance, scheduling, audio-language review all work. Scan submission shows a friendly "needs subarr-subgen" for the features that require our patches. You lose calibrated Layer 3 audio detection, queue cancel, and the curated initial_prompts (those need our patches). |
-| `mccloud/subgen` and you want everything | Swap to `ghcr.io/coaxk/subarr-subgen`. Same upstream image, plus 13 small patches that subarr's orchestration needs. Pull the new image, change one line in your compose, restart. No data loss, no config rewrite. The patches are open and auditable in [`coaxk/subarr-subgen`](https://github.com/coaxk/subarr-subgen). |
-| No subgen yet | Start with `ghcr.io/coaxk/subarr-subgen`. You get every feature on day one. |
-| You are happy with Bazarr alone | Subarr is the layer above Bazarr that adds the coordination, prioritisation, audio-language ground truth, and quality measurement that Bazarr does not do. You can still install subarr without changing anything in Bazarr; Bazarr keeps doing what it does today and subarr adds the brain. |
-
-You do not need to pick at install time. Subarr re-probes subgen every 30 seconds and adopts new capabilities the moment you upgrade. You can start vanilla, decide you want Layer 3 detection a week later, swap the image, restart. No subarr config change needed.
-
-**Where we're going next:** v1.1 ships the in-app Whisper tuning lab (run multiple kwargs variants on one file, score them, adopt the winner per language). v1.2 closes the loop with a crowdsourced global "best kwargs by language" leaderboard from opt-in telemetry. Full [Roadmap](#roadmap) below.
-
----
-
-## Three things nothing else in the *arr ecosystem does
-
-These are the anchor differentiators. Everything else in this README is plumbing in service of them.
-
-### 1. Calibrated audio-language detection (Layer 3 Whisper, multi-chunk)
-
-Vanilla subgen samples one 30-second window at the start of a file and trusts whatever Whisper says about the language. That window is silent, intro music, or a foreign-language opening narration as often as not. Anime is the canonical failure case: an English-dub episode whose first 30 seconds are the Japanese OP gets transcribed in Japanese, the user gets garbage, nobody knows why.
-
-Subarr ships a four-layer ground-truth funnel that arrives at a calibrated confidence value before any transcription begins:
-
-```
-  L1  file metadata          ffprobe audio_language tag.
-                             Cheap, often wrong on retags.
-
-  L2  Tautulli signal        Which audio track is your household
-                             actually picking when they watch?
-
-  L3  Whisper robust detect  Sample 3 chunks across 10/50/90 percent
-                             of the file, vote by majority,
-                             confidence is the MINIMUM probability
-                             across the agreeing chunks (conservative,
-                             so one high-confidence chunk cannot
-                             mask a disagreeing chunk).
-
-  L4  user verification      Review queue surfaces every suspect
-                             row. One click confirms, propagates
-                             back to Sonarr to unblind Bazarr.
-```
-
-Layer 3 is the part nothing else has. Three chunks across the middle 80 percent of the file, full per-chunk evidence rendered in the review modal, conservative aggregation. A 3-of-3 agreement at probability 0.97 is trustworthy. A 2-of-3 agreement at probability 0.41 lands in the manual review queue with the chunk evidence visible.
-
-Once a verification exists, every downstream submission to subgen carries it through an evidence gate. A confidence below 0.5, or a missing source field, refuses to forward the override. Whisper transcribes from the audio, the way it was meant to.
-
-### 2. Provider success leaderboard
-
-Bazarr's UI shows you which providers are configured. It does not show you which ones actually deliver subs that survive contact with your library. Subarr aggregates Bazarr's per-provider history and produces a per-install leaderboard ranked by:
-
-- attempts (volume signal, how often the provider gets tried at all)
-- success rate (delivered a sub that passed Bazarr's score threshold)
-- auto-blacklist rate (sub delivered then later flagged as desynced or wrong)
-- net success (the only column that matters)
-
-First time anyone in the *arr space has measured what providers actually do for a real library rather than what they claim on their marketing page.
-
-The v1.1 roadmap closes the loop by aggregating across installs through the opt-in telemetry channel and publishing a global leaderboard at subarr.com/stats. Then a new user can answer "which providers should I bother with for French TV" by looking at what worked for the global cohort already running that exact pattern.
-
-### 3. In-app Whisper tuning lab (v1.1 preview)
-
-Whisper has roughly 20 knobs that materially affect output quality: initial_prompt, condition_on_previous_text, temperature schedule, beam_size, no_speech_threshold, vad parameters, repetition penalty, length penalty, and more. The defaults are reasonable for podcast English and progressively worse for everything else. Foreign-language content, music-heavy sequences, and dialog-sparse scenes each have a different optimal kwargs set.
-
-Today users either inherit cargo-cult kwargs from a forum post or accept whatever vanilla subgen ships. There is no objective way to know what is best for your library, your language, your content style.
-
-Subarr v1.1 ships a tuning lab inside the app. Pick a representative file, pick a language, pick four variants from curated starter packs ("Anime", "Drama", "Documentary", "Music-heavy", "Foreign-original"). Subarr runs each variant through subgen via a kwargs-override patch, scores them automatically on hallucination signals (repeated phrase loops, blank intervals, opening hallucinations), renders the SRTs side by side with synchronized playback, lets you rank by keyboard, and one-click adopts the winner into your per-language settings.
-
-The v1.2 loop publishes anonymized winning-kwargs distributions to subarr.com/stats so new users can borrow the community-best for their language without running the lab themselves. Settings gains a "use community-best for French (87 percent verification rate, N installations)" row.
-
-The marketing question this answers: are your subs gibberish, drifting, or hallucinating? Run the lab. See exactly what changes per variant. Adopt the one that works. Beat the consensus locally if you can.
-
----
-
-## What else nothing in the market does (the under-the-radar list)
-
-The three anchor differentiators are the headlines. Pulling the surface back, these are the structural capabilities that are also new to this space. Semi-technical inventory for anyone evaluating subarr against what they already run.
-
-- **Subgen restart reconciliation.** When the subgen container reboots (config change, version upgrade, crash) the in-flight queue evaporates. Subarr detects the restart via a watchdog that probes patch revision plus reachability transitions, reconciles every in-flight scan_store entry against the provenance ledger, and surfaces the orphans in a dedicated "Lost on restart" bucket on the Queue page. One click requeues each one through the audio-language override path so re-submission actually transcribes. Nothing else in this space has any concept of "in-flight item that became a ghost."
-
-- **Capability-driven graceful degrade.** Subarr probes subgen's `/queue` and `/status` on startup and again every 30 seconds. Each feature in the UI gates on a specific capability flag. If you swap subgen versions mid-flight, subarr picks up the change inside a minute and lights up or hides the affected surfaces automatically. The Settings panel shows you exactly which capabilities are present and what each one enables.
-
-- **Whisper-or-Bazarr arbiter.** When a file has Bazarr providers exhausted plus a clear Whisper signal, subarr chooses between submitting to subgen and asking Bazarr to retry, based on per-provider success history. Eliminates the common "Bazarr keeps churning a file no provider has" failure pattern.
-
-- **NOW PLAYING priority boost.** Tautulli `get_activity` is polled every cycle. Whatever your household is actively watching gets boosted in the coverage score so subs arrive in time. Reactive without the storm.
-
-- **Vision pre-filter via ollama qwen2.5vl.** Optional. Tautulli serves thumbnails; ollama's qwen2.5vl vision model classifies whether the content is dialog-heavy, music-heavy, or visual-only. Subarr suppresses transcribe submissions for content where Whisper would just hallucinate (extended musical performances, mostly-visual sequences). Cuts wasted GPU minutes substantially. Optional integration; subarr does not require ollama, it just gets smarter when it is present.
-
-- **Calendar JIT walks.** Sonarr's calendar tells subarr what is airing in the next 24 hours. A targeted walk runs against just those upcoming episodes, so subs are ready when the recording lands rather than queued behind a nightly batch.
-
-- **History-driven "just imported" score.** Recently imported episodes get a transient priority boost. The arrival pattern matches when humans actually want them.
-
-- **Sidecar basename mismatch detector.** When subgen and your renamer disagree, the .srt is invisible to Bazarr. Subarr scans for mismatches and proposes the corrected name; one click renames it.
-
-- **Auto-blacklist desync'd subs.** Subs that timing-match wrong stay in your library forever because nothing notices. Subarr catches the drift, blacklists the entry in Bazarr, and re-queues the search.
-
-- **Audio review with multi-track and batch cycle.** Files with multiple audio tracks (dub plus original) get a track selector in the review modal. Sample positions are auto-chosen from dialog-dense regions (silence avoided). Batch mode cycles through every pending row without leaving the modal.
-
-- **Provenance ledger.** Every transcribe job records: who submitted, which subgen patch revision, completion time, Bazarr scan-disk trigger time. Click any file anywhere in the UI, get the full timeline.
-
-- **Coverage caching with background refresh.** Coverage page loads instantly off a snapshot; refresh happens in the background. On a real-size library this is the difference between a 60 to 90 second wait per page load and a sub-100ms render.
-
-- **Concurrent transcribes surfaced.** Subgen has supported `CONCURRENT_TRANSCRIPTIONS` for a long time but no UI ever told you. Subarr's Settings panel surfaces the knob with a per-Whisper-model VRAM budget table so you can pick N correctly.
-
----
-
-## What it solves today
-
-The most-felt pains in the Bazarr plus subgen plus subtitle-automation space, documented across r/bazarr, GitHub issues, and TRaSH guide forums. Subarr fixes that, and a lot more besides.
-
-1. **Bazarr keeps re-searching subs you already have.** Subarr probes your media with ffprobe and knows what is already embedded or sidecar'd. Coverage walks suppress the false-positive gap rows that make Bazarr re-search forever.
-
-2. **See your whole library's subtitle coverage at a glance.** Gap list across every series and movie, prioritised by Tautulli watch history. No native tool does this.
-
-3. **Stop burning GPU on content you will never watch.** Scheduled coverage walks instead of reactive event storms. You tell subarr the rule once. It runs nightly and only queues what matches.
-
-4. **Know exactly which provider gave you this sub.** Provenance ledger records every transcribe job: who submitted, what subgen version, completion time, Bazarr scan-disk trigger. Unique to subarr in this space.
-
-5. **Treat embedded subs as first-class.** SDH versus forced versus commentary versus full are distinct states, not a binary "has subs" flag. Per-track audio language detection too.
-
-6. **Recover automatically when subgen restarts.** A container reboot, version upgrade, or crash that used to lose in-flight work now triggers automatic reconciliation. Lost items appear in a dedicated bucket on the Queue page with a one-click requeue that passes the verified audio language through, so re-submission actually transcribes.
-
----
-
-## Quickstart
-
-The fastest path: drop a four-line compose, run it, walk the wizard. The wizard does the actual configuration.
+## Five-minute install
 
 ```yaml
 # compose.yaml
@@ -153,267 +35,143 @@ services:
     image: ghcr.io/coaxk/subarr:latest
     container_name: subarr
     restart: unless-stopped
-    ports: ["9922:9922"]
+    ports:
+      - "9922:9922"
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - UMASK=022
     volumes:
-      - /mnt/nas/Media:/media/library:rw    # your library root
-      - ./data:/data                        # subarr's SQLite + ledger
+      - ./subarr/config:/config
+      - /path/to/media:/media/library:rw   # same path Bazarr and subgen see
 ```
-
-Bring it up.
 
 ```bash
 docker compose up -d
+# Open http://localhost:9922, onboarding wizard auto-detects your stack.
 ```
 
-Open `http://localhost:9922`. The 10-step onboarding wizard takes it from here: auto-detects your *arr stack if you bind the docker socket (Tier 2 template below), falls back to manual entry of URLs and API keys for every integration if not, and validates each connection live before committing it to settings. Auto-detect plus manual fallback is the design point. You always have a path forward.
+The wizard tries to auto-detect Sonarr/Radarr/Bazarr/Tautulli/subgen on your existing Docker network and prefills URLs. Manual entry is available at every step as a safety net. Auto-detect plus manual fallback at every step is the design rule.
 
-**Why `:rw` on the media mount.** Subarr's sidecar mismatch detector renames orphaned .srt files in place when you approve the rename. Mount read-only and that feature is the only thing that breaks; everything else still works. If you want the strongest containment posture and do not need auto-rename, change to `:ro` and live without that feature.
+**Why `:rw` on the media mount.** Subarr's sidecar mismatch detector renames orphaned `.srt` files whose basename drifted from the video. Read-only blocks this. If you don't want it, set `SUBARR_SIDECAR_RENAME=0` and mount `:ro`, the rest of the product works.
 
-### Full template with auto-detect and integration URLs
+## I already have subgen. What do I do?
 
-For shared-network deploys where subarr can reach your *arr containers by name, use the Tier 2 template. It pre-fills the integration URLs so the wizard skips the manual entry steps.
+The most-asked question. Quick answer.
 
-```bash
-mkdir -p ~/subarr && cd ~/subarr
-curl -O https://raw.githubusercontent.com/coaxk/subarr/main/deploy/templates/tier2-socket-proxy.compose.yaml
-curl -O https://raw.githubusercontent.com/coaxk/subarr/main/deploy/templates/.env.example
-mv .env.example .env
-$EDITOR .env  # TZ, MEDIA_ROOT, your *arr docker network name
-docker compose -f tier2-socket-proxy.compose.yaml up -d
-```
-
-Three deployment tiers are available. See [`deploy/templates/README.md`](deploy/templates/README.md) for the trade-offs. Tier 2 is the recommended default.
-
----
-
-## Architecture
-
-Subarr is a coordinator, not a transcriber. It owns no GPU code. Subgen does that. State lives in the upstream services (Bazarr, Sonarr, Radarr, Tautulli) plus Docker plus subarr's own SQLite for the work subarr itself initiates.
-
-```
-   +-----------+        +---------+        +---------+
-   | Bazarr    |<------>|         |------->| subgen  |
-   | Sonarr    |        |         |        | whisper |
-   | Radarr    |<------>| subarr  |<-------|         |
-   | Tautulli  |        |         |        +---------+
-   | Plex      |<------>|         |
-   | ollama    |<------>|         |        +---------+
-   +-----------+        +---------+------->| host    |
-                                           | docker  |
-                                           +---------+
-```
-
-| Layer | Tech |
+| You have | What to do |
 |---|---|
-| Backend | Python 3.11+, FastAPI, uvicorn, httpx, SQLite |
-| Frontend | React 18 from CDN with design tokens, esbuild bundling |
-| Migrations | Hand-rolled SQL runner. One file per change |
-| Discovery | Read-only docker API via [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) |
-| Storage | Single SQLite file at `/data/subarr.db` |
-| Telemetry | Anonymous, opt-out, roughly 1 KB per day. Public stats at subarr.com/stats |
+| Vanilla `mccloud/subgen` | Keep it. Add subarr next to it. Subarr detects vanilla and runs in compat mode. Coverage, provenance, scheduling, audio-language review all work. You miss calibrated multi-chunk detection and queue cancel, both require our subgen patches. |
+| `mccloud/subgen` and you want everything | Swap to `ghcr.io/coaxk/subarr-subgen`. Same upstream image plus 13 small auditable patches. Pull, change one line in your compose, restart. No data loss, no config rewrite. |
+| No subgen yet | Start with `ghcr.io/coaxk/subarr-subgen`. Everything works on day one. |
+| You run Bazarr only | Subarr adds a coordination layer beside Bazarr. Bazarr keeps doing what it does. Subarr surfaces what is actually missing, schedules the work, and writes results back. |
 
-### About ollama (optional, recommended)
+You do not need to decide at install. Subarr re-probes subgen every 30 seconds and adopts new capabilities the moment you upgrade.
 
-Subarr does not require ollama. If you do run it, subarr uses it for two things:
+## Do you need subarr?
 
-- **Structured enrichment.** When Bazarr's wanted entries are vague, subarr asks ollama (any local model that supports the structured JSON output format) to classify the entry by language, genre hints, expected dialog density. Improves prioritisation accuracy. Works with any text model you have installed.
-- **Vision pre-filter.** Tautulli serves thumbnails; a vision-capable model classifies the content frame by frame as dialog-heavy, music-heavy, visual-only, or mixed. Subarr suppresses transcribe submissions for content where Whisper would just hallucinate. Cuts wasted GPU minutes significantly on libraries with concerts, performances, or visual-only material.
+Skip subarr if any of these are true:
 
-**The two models are separate.** The text model and the vision model are different env knobs: `OLLAMA_MODEL` and `OLLAMA_VISION_MODEL`. Subarr defaults the vision model to `qwen2.5vl:7b` because that is the current best-fit for the thumb-classification job, but auto-detects any of the following families when you have one installed: `qwen2.5vl`, `qwen2-vl`, `llama3.2-vision`, `llava`, `bakllava`, `minicpm-v`, `moondream`. Set `OLLAMA_VISION_MODEL=auto` and subarr picks the first vision-capable model from your `/api/tags` list.
+- Your library is single-language and you have never had a wrong-language subtitle land.
+- You use one or two providers and never wonder which one delivered what.
+- You don't run Whisper or any local transcription, and don't plan to.
 
-**What happens if you do not have a vision-capable model installed.** Subarr's startup probe and the Settings page Integrations card surface this honestly: "Vision pre-filter inactive — no vision-capable model installed. Pull qwen2.5vl:7b (around 5 GB)." One click in the wizard or in Settings runs `POST /api/pull` with streamed progress and turns the pre-filter on the moment the pull finishes. Nothing else breaks: enrichment with your text model keeps working, every other ollama feature stays on, the pre-filter is just disabled. We never silently call a text model with image data attached — that path was a real launch-day wrinkle in earlier builds, now closed and regression-tested.
-
-If you do not have ollama running at all, subarr falls back to less precise heuristics for both enrichment and the pre-filter. Nothing breaks.
-
----
+Subarr's value compounds with: multi-language libraries, three or more Bazarr providers, Whisper-in-the-loop, and a habit of asking "why did Bazarr re-search this?"
 
 ## What is in v1.0
 
 | Surface | Function |
 |---|---|
-| Dashboard | Live column-as-stage pipeline (discovered, probing, bazarr-wanted, transcribing, written-back) plus GPU widget, integration health, next scheduled run, recent activity |
-| Coverage | Flat, dense gap-list table. Score-gradient sort. Reason chips (no-track, embedded-only, bazarr-wanted, audio-mislabel, low-score, unmonitored). Bulk select plus apply rule plus queue |
-| Library | Tree view across all series and movies with audio, sub, runtime columns and probe-state indicators |
-| Queue | Featured Queue: Processing, Queued, Lost on restart (subgen-reboot reconciliation), Issues (silent fails subgen swallowed), and Recently submitted history. Per-row actions: requeue, remove, cancel (when subgen is v4.4+). Promote, demote, reorder, and pause are not in v1.0 (see roadmap) |
-| Review | Manual audio-language verification queue with audio player, multi-track support, batch cycle, and Layer 3 Whisper detection inline |
-| Onboarding | 10-step wizard. Auto-detect via docker-socket-proxy plus manual fallback at every step |
-| Rules | Build, Test, Deploy triad for auto-queue rules. Dry-run preview before commit. Curated rule packs (Anime, Hearing-impaired, Foreign-language learner, Movies-only) |
-| Settings | Integration test, telemetry transparency panel, updates panel, per-language Whisper kwargs surface, concurrent-transcribe VRAM guide, capability detection |
-| Per-file verdict | Modal timeline showing every probe, scan, write-back for any video file |
+| Dashboard | Live column-as-stage pipeline (discovered → probing → bazarr-wanted → transcribing → written-back), GPU widget, integration health, next scheduled run, recent activity |
+| Coverage | Flat, dense gap-list table. Score-gradient sort. Reason chips (no-track, embedded-only, bazarr-wanted, audio-mislabel, low-score, unmonitored). Bulk select + apply rule + queue |
+| Library | Tree across all series and movies. Audio / sub / runtime columns with probe-state indicators |
+| Queue | Featured Queue: Processing, Queued, Lost-on-restart, Issues, Recently done. Per-row requeue, remove, cancel. Promote / demote / reorder / pause are roadmap (need subgen v4.9 queue-mutation endpoints) |
+| Review | Manual audio-language verification queue with audio player, multi-track support, batch cycle, Layer 3 Whisper detection inline |
+| Rules | Auto-queue rules with score thresholds, language filters, custom-format pre-classification |
+| Settings | Per-language Whisper kwargs, integrations health, system actions, telemetry transparency panel showing the exact JSON last sent |
 
----
+### About ollama (optional, recommended)
 
-## The audio-language ground-truth pipeline
+Subarr does not require ollama. With it, you get two extras:
 
-This is the centerpiece. Most subtitle-generation failures are not Whisper failures. They are pipeline failures upstream of Whisper. Subarr fixes the pipeline.
+- **Structured enrichment.** Vague Bazarr wanted entries get classified by language, genre hints, dialog density. Improves prioritisation. Works with any text model.
+- **Vision pre-filter.** A vision-capable model classifies Tautulli thumbnails as dialog-heavy / music-heavy / visual-only. Suppresses transcribe submissions where Whisper would hallucinate.
+
+Vision and text models are separate (`OLLAMA_MODEL` and `OLLAMA_VISION_MODEL`). Default vision model is `qwen2.5vl:7b`. Subarr auto-detects any installed model from `qwen2.5vl`, `qwen2-vl`, `llama3.2-vision`, `llava`, `bakllava`, `minicpm-v`, `moondream`. Without a vision-capable model the pre-filter is cleanly disabled, not silently broken. Settings shows the active state.
+
+## How calibrated audio detection works
+
+Vanilla subgen samples one 30-second window at the start of a file and trusts whatever Whisper says. That window is silent, intro music, or a foreign-language opening narration as often as not. Anime is the canonical failure case: an English-dub episode whose first 30 seconds are the Japanese OP gets transcribed in Japanese, the user gets garbage, nobody knows why.
+
+Subarr's audio-language pipeline:
 
 ```
-  STEP 1   ffprobe reads audio_language tag from the file container
-           Captures: declared language, declared track count
-           Failure modes: unset (und), retagged wrong, embedded
-           in a foreign track ordering
+  L1  file metadata          ffprobe audio_language tag.
+                             Cheap, often wrong on retags.
 
-  STEP 2   Cross-check vs Sonarr or Radarr originalLanguage
-           Captures: what the upstream metadata thinks
-           Mismatches flagged audio_label_suspect
+  L2  Tautulli signal        Which audio track is your household
+                             actually picking when they watch?
 
-  STEP 3   Tautulli get_activity for live signal
-           Captures: which audio track is your household choosing?
-           Resolves cases where the file has both EN dub and JA
-           original; your watch behaviour disambiguates
+  L3  Whisper robust detect  Sample 3 chunks across 10 / 50 / 90 percent
+                             of the file. Vote by majority. Confidence
+                             is the MINIMUM probability across the
+                             agreeing chunks, one high-confidence
+                             chunk cannot mask a disagreeing one.
 
-  STEP 4   Subgen v4.5 robust language detection on demand
-           Triggered from the review modal when L1-L3 disagree
-           Three Whisper chunks at 10/50/90 percent of the file
-           Confidence is min(probabilities of agreeing chunks)
-
-  STEP 5   User confirms in review modal
-           Audio player with sample positions chosen from
-           dialog-dense regions (silence avoided automatically)
-           Multi-track UI when N audio tracks present
-           Batch review cycle across all pending rows
-
-  STEP 6   Verification persists to audio_lang_store
-           Propagates back to Sonarr to unblind Bazarr
-           Forwarded as audio_language_override to subgen
-           on every subsequent submission (with evidence gate)
+  L4  user verification      Review queue surfaces every suspect row.
+                             One click confirms, propagates to Sonarr
+                             so Bazarr stops getting blinded.
 ```
 
-The evidence gate is the part that took two iterations to get right. Forwarding a wrong override is worse than no override because subgen will trust subarr's bad value and transcribe English audio as if it were Japanese, producing unreadable text rather than degraded text. The gate refuses any override below 0.5 confidence and any override with an empty source field. Risky non-Latin script languages (Japanese, Korean, Chinese) get a distinct log line so post-hoc audits can grep specifically for the dangerous category.
+Once a verification exists, every downstream submission carries it through an evidence gate. Confidence below 0.5, or missing source field, refuses to forward the override. Whisper transcribes from the audio, the way it was meant to.
 
----
+## Known limitations (v1.0)
 
-## Roadmap
+Transparent before you install.
 
-v1.0 ships the brain. v1.1 turns it into a measurement and tuning layer. v1.2 closes the loop with crowdsourced consensus.
-
-### v1.1: In-app Whisper tuning lab
-
-The killer feature. Run multiple Whisper kwargs variants against a single file, score the outputs automatically, review them side by side, adopt the winner into your per-language settings. See the [In-app Whisper tuning lab](#3-in-app-whisper-tuning-lab-v11-preview) section above.
-
-Phases:
-- v1.1-A: subarr-subgen patch v4.8 for kwargs override, experiment backend, Experiments tab MVP
-- v1.1-B: adopt button plus persistent per-language settings store
-- v1.1-C: telemetry payload extension (opt-in, sanitised) for kwargs and verification outcomes
-
-### v1.1 queue controls
-
-Promote, demote, reorder, and pause buttons on the Queue page. Requires a subgen-side patch (planned v4.9) that exposes queue mutation endpoints. Currently subgen's `DeduplicatedQueue` only supports insert plus cancel, so reorder needs the upstream change first.
-
-### v1.2: Global tuning consensus
-
-- Cross-install aggregation of kwargs distributions ranked by verification outcomes
-- subarr.com/stats publishes "best Whisper kwargs by language" with confidence
-- "Use community-best for French" one-click adoption in Settings
-- "Beat the consensus" challenge in the Experiments tab for users who want to push past the global default
-
-### Other items in flight
-
-- Global provider leaderboard published at subarr.com/stats
-- Tuning lab presets for genre-specific content (Anime, Drama, Documentary, Music-heavy)
-- subarr.com/stats public telemetry dashboard
-
----
-
-## The subgen patch story
-
-Subarr drives subgen through 13 small patches over upstream McCloudS/subgen. Each is independent, idempotent on reapply, and required for one specific subarr orchestration behaviour. Living patch stack at [`coaxk/subarr-subgen`](https://github.com/coaxk/subarr-subgen).
-
-| Patch | Capability | Why subarr needs it |
-|---|---|---|
-| 0001 | Per-language `SUBGEN_KWARGS_LANG_XX` env overrides | Different Whisper kwargs per source language |
-| 0002 | Eager model load on container start | Removes the cold-start delay on first batch |
-| 0003 | Reverse sort for transcribe-existing walks | Newest files first |
-| 0004 | `POST /batch` structured response | Subarr can count queued vs skipped vs error per submission |
-| 0005-0006 | Internal correctness fixes | `LanguageCode.from_string` and import safety |
-| 0007 | `GET /queue` with type-tracked deduplicated queue | Featured Queue UI |
-| 0008 | Log language detection probability | Debug visibility |
-| 0009 | `audio_language_override` query param | Subarr can bypass `SKIP_IF_AUDIO_LANGUAGES` with verified evidence |
-| 0010 | `POST /queue/cancel` | Queue page cancel button |
-| 0011 | `POST /detect_language_robust` | Layer 3 multi-chunk Whisper detection |
-| 0012 | Curated per-language `initial_prompt`s | Punctuation seeding for 12 major languages |
-| 0013 | `SUBARR_SUBGEN_SAFE_DECODE` preset | Opt-in anti-hallucination kwargs |
-
-The maintained image is `ghcr.io/coaxk/subarr-subgen:<tag>`. Tagged releases: `v4.7` is current, with `latest`, `stable` (7-day soak), and per-version tags published.
-
-You do not need our patched image. See the decision table at the top of this README for the "I already have subgen" walkthrough.
-
----
-
-## Compat mode
-
-Subarr works with any subgen. On startup it probes `/queue` and `/status` and figures out what is available. The watchdog re-probes every 30 seconds so capability changes between subgen restarts get picked up automatically.
-
-| Subgen build | /queue | /batch structured | Capabilities | What works |
-|---|---|---|---|---|
-| `ghcr.io/coaxk/subarr-subgen` v4.5 plus | yes | yes | queue_cancel, robust_language_detection, audio_language_override, curated_language_prompts, safe_decode_preset | Everything |
-| `ghcr.io/coaxk/subarr-subgen` v4.3 to v4.4 | yes | yes | audio_language_override | Most things, no Layer 3 |
-| `mccloud/subgen` vanilla | no | plain text | none | Coverage, Provenance, scheduling. Scan submission shows "needs subarr-subgen" |
-
-The Settings panel shows the detected mode and version so there is never confusion about which features are active. When a feature requires a newer subgen than what is running, the UI surfaces the specific patch revision needed instead of silently degrading.
-
----
+- Requires `ghcr.io/coaxk/subarr-subgen` for calibrated Layer 3 detection, queue cancel, curated per-language `initial_prompt`s, and the safe-decode preset. Vanilla subgen works in compat mode but you miss these.
+- No built-in multi-user auth. Basic-auth env vars exist as a single-admin fallback. Run behind a reverse proxy (Authelia / Caddy / Traefik) for anything serious.
+- Queue reorder / promote / demote / pause are not in v1.0, they need subgen patch v4.9 to land first. Requeue / remove / cancel ship today.
+- Auto-update is intentionally absent. Update notifications appear in the UI; you run the upgrade.
+- Plex integration goes through Tautulli for activity signal, not Plex directly. Tautulli is the bridge.
+- SQLite only. No Postgres backend in v1.0.
+- Single-host. Workers / multi-host are an explicit non-goal until users ask.
+- Jellyfin / Emby are not yet supported.
+- arm64 builds are not yet published. Pi 4 / 5 users need to build locally for now.
+- Compose example uses bind mounts. Named volumes work but you lose the "same path Bazarr and subgen see" sanity.
 
 ## Security
 
-Subarr is built to run inside your trusted LAN, but we hold the codebase to a higher bar than that. Full policy and threat model in [`SECURITY.md`](SECURITY.md); the headlines:
-
-**Continuous scanning, four tools, two repos.** Every push to `coaxk/subarr` and `coaxk/subarr-subgen` runs:
-
-| Tool | What it catches | Where to read |
-|---|---|---|
-| **Bandit** | Python security smells (eval, shell=True, weak crypto, hardcoded secrets) | GitHub Security tab, SARIF upload |
-| **Semgrep** | Pattern-based vulns (SQL injection, path traversal, auth bypass, unsafe deserialisation) | GitHub Security tab, SARIF upload |
-| **pip-audit** | Known CVEs in pinned dependencies | CI log, fails the build on HIGH or CRITICAL |
-| **Trivy** | Container image vulns on the published GHCR image | GitHub Security tab |
-
-Weekly scheduled runs catch CVEs disclosed between releases. Every dependency in `pyproject.toml` is version-pinned, so a transitive bump never sneaks in unverified.
-
-**Defences in the code itself** (each one regression-tested):
-
-- **Basic-auth** uses `secrets.compare_digest` (constant-time, defeats timing attacks). Test: `test_uses_constant_time_compare`.
-- **API keys never leave the backend.** Every API response that touches an integration key returns a masked form (`••••f6c0`). Raw key only lives in a dataclass internal field. Test: `test_api_key_never_surfaces_in_response`.
-- **Path safety.** Every filesystem operation routes through `canonical_to_fs()` which rejects path-traversal outside the configured media root. Test: `test_canonical_to_fs_rejects_traversal`.
-- **SQL.** Parameterised queries everywhere. Zero string-concat-into-SQL. Grepped in CI.
-- **Subprocess.** `shell=False` everywhere. No user input ever flows into `subprocess.run` args. Grepped in CI.
-- **Telemetry.** Payload contents are enumerated in `src/subarr/telemetry.py` and a regression test (`test_payload_never_includes_forbidden_fields`) guards against accidentally adding a fingerprintable field. The Settings panel shows the exact JSON of the last ping.
-
-**Reporting a vulnerability.** Email `security@subarr.com`. We acknowledge within 72 hours, scope, coordinate, and credit you in the release notes if you'd like recognition. Full details in [`SECURITY.md`](SECURITY.md).
-
-**246 tests passing on every push.** API contracts, security regressions, frontend smoke, capability negotiation, the whole audio-language pipeline. CI fails closed: if the security gates fail, the release does not ship.
-
----
+- Bandit, Semgrep, pip-audit, Trivy run on every push to `coaxk/subarr` and `coaxk/subarr-subgen`. SARIF uploads to the GitHub Security tab.
+- Constant-time auth comparison (`secrets.compare_digest`). Regression tested.
+- API keys never appear in any HTTP response, masked surface, raw key only in dataclass internals. Regression tested.
+- Every filesystem operation routes through `canonical_to_fs()` which rejects path-traversal outside the configured media root. Regression tested.
+- Parameterised SQL throughout. Zero string-concat. Grepped in CI.
+- `shell=False` everywhere. No user input flows into `subprocess.run`. Grepped in CI.
+- Telemetry payload contents enumerated in `src/subarr/telemetry.py` with a regression test (`test_payload_never_includes_forbidden_fields`) guarding against accidental fingerprintable fields.
+- Reporting a vulnerability: `security@subarr.com`. We acknowledge within 72 hours. Full policy in [`SECURITY.md`](SECURITY.md).
 
 ## Telemetry
 
-Subarr ships with anonymous telemetry on by default. We are being explicit about what telemetry buys you because there is a direct line between the data the cohort sends and the value the cohort gets back.
+Subarr ships with anonymous telemetry **on by default**. We are explicit about what it buys you, and the opt-out is one click in Settings and one click in the onboarding wizard.
 
-**Why telemetry being on by default helps you specifically:**
+**What gets sent:** install ID (random UUID generated locally, not a user identity), subarr version, Python version, OS / arch, subgen kind (subarr-subgen / vanilla / unreachable), subgen version, integration booleans (configured yes / no, never URLs or keys), library-size bucket (under 100 / 100-1k / 1k-10k / over 10k), scheduler mode, walks-per-day rolling average, error counts by exception class, docker tier.
 
-- The v1.2 global Whisper kwargs leaderboard is built from aggregated telemetry. The more installs that send their per-language kwargs plus verification outcomes, the more accurate the "best French settings" recommendation gets. If you opt out, you still get the recommendations; you just do not contribute to making them better.
-- The v1.1 global provider leaderboard is the same loop for Bazarr providers. Send your per-provider success rates, see the cohort's success rates, decide which providers are worth your time based on what works for installs like yours.
-- The v1.1 tuning lab pre-fills variant suggestions from the cohort. Without telemetry contributions, the tool still works locally; with them, your starting variants are already the ones the cohort has found best for your language plus genre profile.
+**Never sent:** file paths, titles, IPs, hostnames, API keys, languages, anything user-fingerprintable. Enforced by a regression test on the client AND by an allow-list / forbidden-pattern check on the receiving Cloudflare Worker. Both pin against the same forbidden-fields list.
 
-Concretely:
+**What it buys you:**
+- The v1.1 global Whisper kwargs leaderboard is built from aggregated telemetry. The more installs send their per-language kwargs plus verification outcomes, the more accurate the "best French settings" recommendation gets.
+- The v1.1 global provider success leaderboard is the same loop for Bazarr providers.
+- The v1.1 tuning lab pre-fills variant suggestions from cohort data.
 
-- Roughly 1 KB per day payload
-- Public dashboard at subarr.com/stats (goes live with v1.0 publish)
-- Settings panel shows the **exact JSON** sent on the most recent ping
-- One-click opt-out in Settings or during the onboarding wizard
+**Where to verify:** Settings → Telemetry shows the exact JSON of the last ping. Receiving worker source at [`coaxk/subarr-telemetry`](https://github.com/coaxk/subarr-telemetry). Public stats dashboard at `subarr.com/stats` [planned with v1.0 publish].
 
-**What is in the v1.0 payload:** install ID (random UUID, generated locally), subarr version, Python version, OS or arch, subgen kind (subarr-subgen, vanilla, unreachable), subgen version, integration booleans (configured yes or no, never URLs or keys), library size bucket (under 100, 100 to 1k, 1k to 10k, over 10k), scheduler mode, walks per day rolling average, error counts by exception class, docker tier.
-
-**Never in the payload:** file paths, titles, IPs, hostnames, API keys, languages, anything user-fingerprintable. Enforced by a regression test.
-
-**Coming in v1.1 (opt-in granularity, separate toggles in Settings):** per-language Whisper kwargs hash plus shape (never the raw `initial_prompt` string, only the hash), verification confirmation counts per language, experiment winning-kwargs hash. Three separate toggles so users can choose to share any combination.
-
-**Note for Pi-hole users:** many privacy-conscious Pi-hole regex blocklists deny anything matching `*telemetry*` by default. We use the literal subdomain `telemetry.subarr.com` because hiding behind a misleading name (for example `stats.subarr.com`) would be the opposite of honest. If you actively want telemetry off, do not allow it. If you want to send it, allow `subarr.com` in your Pi-hole and the regex deny will no longer apply.
-
----
+**Note for Pi-hole users:** privacy-conscious regex blocklists deny anything matching `*telemetry*` by default. We use the literal subdomain `telemetry.subarr.com` because hiding behind a misleading name (`stats.subarr.com`) would be the opposite of honest. If you want telemetry off, do not allow it. If you want to send it, allow `subarr.com` in your Pi-hole.
 
 ## Authentication
 
-Subarr ships with no built-in auth by default. Designed to sit behind a reverse proxy (Authelia, Caddy basicauth, Traefik forward-auth) for production. The in-product fallback is HTTP Basic auth via env vars.
+No built-in auth by default. Designed for a reverse proxy (Authelia, Caddy basicauth, Traefik forward-auth). In-product fallback is HTTP Basic via env vars:
 
 ```yaml
 environment:
@@ -423,22 +181,11 @@ environment:
 
 When both are set, every non-monitoring request requires Basic credentials. `/api/health` always bypasses for monitoring tools.
 
-**Honest limitations** of basic auth: one global user, no per-user audit trail, credentials transmitted on every request (use HTTPS via the proxy). Reverse-proxy auth is the right answer for anything that matters.
-
----
+Honest limitations of basic auth: one global user, no per-user audit, credentials transmitted on every request. Reverse-proxy auth is the right answer for anything that matters.
 
 ## Updates
 
-Subarr polls GitHub releases once per 24 hours for both `coaxk/subarr` and `coaxk/subarr-subgen`. The subarr-subgen comparison uses patch-stack revision (v4.7 versus v4.8) rather than upstream subgen version, so patch-level updates are detected even when the underlying McCloudS/subgen version stays the same.
-
-When a new version is available the header version label gets a soft violet pip and the Home dashboard surfaces an "Update available" tile. Click through to Settings, Updates panel, which shows:
-
-- Current version versus latest, per product (subarr and subarr-subgen)
-- The release notes for the new version, inline
-- Copy-paste compose edit instructions for changing the image tag
-- A breaking-change banner if the GitHub release flags it
-
-The actual update is two commands you run on your host. The panel shows you the exact commands for your detected compose location.
+Subarr polls GitHub releases once per 24 hours for both `coaxk/subarr` and `coaxk/subarr-subgen`. The subarr-subgen comparison uses patch-stack revision so patch-level updates are detected even when upstream subgen version stays the same.
 
 ```bash
 # In the directory with your compose.yaml
@@ -446,61 +193,48 @@ docker compose pull
 docker compose up -d
 ```
 
-No auto-update by design. You always run the upgrade yourself so you know exactly when it happens.
+The Settings panel shows the current vs latest version per product with release notes inline. No auto-update by design, you run upgrades when you know it is happening.
 
----
+## Architecture
 
-## Networking: how subarr finds your *arr stack
-
-Subarr's integrations (Sonarr, Radarr, Bazarr, Tautulli, subgen, Plex, ollama) reach those services via the URLs you provide in the wizard or in your `.env`. There are two common topologies.
-
-**1. Shared docker network (recommended).** Add subarr to the same docker network as your *arr stack. Then you can address each service by its container name on the default arr ports.
-
-```yaml
-networks:
-  - safe-bridge       # or whatever your *arr stack already uses
-
-# .env
-SONARR_URL=http://sonarr:8989
-RADARR_URL=http://radarr:7878
-BAZARR_URL=http://bazarr:6767
-SUBGEN_URL=http://subgen:9000
-TAUTULLI_URL=http://tautulli:8181
-PLEX_URL=http://plex:32400
-```
-
-This is what `docker-compose.yaml` in `deploy/templates/` ships with. DNS resolves container names within the network, so no IP addresses get baked in.
-
-**2. Bypass: subarr on host network or different stack.** If subarr is deployed standalone (no shared network with the *arr stack), reach each service by host IP plus published port.
-
-```env
-SONARR_URL=http://192.168.1.10:8989
-RADARR_URL=http://192.168.1.10:7878
-BAZARR_URL=http://192.168.1.10:6767
-SUBGEN_URL=http://192.168.1.10:9000
-```
-
-Common gotcha: **`localhost` from inside a container points at the container, not the host.** Use the host's LAN IP (or `host.docker.internal` on Docker Desktop) instead of `localhost`.
-
-The onboarding wizard's "Test connection" button validates each URL against the live service before you commit it to settings. If it fails the chip stays red with the actual httpx error so you can fix the URL without restarting subarr.
-
----
-
-## Performance and concurrency
-
-Subgen supports running multiple Whisper workers in parallel via `CONCURRENT_TRANSCRIPTIONS` in the subgen container env. Subarr's pipeline handles N parallel jobs end-to-end: the Featured Queue surfaces N processing rows, each with its own progress bar and cancel button. Subarr's Settings panel surfaces the knob plus a VRAM budget table per Whisper model size so you can pick N correctly.
-
-| Whisper model | VRAM per worker (float16) |
+| Layer | Detail |
 |---|---|
-| tiny | roughly 1 GB |
-| base | roughly 1 GB |
-| small | roughly 2 GB |
-| medium | roughly 5 GB |
-| large or large-v3 | roughly 10 GB |
+| Backend | Python 3.12 + FastAPI + httpx. Async throughout. |
+| Storage | Single SQLite file at `/config/subarr.db`. Hand-rolled migrations runner. |
+| Frontend | React 18 + esbuild. CDN React. Bundles committed so `pip install` ships a working SPA. |
+| Subgen drive | HTTP. 13 small patches over upstream McCloudS/subgen. Living patch stack at [`coaxk/subarr-subgen`](https://github.com/coaxk/subarr-subgen). |
+| Discovery | Read-only Docker API via [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy). |
+| Telemetry receiver | Cloudflare Worker + D1. Open source at [`coaxk/subarr-telemetry`](https://github.com/coaxk/subarr-telemetry). |
 
-Leave 1 to 2 GB headroom for the container itself plus CUDA cache. Subarr's GPU widget on the Dashboard shows live VRAM utilisation so you can verify your N choice is right.
+Three deployment tiers (full templates in [`deploy/templates/`](deploy/templates/README.md)):
 
----
+| Tier | What you get | What you give up | Who it is for |
+|---|---|---|---|
+| 1, Standalone | Manual integration URLs, no Docker access | Auto-detect, container-name hostnames | Non-Docker hosts |
+| 2, Socket proxy (recommended) | Auto-detect on your existing Docker network | Slightly more setup | Most homelabs |
+| 3, Full integration | Tier 2 + API-key auto-extract from config volumes | Subarr can read every mounted config dir | Trust your single-tenant box |
+
+## Roadmap
+
+**v1.1** ships the global feedback loops:
+
+- **Provider success leaderboard** [v1.1]: aggregates Bazarr per-provider history across opt-in installs into a global ranking. Closes "which subtitle providers actually deliver?", a long-standing Bazarr feature request.
+- **In-app Whisper tuning lab** [v1.1]: run multiple Whisper kwargs variants against a single file, score them, review side by side, adopt the winner per language. The aggregated kwargs distribution becomes the global "best for French" recommendation.
+- **Queue mutation** [v1.1]: promote, demote, reorder, pause. Requires subarr-subgen v4.9 patch first.
+
+**v1.2** closes the consensus loops:
+
+- Cross-install kwargs aggregation ranked by verification outcomes.
+- "Use community-best for &lt;language&gt;" one-click adoption in Settings.
+- Series-level audio-language intent memory propagating to newly discovered episodes.
+
+## The subgen patch story
+
+Subarr drives subgen through 13 small patches over upstream McCloudS/subgen. Each is independent, idempotent on reapply, required for one specific subarr orchestration behaviour. Living patch stack at [`coaxk/subarr-subgen`](https://github.com/coaxk/subarr-subgen).
+
+The maintained image is `ghcr.io/coaxk/subarr-subgen:<tag>`. Tagged releases: `v4.7` current, with `latest`, `stable` (7-day soak), and per-version tags.
+
+You do not need our patched image. See the "I already have subgen" table at the top.
 
 ## Development
 
@@ -510,34 +244,16 @@ cd subarr
 python -m venv .venv && source .venv/bin/activate
 pip install -e .[dev]
 PYTHONPATH=src uvicorn subarr.app:app --reload --port 9922
+PYTHONPATH=src pytest -q                    # 266 passing
+npm install && npm run build:frontend       # SPA bundles
 ```
-
-Tests:
-
-```bash
-PYTHONPATH=src pytest -q
-```
-
-Migrations:
-
-```bash
-# Add a new migration:
-touch src/subarr/migrations/004_my_change.sql
-# Write your SQL. See src/subarr/migrations/README.md for conventions.
-```
-
----
 
 ## Related
 
-- [Bazarr](https://github.com/morpheus65535/bazarr): the librarian. Subarr reads its wanted list and writes back its scan-disk trigger.
-- [McCloudS/subgen](https://github.com/McCloudS/subgen): the worker. Subarr drives it via the patches in [`coaxk/subarr-subgen`](https://github.com/coaxk/subarr-subgen).
-- [subsyncarr](https://github.com/McCloudS/subsyncarr): the synchroniser. Recommended companion for sync issues subarr does not tackle. Mentioned in the wizard.
-
----
+- [Bazarr](https://github.com/morpheus65535/bazarr), the librarian. Subarr reads its wanted list and writes back its scan-disk trigger.
+- [McCloudS/subgen](https://github.com/McCloudS/subgen), the worker. Subarr drives it via the patches in [`coaxk/subarr-subgen`](https://github.com/coaxk/subarr-subgen).
+- [subsyncarr](https://github.com/McCloudS/subsyncarr), the synchroniser. Recommended companion for sync issues subarr does not tackle.
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
-
-The patched subgen image (`ghcr.io/coaxk/subarr-subgen`) is a derived work of upstream McCloudS/subgen. See that repo's [`NOTICE`](https://github.com/coaxk/subarr-subgen/blob/main/NOTICE) for attribution.
+MIT. See [LICENSE](LICENSE). The patched subgen image (`ghcr.io/coaxk/subarr-subgen`) is a derived work of upstream McCloudS/subgen. See that repo's [`NOTICE`](https://github.com/coaxk/subarr-subgen/blob/main/NOTICE) for attribution.


### PR DESCRIPTION
## Summary

Launch-prep PR per `11-launch-plan-2026-06-01.md` (workstreams). Restructures README from 543 lines to 259 per the fresh-eyes audit, adds a tone-gate CI workflow that fails the build on Bazarr-killer phrasing, adds three launch-targeted issue templates.

## Key changes

### README

- **Order:** H1 → tagline → badges → AI disclosure → hero GIF placeholder → 5-bullet "In one breath" → 5-min install **with PUID/PGID/TZ/UMASK** → decision table → **"Do you need subarr?" self-disqualification** → v1.0 surfaces → ollama → audio-language pipeline (kept, strongest single explainer) → **Known limitations (v1.0)** → Security → Telemetry → Auth → Updates → Architecture (tiered table) → Roadmap → patch story → Dev → Related → License.

- **Locked-tone rewrites:** `subarr is the brain` → `subarr coordinates between Bazarr and subgen`. `Bazarr does not show you` → `Subarr surfaces ... measurement layer`. All three "brain" mentions from prior drafts removed.

- **New sections:** "Known limitations (v1.0)" before Roadmap, "Do you need subarr?" disqualification, 3-tier deployment comparison table.

- **Scope tags:** Leaderboard + tuning lab consistently tagged `[v1.1]` per the dated scope amendment in `00-synthesis.md`. `subarr.com/stats` tagged `[planned with v1.0 publish]` until Pages deploy lands.

- Zero em dashes, en dashes, emoji.

### Tone-gate workflow

- New `.github/workflows/tone-gate.yml`. Greps README on every change for the locked banned-phrase list and fails the build with the exact line on hit.
- Exception marker: `<!-- tone-allow: <reason> -->` on the line above lets a phrase through with rationale.

### Issue templates (3 new)

- `compat_question.yml` — for the most-asked "do I have to swap to subarr-subgen?" question class
- `provider_leaderboard_data.yml` — captures opt-in per-provider success-rate data that feeds v1.1 leaderboard design
- `whisper_tuning_question.yml` — captures per-language kwargs questions until v1.1 tuning lab ships

## Companion artifacts (NOT in this PR)

- `_workstreams/subarr-landscape/11-launch-plan-2026-06-01.md` — full launch sequence + per-subreddit plan + risks
- `_workstreams/subarr-landscape/12-launch-copy.md` — draft Reddit posts (r/bazarr, r/selfhosted, r/homelab) + telemetry self-disclosure + 7 pre-drafted FAQ replies + "is this Bazarr-killer" rebuttal. **All pending Judd's voice-check.**
- `_workstreams/subarr-landscape/00-synthesis.md` — amended with dated scope decision so the v1.0-anchor vs v1.1-teaser question is locked
- `coaxk/subarr-telemetry/stats/` — placeholder page for `subarr.com/stats` (deploy via Cloudflare Pages)

## Test plan

- [ ] Tone-gate CI passes on this branch (verifies the workflow itself works)
- [ ] Normal CI passes (bundle drift unaffected, frontend untouched)
- [ ] Render README on GitHub preview, eyeball layout
- [ ] Hero GIF placeholder comment doesn't render visibly
- [ ] Voice-check the post drafts in `12-launch-copy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
