### PR TITLE
README: Two ways to use subarr + de-anime'd Common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ The wizard tries to auto-detect Sonarr/Radarr/Bazarr/Tautulli/subgen on your exi
 
 **Why `:rw` on the media mount.** Subarr's sidecar mismatch detector renames orphaned `.srt` files whose basename drifted from the video. Read-only blocks this. If you don't want it, set `SUBARR_SIDECAR_RENAME=0` and mount `:ro`, the rest of the product works.
 
+## Two ways to use subarr
+
+Pick whichever fits how you work. You can do both.
+
+**Simple, "I just want a real frontend for subgen".** Install subarr, open the Library tab, tick a file or a folder or a whole series, hit "Queue for transcription". Watch it run. Re-queue, cancel, see what failed and why. Same way you'd use Sonarr's queue for downloads. No coverage walks, no rules, no scheduler. Just a working UI on top of subgen.
+
+**Advanced, "tell me what I should fix first".** Open the Coverage tab. Subarr has already walked your library and sorted gaps by score with reason chips per row (no track, embedded-only, bazarr-wanted, audio-mislabel, low-score, unmonitored). Apply auto-queue rules, run scheduled walks, integrate Tautulli playback signal into priority. Set it up once, walk away. Subarr decides what's worth running.
+
+Most installs start simple and grow into advanced as the coverage walk surfaces things worth doing. Nothing forces the move; both are valid forever.
+
 ## I already have subgen. What do I do?
 
 The most-asked question. Quick answer.
@@ -125,6 +135,16 @@ Subarr's audio-language pipeline:
 ```
 
 Once a verification exists, every downstream submission carries it through an evidence gate. Confidence below 0.5, or missing source field, refuses to forward the override. Whisper transcribes from the audio, the way it was meant to.
+
+## Common questions
+
+**Is this just for anime?** No. The audio-language detection problem hits anything where the first 30 seconds of a file aren't representative: foreign-language openings on dubbed releases, silent cold opens, music-only intros, opening narrations in a different language than the dialog. Anime gets cited a lot because the OP pattern is universal across the genre, but the technical problem is general across multi-language libraries. Coverage, scheduling, provenance, and the queue UI are all language-and-genre-agnostic.
+
+**Do I need ollama?** No. It enables two optional extras (structured enrichment and the vision pre-filter). Everything else works without it.
+
+**Do I need Tautulli?** No, but you get NOW PLAYING boost, just-imported boost, and per-user language profiles if you have it. Without Tautulli the scheduler still works, it just has one fewer priority signal.
+
+**Will this work with Jellyfin / Emby?** Not in v1.0. v1.1 candidate if there's demand. Open a feature request.
 
 ## Known limitations (v1.0)
 


### PR DESCRIPTION
Two product-positioning gaps Judd flagged during launch-copy voice-check.

## 1. Dual-mode entry path
New 'Two ways to use subarr' section right before the I-already-have-subgen table. Establishes two valid ways to get started:
- **Simple**: install, open Library, tick files, queue. Use subarr as a real frontend for subgen.
- **Advanced**: open Coverage, let subarr decide what to fix first.

Both valid. Simple is the first-hour win that gets users through the door; Advanced is what they grow into.

## 2. Anime perception pre-empt
Three anime mentions in the README + the matching r/bazarr post draft risked reading as 'subarr is for anime watchers'. New 'Common questions' section above Known limitations explicitly answers 'Is this just for anime?' (no, foreign-language opens / silent cold opens / music intros all hit the same technical issue across multi-language libraries).

Same section also pre-empts three other FAQs that show up in every launch thread: ollama required, Tautulli required, Jellyfin support.

Companion change in workstreams: `12-launch-copy.md` v3 de-anime's the r/bazarr post body, adds 'Two ways to use subarr' framing to all three Reddit posts.

## Test plan
- [ ] Tone-gate CI passes
- [ ] Normal CI passes
- [ ] Render README on GitHub, verify the two new sections flow correctly
- [ ] Verify Common questions reads as a pre-empt, not a defensive justification