### PR TITLE
fix(security): SSRF allowlist on /api/vision/check + path guard on /api/queue/cancel

### DIFF
--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -271,6 +271,11 @@ async def cancel_queued(req: CancelRequest, request: Request) -> dict:
     canonical = (req.path or "").strip().strip("/")
     if not canonical:
         raise HTTPException(400, detail="path required")
+    # Reject path-escape attempts, consistent with /queue/requeue.
+    try:
+        canonical_to_fs(canonical)
+    except (PathOutsideRootError, OSError):
+        raise HTTPException(400, detail=f"path escapes media root: {canonical!r}")
     caps = getattr(request.app.state, "subgen_caps", None)
     if caps is None or not getattr(caps, "queue_cancel", False):
         raise HTTPException(

--- a/src/subarr/routers/vision.py
+++ b/src/subarr/routers/vision.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from ..config import settings
 from ..integrations.ollama import OllamaError, _VISION_FAMILIES
 
 router = APIRouter(prefix="/api/vision", tags=["vision"])
@@ -47,6 +49,34 @@ class VisionCheckRequest(BaseModel):
     image_b64: str | None = None
     model: str | None = None
     prompt: str | None = None  # override prompt for advanced callers
+
+
+def _image_url_allowed(url: str, allowed_hosts: set[str]) -> bool:
+    """True iff url is http(s) and its host[:port] is in allowed_hosts.
+
+    image_url is fetched server-side by vision_describe, so an unrestricted
+    value is an SSRF vector. Thumbnails only ever come from the configured
+    Plex / Tautulli hosts, so we allowlist exactly those netlocs. An empty
+    allowlist (neither configured) denies — the caller must pass image_b64.
+    """
+    try:
+        p = urlparse(url)
+    except Exception:
+        return False
+    if p.scheme not in ("http", "https") or not p.netloc:
+        return False
+    return p.netloc.lower() in allowed_hosts
+
+
+def _allowed_image_hosts() -> set[str]:
+    """Netlocs (host[:port]) of the configured thumbnail sources."""
+    hosts: set[str] = set()
+    for url in (settings.plex_url, settings.tautulli_url):
+        if url:
+            netloc = urlparse(url).netloc.lower()
+            if netloc:
+                hosts.add(netloc)
+    return hosts
 
 
 class VisionPullRequest(BaseModel):
@@ -129,6 +159,16 @@ async def vision_check(req: VisionCheckRequest, request: Request) -> dict[str, A
     ollama = request.app.state.ollama
     if not ollama.is_configured():
         raise HTTPException(503, detail="ollama not configured")
+    # SSRF guard: image_url is fetched server-side. Only allow the
+    # configured Plex / Tautulli thumbnail hosts; everything else must
+    # arrive as image_b64.
+    if req.image_url and not req.image_b64:
+        if not _image_url_allowed(req.image_url, _allowed_image_hosts()):
+            raise HTTPException(
+                400,
+                detail=("image_url host not allowed — must be the configured "
+                        "Plex or Tautulli host, or pass image_b64 instead"),
+            )
     try:
         # #232: pass model=None so resolve_vision_model() runs and we get
         # honest "vision pre-filter unavailable" instead of a text-model

--- a/tests/test_vision_ssrf.py
+++ b/tests/test_vision_ssrf.py
@@ -1,0 +1,36 @@
+"""SSRF guard for POST /api/vision/check.
+
+vision_describe fetches image_url server-side, so an unrestricted
+image_url lets a caller make subarr GET arbitrary internal URLs. Thumbnails
+only ever come from the configured Plex / Tautulli hosts, so we allowlist
+those.
+"""
+
+from __future__ import annotations
+
+
+def _imp():
+    from subarr.routers.vision import _image_url_allowed
+    return _image_url_allowed
+
+
+def test_allows_configured_host():
+    allowed = {"plex.local:32400", "tautulli.local:8181"}
+    assert _imp()("http://plex.local:32400/photo/:/transcode?url=x", allowed) is True
+
+
+def test_blocks_cloud_metadata_endpoint():
+    assert _imp()("http://169.254.169.254/latest/meta-data/", {"plex.local:32400"}) is False
+
+
+def test_blocks_arbitrary_host():
+    assert _imp()("http://evil.example.com/x", {"plex.local:32400"}) is False
+
+
+def test_blocks_non_http_scheme():
+    assert _imp()("file:///etc/passwd", {"plex.local:32400"}) is False
+
+
+def test_empty_allowlist_denies():
+    # Nothing configured to validate against -> deny (caller must use image_b64).
+    assert _imp()("http://plex.local:32400/x", set()) is False


### PR DESCRIPTION
Two input-validation hardening fixes from the audit (low impact — auth-context dependent, single-user — but real).

## `/api/vision/check` SSRF
`image_url` is fetched server-side by `vision_describe` ([ollama.py:244](src/subarr/integrations/ollama.py)), so an unrestricted value lets a caller make subarr GET arbitrary internal URLs (cloud metadata, other containers). The response isn't exfiltrated (only a vision-model description is returned — blind SSRF), but it's still a vector.

**Fix:** allowlist the configured Plex / Tautulli netlocs (the only legitimate thumbnail sources); anything else must arrive as `image_b64`. Empty allowlist (neither configured) denies. No in-app caller passes `image_url`, so nothing legitimate breaks.

## `/api/queue/cancel` path guard
Added the same `canonical_to_fs` path-escape guard that `/queue/requeue` already has — cancel was forwarding an unvalidated path string to subgen.

## Tests
`tests/test_vision_ssrf.py` — allowlist accepts the configured host; denies cloud-metadata, arbitrary host, non-http scheme, and empty allowlist.

## Verification (dev, 9923)
- `POST /api/vision/check` with `image_url=http://169.254.169.254/...` → **400**
- `POST /api/queue/cancel` with `path=../../etc/passwd` → **400**

🤖 Generated with [Claude Code](https://claude.com/claude-code)