### PR TITLE
chore: remove dead code + fix inaccurate DashboardCache docstring

### DIFF
--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -1225,31 +1225,6 @@ async def _add_bazarr_blind_synthetic_rows(
     return items
 
 
-def _lookup_probe_audio_langs(
-    file_canonical: str,
-    probe_by_series_prefix: dict[str, list[tuple[str, Any]]],
-) -> list[str] | None:
-    """Find probe-cache audio_langs for `file_canonical` if any entry
-    matches. Probe entries are ProbeResult objects whose audio_langs
-    must be derived via `audio_lang_summary_with_titles()` rather than
-    a direct attribute lookup.
-
-    Returns None when no probe entry exists — caller treats as
-    'insufficient evidence' and skips synthesis (no false positives)."""
-    from .media_probe import audio_lang_summary_with_titles
-    parts = file_canonical.split("/")
-    for i in range(len(parts) - 1, 0, -1):
-        prefix = "/".join(parts[:i])
-        for path, entry in probe_by_series_prefix.get(prefix, []):
-            if path == file_canonical:
-                try:
-                    langs, _notes = audio_lang_summary_with_titles(entry)
-                    return list(langs or [])
-                except Exception:
-                    return []
-    return None
-
-
 def _audio_metadata_looks_mislabeled(audio_langs: list[str] | None) -> bool:
     """The Bazarr-blind signature: file's audio metadata claims English
     OR is undetected, on a series Sonarr knows is foreign-language.

--- a/src/subarr/routers/home.py
+++ b/src/subarr/routers/home.py
@@ -12,9 +12,11 @@ only makes one round-trip per poll. Five sections:
   - next_run     : scheduler config + countdown to next walk
   - activity     : last N provenance entries with kind classification
 
-Designed to be cheap: each section is a single store query, no network
-fan-out to upstreams beyond what the existing /api/integrations/health
-already does. Caller polls this on a 5s tick.
+Cost note: most sections are single store queries, but the stages block
+DOES fan out to Bazarr (episodes/movies wanted) + subgen /queue. To keep
+that off the request path, a 30s DashboardCache (see app.py) fronts this
+builder — the frontend's 5s poll mostly hits the cached snapshot, and the
+upstream fan-out runs on the cache's own 30s tick.
 """
 
 from __future__ import annotations

--- a/src/subarr/scheduler.py
+++ b/src/subarr/scheduler.py
@@ -251,31 +251,27 @@ class Scheduler:
                 "stale_count": len(stale),
             }
 
-        # Reuse the completion watcher's task-id cache if it's already
-        # discovered the scan-disk task id, otherwise discover it here.
-        # Watcher discovers on first ledger completion; coverage_walk may
-        # run before that on a fresh install.
-        watcher = getattr(self, "_watcher", None)
-        task_id = getattr(watcher, "_bazarr_task_id", None) if watcher else None
-        if task_id is None:
-            # Discover inline — same hints the watcher uses.
-            try:
-                tasks = await bazarr.list_tasks()
-                hints = (
-                    "series_full_scan_subtitles", "movies_full_scan_subtitles",
-                    "scan_disk_series", "scan_disk_episodes",
-                    "scan disk", "index all existing episodes",
-                )
-                for hint in hints:
-                    for t in tasks:
-                        if hint in (t.get("job_id") or "").lower() or hint in (t.get("name") or "").lower():
-                            task_id = t.get("job_id")
-                            break
-                    if task_id:
+        # Discover the Bazarr scan-disk task id. (A prior design reused a
+        # cached id off a self._watcher backref that was never wired, so
+        # discovery always ran anyway — removed the dead reuse path.)
+        task_id = None
+        try:
+            tasks = await bazarr.list_tasks()
+            hints = (
+                "series_full_scan_subtitles", "movies_full_scan_subtitles",
+                "scan_disk_series", "scan_disk_episodes",
+                "scan disk", "index all existing episodes",
+            )
+            for hint in hints:
+                for t in tasks:
+                    if hint in (t.get("job_id") or "").lower() or hint in (t.get("name") or "").lower():
+                        task_id = t.get("job_id")
                         break
-            except Exception as e:
-                log.warning("coverage_walk: bazarr task discovery failed: %s", e)
-                return {"fired": False, "reason": f"task discovery failed: {e}", "stale_count": len(stale)}
+                if task_id:
+                    break
+        except Exception as e:
+            log.warning("coverage_walk: bazarr task discovery failed: %s", e)
+            return {"fired": False, "reason": f"task discovery failed: {e}", "stale_count": len(stale)}
 
         if not task_id:
             return {"fired": False, "reason": "no scan-disk task id found", "stale_count": len(stale)}


### PR DESCRIPTION
Verified-safe cleanups from the audit punch list.

- **scheduler**: drop the `self._watcher` task-id reuse path. `_watcher` was never assigned, so the branch always fell through to inline discovery — removed the dead reuse + the always-true guard ([scheduler.py](src/subarr/scheduler.py)).
- **coverage_engine**: remove `_lookup_probe_audio_langs` (zero callers; the blind-defense path uses `_classify_audio_label`).
- **routers/home**: the module docstring claimed "single store query, no network fan-out" — the stages block actually fans out to Bazarr + subgen. Corrected to describe the 30s `DashboardCache` that fronts it.

**Deliberately left for v1.1** (feature/risk, not a sweep): arbiter movie-accept 501, `init_schema` migration debt removal, real telemetry walks/error metrics. Flagging rather than rushing them pre-launch.

Tests: scheduler/coverage/auto_queue/blind-defense suites pass (41); app boots, dashboard 200 on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)