### PR TITLE
feat(arbiter): implement movie candidate accept (was 501)

### DIFF
--- a/src/subarr/integrations/bazarr.py
+++ b/src/subarr/integrations/bazarr.py
@@ -189,6 +189,34 @@ class BazarrClient(IntegrationClient):
         except ValueError:
             return None
 
+    async def download_movie_candidate(
+        self, *, movie_id: int, language: str, provider: str,
+        subtitles_id: str, score: int, forced: bool = False, hi: bool = False,
+    ) -> dict[str, Any] | None:
+        """Movie mirror of download_episode_candidate: POST
+        /api/providers/movies (form field `radarrid`, matching
+        candidate_movie_subtitles + upload_movie_subtitle) so the arbiter
+        accept loop works for movies too."""
+        data = {
+            "radarrid": str(movie_id),
+            "language": language,
+            "provider": provider,
+            "subtitles_id": subtitles_id,
+            "score": str(score),
+            "forced": "true" if forced else "false",
+            "hi": "true" if hi else "false",
+        }
+        try:
+            r = await self._client.post("/api/providers/movies", data=data)
+        except Exception as e:
+            raise IntegrationError(f"bazarr download_movie_candidate: {e}") from e
+        if r.status_code >= 400:
+            raise IntegrationError(f"bazarr download_movie_candidate HTTP {r.status_code}: {r.text[:200]}")
+        try:
+            return r.json()
+        except ValueError:
+            return None
+
     async def upload_episode_subtitle(
         self, *, series_id: int, episode_id: int, language: str,
         file_path: str, hi: bool = False, forced: bool = False,

--- a/src/subarr/routers/arbiter.py
+++ b/src/subarr/routers/arbiter.py
@@ -111,8 +111,15 @@ async def accept_candidate(req: AcceptRequest, request: Request) -> dict[str, An
                 hi=req.hi,
             )
         else:
-            # Movie variant not yet shipped — fail clearly
-            raise HTTPException(501, detail="movie candidate accept not implemented yet")
+            result = await bazarr.download_movie_candidate(
+                movie_id=req.movie_id,
+                language=req.language,
+                provider=req.provider,
+                subtitles_id=req.subtitles_id,
+                score=req.score,
+                forced=req.forced,
+                hi=req.hi,
+            )
     except IntegrationError as e:
         raise HTTPException(502, detail=str(e))
     return {"accepted": True, "bazarr_response": result}

--- a/tests/test_arbiter_movie_accept.py
+++ b/tests/test_arbiter_movie_accept.py
@@ -1,0 +1,76 @@
+"""Arbiter movie-accept (POST /api/arbiter/accept with movie_id).
+
+GET /candidates already supports movies; accept raised 501 for them. These
+pin the movie path to mirror the episode passthrough to Bazarr
+(/api/providers/movies, form field radarrid).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+
+def test_download_movie_candidate_posts_radarrid():
+    """Unit: the new Bazarr method must POST to /api/providers/movies with a
+    `radarrid` form field (movies use radarrid, not episodeid)."""
+    from subarr.integrations.bazarr import BazarrClient
+
+    captured = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        captured["body"] = req.content.decode()
+        return httpx.Response(200, json={"downloaded": True})
+
+    c = BazarrClient()
+    c._client = httpx.AsyncClient(
+        base_url="http://bazarr:6767", transport=httpx.MockTransport(handler)
+    )
+    c._configured = True
+
+    res = asyncio.run(
+        c.download_movie_candidate(
+            movie_id=42, language="en", provider="opensubtitles",
+            subtitles_id="abc123", score=91, forced=False, hi=False,
+        )
+    )
+    assert captured["path"] == "/api/providers/movies"
+    assert "radarrid=42" in captured["body"]
+    assert "episodeid" not in captured["body"]
+    assert res == {"downloaded": True}
+
+
+def test_accept_movie_routes_to_bazarr(app_with_stub):
+    """Router: POST /accept with movie_id returns 200 and invokes the movie
+    download (no more 501)."""
+    c = app_with_stub
+    calls = {}
+
+    class FakeBazarr:
+        def is_configured(self):
+            return True
+
+        async def download_movie_candidate(self, **kw):
+            calls.update(kw)
+            return {"downloaded": True}
+
+        async def aclose(self):  # lifespan shutdown gathers bazarr.aclose()
+            pass
+
+    c.app.state.integrations.bazarr = FakeBazarr()
+    r = c.post("/api/arbiter/accept", json={
+        "movie_id": 42, "provider": "opensubtitles",
+        "subtitles_id": "abc123", "score": 91,
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["accepted"] is True
+    assert calls["movie_id"] == 42
+
+
+def test_accept_requires_an_id(app_with_stub):
+    r = app_with_stub.post("/api/arbiter/accept", json={
+        "provider": "opensubtitles", "subtitles_id": "x", "score": 1,
+    })
+    assert r.status_code == 400


### PR DESCRIPTION
`GET /api/arbiter/candidates` supports movies, but `POST /accept` raised **501** for `movie_id` — the UI could surface movie candidates it could never accept.

## Fix
- Add `BazarrClient.download_movie_candidate` — mirror of `download_episode_candidate`, POSTing to `/api/providers/movies` with the `radarrid` form field (matching the existing `candidate_movie_subtitles` + `upload_movie_subtitle`, which already use `radarrid` in production).
- Route the movie branch to it. `AcceptRequest` already declared `movie_id`; no model change. Symmetric with the episode path (pure Bazarr passthrough — no provenance/Radarr/scan side effects, matching episode behaviour).

## Tests
- Unit: POST hits `/api/providers/movies` with `radarrid` (not `episodeid`).
- Router: `movie_id` → 200 + `download_movie_candidate` invoked; 501 path gone; missing-id → 400.

Verified clean boot on dev; did not trigger a live movie download (side-effect risk) — `radarrid` is already proven by the production movie methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)