### PR TITLE
fix(onboarding): env-set config is authoritative, not clobbered on complete

### DIFF
--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -210,3 +210,37 @@ def load() -> Settings:
 
 
 settings = load()
+
+
+# ─── Onboarding clobber guard support ───────────────────────────────
+# Maps each Settings field the onboarding wizard can write to the env var
+# that backs it in load(). config owns this so the field<->env relationship
+# has a single source of truth (drift-checked in tests). Used by the
+# onboarding apply step: an env-set field is the operator's authoritative
+# declaration and must NOT be overwritten by stored wizard progress.
+FIELD_ENV_VARS: dict[str, str] = {
+    "media_root": "SUBARR_MEDIA_ROOT",
+    "arr_path_prefix": "ARR_PATH_PREFIX",
+    "bazarr_url": "BAZARR_URL",
+    "bazarr_api_key": "BAZARR_API_KEY",
+    "sonarr_url": "SONARR_URL",
+    "sonarr_api_key": "SONARR_API_KEY",
+    "radarr_url": "RADARR_URL",
+    "radarr_api_key": "RADARR_API_KEY",
+    "tautulli_url": "TAUTULLI_URL",
+    "tautulli_api_key": "TAUTULLI_API_KEY",
+    "subgen_url": "SUBGEN_URL",
+    "ollama_url": "OLLAMA_URL",
+    "ollama_model": "OLLAMA_MODEL",
+}
+
+
+def env_is_set(settings_attr: str) -> bool:
+    """True iff the env var backing this Settings field is present AND
+    non-empty (mirrors _env_or's empty==missing rule, so a blank
+    `BAZARR_URL=` line counts as unset)."""
+    name = FIELD_ENV_VARS.get(settings_attr)
+    if not name:
+        return False
+    raw = os.environ.get(name)
+    return raw is not None and raw.strip() != ""

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -503,7 +503,7 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
     we rely on the user pinning their env vars in compose after the
     wizard finishes (the wizard's final step shows a copy-paste
     snippet of the values they entered)."""
-    from ..config import settings
+    from ..config import settings, env_is_set
     mapping = {
         "media_root":       ("media_root", Path),
         "arr_path_prefix":  ("arr_path_prefix", str),
@@ -521,6 +521,17 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
     }
     for src_key, (settings_attr, coerce) in mapping.items():
         if src_key in progress and progress[src_key]:
+            # Clobber guard: an env-set field is the operator's
+            # authoritative config. Do NOT overwrite it from stored wizard
+            # progress (stale/auto-detected progress clobbering an env-set
+            # value is the bug that broke subgen on dev). Fields not set via
+            # env still apply from the wizard (the primary first-run path).
+            # Trade-off: a wizard edit to an env-set field won't take effect
+            # live — env wins until the operator updates env + restarts.
+            if env_is_set(settings_attr):
+                log.debug("clobber-guard: kept env-set %s (ignored wizard value)",
+                          settings_attr)
+                continue
             try:
                 # Settings is a frozen dataclass — plain setattr raises
                 # FrozenInstanceError. object.__setattr__ bypasses the

--- a/tests/test_live_reload.py
+++ b/tests/test_live_reload.py
@@ -114,7 +114,10 @@ def test_subgen_watchdog_resolves_subgen_via_provider():
     assert w._subgen is s2
 
 
-def test_apply_progress_mutates_frozen_settings():
+def test_apply_progress_mutates_frozen_settings(monkeypatch):
+    # Verifies the object.__setattr__ frozen-dataclass bypass. Must be a
+    # field that is NOT env-set, or the clobber guard correctly skips it.
+    monkeypatch.delenv("BAZARR_URL", raising=False)
     from subarr.routers.onboarding import _apply_progress_to_settings
     from subarr.config import settings
 

--- a/tests/test_onboarding_clobber_guard.py
+++ b/tests/test_onboarding_clobber_guard.py
@@ -1,0 +1,83 @@
+"""Onboarding clobber guard.
+
+env-set integration config is the operator's authoritative declaration and
+must NOT be overwritten by stored wizard progress on /complete — that's the
+bug that broke subgen on dev (stale progress subgen_url clobbered the
+env-set value). Fields NOT set via env still apply from the wizard (the
+primary first-run path).
+
+The `subarr_env` fixture sets every integration env var, so by default all
+fields are env-set; tests delenv a field to exercise the apply path.
+"""
+
+from __future__ import annotations
+
+
+def _apply():
+    from subarr.routers.onboarding import _apply_progress_to_settings
+    return _apply_progress_to_settings
+
+
+def test_env_is_set_helper(subarr_env, monkeypatch):
+    from subarr import config
+    assert config.env_is_set("bazarr_url") is True          # set by subarr_env
+    monkeypatch.delenv("BAZARR_URL", raising=False)
+    assert config.env_is_set("bazarr_url") is False
+    monkeypatch.setenv("BAZARR_URL", "   ")                   # blank == unset
+    assert config.env_is_set("bazarr_url") is False
+    assert config.env_is_set("not_a_real_field") is False
+
+
+def test_env_set_url_not_clobbered(subarr_env):
+    from subarr.config import settings
+    before = settings.bazarr_url
+    _apply()({"bazarr_url": "http://stale-wizard:6767"})
+    assert settings.bazarr_url == before
+    assert settings.bazarr_url != "http://stale-wizard:6767"
+
+
+def test_env_set_api_key_not_clobbered(subarr_env):
+    from subarr.config import settings
+    before = settings.bazarr_api_key
+    _apply()({"bazarr_api_key": "stale-key"})
+    assert settings.bazarr_api_key == before
+
+
+def test_applies_when_field_not_env_set(subarr_env, monkeypatch):
+    monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+    from subarr.config import settings
+    _apply()({"ollama_model": "wizard-chosen-model"})
+    assert settings.ollama_model == "wizard-chosen-model"
+
+
+def test_applies_when_env_blank(subarr_env, monkeypatch):
+    monkeypatch.setenv("OLLAMA_MODEL", "   ")  # blank == unset → wizard applies
+    from subarr.config import settings
+    _apply()({"ollama_model": "wizard-model-2"})
+    assert settings.ollama_model == "wizard-model-2"
+
+
+def test_idempotent_for_env_set(subarr_env):
+    from subarr.config import settings
+    before = settings.subgen_url
+    _apply()({"subgen_url": "http://stale-subgen:9000"})
+    _apply()({"subgen_url": "http://stale-subgen:9000"})
+    assert settings.subgen_url == before  # the actual dev-clobber scenario
+
+
+def test_field_env_map_covers_all_apply_keys(subarr_env):
+    import dataclasses
+    from subarr import config
+    from subarr.config import Settings
+    apply_attrs = {
+        "media_root", "arr_path_prefix",
+        "bazarr_url", "bazarr_api_key", "sonarr_url", "sonarr_api_key",
+        "radarr_url", "radarr_api_key", "tautulli_url", "tautulli_api_key",
+        "subgen_url", "ollama_url", "ollama_model",
+    }
+    # every field the wizard can apply must be guardable
+    assert apply_attrs <= set(config.FIELD_ENV_VARS)
+    # and every mapped attr must be a real Settings field
+    fields = {f.name for f in dataclasses.fields(Settings)}
+    for attr in config.FIELD_ENV_VARS:
+        assert attr in fields


### PR DESCRIPTION
`POST /api/onboarding/complete` applied stored wizard progress onto live Settings, so a stale/auto-detected progress value could overwrite an **env-set** integration config in-memory until restart. That's what broke subgen on dev (stale progress `subgen_url` clobbered the env-set value).

## The correct rule
The originally-scoped "skip only when progress == env" does **not** fix this — the real clobber was progress that *differed* from env. The correct rule: **an env-set field is the operator's authoritative declaration and is never overwritten by wizard progress.** Fields not set via env still apply from the wizard (the primary first-run path).

- `config.py`: `FIELD_ENV_VARS` (field → backing env var, single source of truth) + `env_is_set(attr)` (present AND non-empty, mirroring `_env_or`'s empty==missing).
- `onboarding.py`: skip applying progress for any env-set field.

**Trade-off (documented):** a wizard edit to an env-set field won't take effect live — env wins until the operator updates env + restarts. Matches the existing "pin your env vars" v1.0 model.

## Tests
`tests/test_onboarding_clobber_guard.py` — env-set url/key not clobbered, non-env + blank-env apply, idempotency, and a field↔env drift guard. Live-reload apply test updated to `delenv` first (non-env path). 53 onboarding/config/live-reload tests green.

## Verification (dev, 9923)
subgen stays **reachable through `/complete`** — the exact scenario that clobbered it before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)