### PR TITLE
feat(telemetry): real walks_per_day_30d + error_counts_30d

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -35,6 +35,7 @@ from .routers import (
 )
 from .scan_runner import ScanRunner
 from .scan_store import ScanStore
+from .error_store import ErrorStore
 from .schedule_store import ScheduleStore
 from .scheduler import Scheduler
 from .subgen_client import SubgenClient
@@ -72,12 +73,16 @@ async def lifespan(app_: FastAPI):
     app_.state.subgen_restart_to = None
     app_.state.scans = ScanStore(settings.db_path)
     app_.state.scans.init_schema()
+    # Anonymous error-class log for telemetry (schema via migration 006).
+    app_.state.errors = ErrorStore(settings.db_path)
     app_.state.runner = ScanRunner(
         store=app_.state.scans,
         caps_provider=lambda: getattr(app_.state, "subgen_caps", None),
         # Resolve subgen live so onboarding can swap the client without
         # restarting the runner.
         subgen_provider=lambda: app_.state.subgen,
+        # Best-effort anonymous error-class recording for telemetry.
+        error_recorder=lambda cls: app_.state.errors.record(cls),
     )
     app_.state.docker = DockerOps()
     app_.state.integrations = IntegrationBundle()
@@ -304,6 +309,7 @@ async def lifespan(app_: FastAPI):
         await app_.state.integrations.aclose()
         await app_.state.ollama.aclose()
         app_.state.scans.close()
+        app_.state.errors.close()
         app_.state.provenance.close()
         app_.state.schedule.close()
         app_.state.enrichment.close()

--- a/src/subarr/error_store.py
+++ b/src/subarr/error_store.py
@@ -1,0 +1,58 @@
+"""Anonymous error-class event log, feeding telemetry's error_counts_30d.
+
+Stores ONLY the exception class name + a timestamp -- never the message --
+so the public stats dashboard can report failure-class counts without
+leaking paths / titles / keys. Schema lives in migrations/006; this store
+does NOT init_schema (migrations are the sole schema path).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+class ErrorStore:
+    """Thread-safe SQLite wrapper (single conn + lock, matching ScanStore)."""
+
+    def __init__(self, db_path: Path):
+        self._path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._lock = threading.Lock()
+
+    def record(self, exc_class: str, *, when: float | None = None) -> None:
+        """Record one error occurrence by class name. Best-effort: never
+        raises into the caller's hot path (a telemetry write must not break
+        a scan). Only the bare class name is stored (truncated for safety)."""
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO error_events (exc_class, occurred_at) VALUES (?, ?)",
+                    (str(exc_class)[:80], when if when is not None else time.time()),
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            log.debug("error_store.record failed: %s", e)
+
+    def counts_since(self, since_epoch: float) -> dict[str, int]:
+        """{exc_class: count} for events at or after since_epoch."""
+        try:
+            with self._lock:
+                rows = self._conn.execute(
+                    "SELECT exc_class, COUNT(*) FROM error_events "
+                    "WHERE occurred_at >= ? GROUP BY exc_class",
+                    (since_epoch,),
+                ).fetchall()
+            return {r[0]: int(r[1]) for r in rows}
+        except Exception as e:  # pragma: no cover - defensive
+            log.debug("error_store.counts_since failed: %s", e)
+            return {}
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()

--- a/src/subarr/migrations/006_error_events.sql
+++ b/src/subarr/migrations/006_error_events.sql
@@ -1,0 +1,11 @@
+-- Real telemetry (error_counts_30d): persist anonymous error-class counts
+-- so the public stats dashboard reflects actual failure classes instead of
+-- an empty {}. Stores ONLY type(e).__name__ (e.g. 'SubgenUnavailable',
+-- 'ConnectError') plus a timestamp -- never the exception message -- so no
+-- paths / titles / API keys can leak into telemetry.
+CREATE TABLE IF NOT EXISTS error_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    exc_class   TEXT NOT NULL,
+    occurred_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_error_events_occurred ON error_events (occurred_at);

--- a/src/subarr/scan_runner.py
+++ b/src/subarr/scan_runner.py
@@ -40,7 +40,7 @@ class CompatModeError(RuntimeError):
 
 class ScanRunner:
     def __init__(self, subgen: SubgenClient | None = None, store: ScanStore = None,
-                 caps_provider=None, subgen_provider=None):
+                 caps_provider=None, subgen_provider=None, error_recorder=None):
         # subgen is resolved through a provider so onboarding live-reload
         # can swap the client on app.state without restarting the runner.
         # Backward compatible: a directly-passed `subgen` is wrapped in a
@@ -62,6 +62,10 @@ class ScanRunner:
         # The provider may return None (caps not yet probed) — treated
         # as "assume capable" so first-boot scans don't fail spuriously.
         self._caps_provider = caps_provider or (lambda: None)
+        # Best-effort anonymous error-class recorder for telemetry. No-op by
+        # default; app.py wires it to ErrorStore.record. Must never raise
+        # into the scan path (ErrorStore.record already swallows).
+        self._error_recorder = error_recorder or (lambda cls: None)
 
     @property
     def _subgen(self):
@@ -223,6 +227,7 @@ class ScanRunner:
             except SubgenUnavailable as e:
                 result.status = PATH_STATUS_ERROR
                 result.error = str(e)
+                self._error_recorder(type(e).__name__)
             except asyncio.CancelledError:
                 result.status = PATH_STATUS_ERROR
                 result.error = "cancelled"
@@ -234,6 +239,7 @@ class ScanRunner:
             except Exception as e:
                 result.status = PATH_STATUS_ERROR
                 result.error = repr(e)
+                self._error_recorder(type(e).__name__)
 
             result.finished_at = time.time()
             self._store.save(scan)

--- a/src/subarr/scan_store.py
+++ b/src/subarr/scan_store.py
@@ -165,6 +165,16 @@ class ScanStore:
             results=[PathResult.from_dict(d) for d in json.loads(row[6])],
         )
 
+    def count_since(self, since_epoch: float) -> int:
+        """Number of scans created at or after since_epoch (telemetry:
+        walks_per_day_30d)."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT COUNT(*) FROM scans WHERE created_at >= ?",
+                (since_epoch,),
+            ).fetchone()
+        return int(row[0]) if row else 0
+
     def save(self, scan: Scan) -> None:
         with self._lock:
             self._conn.execute(

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -356,6 +356,27 @@ class TelemetryCollector:
 # ─── Default stats provider — reads from app.state ─────────────────
 
 
+def _walks_per_day_30d(app_state) -> float:
+    """Coverage activity: scans created in the last 30 days / 30. Fixed
+    divisor keeps it comparable across installs (a new install reports a
+    low rate, which is correct). Best-effort: 0.0 if the store is
+    unavailable."""
+    try:
+        cutoff = time.time() - 30 * 86400
+        return round(app_state.scans.count_since(cutoff) / 30.0, 2)
+    except Exception:
+        return 0.0
+
+
+def _error_counts_30d(app_state) -> dict[str, int]:
+    """Anonymous {exc_class: count} over the last 30 days. Best-effort."""
+    try:
+        cutoff = time.time() - 30 * 86400
+        return app_state.errors.counts_since(cutoff)
+    except Exception:
+        return {}
+
+
 def make_default_stats_provider(app_state) -> Any:
     """Returns a callable suitable for TelemetryCollector(stats_provider=...)
     that pulls live data off app.state. Kept separate so tests can swap
@@ -418,8 +439,8 @@ def make_default_stats_provider(app_state) -> Any:
             "library_bucket": bucket,
             "scheduler_enabled": sched_enabled,
             "scheduler_mode": sched_mode,
-            "walks_per_day_30d": 0.0,  # TODO: compute from pending_walks 30d history
-            "error_counts_30d": {},     # TODO: tally from logs (later)
+            "walks_per_day_30d": _walks_per_day_30d(app_state),
+            "error_counts_30d": _error_counts_30d(app_state),
             "docker_tier": docker_tier,
         }
 

--- a/tests/test_telemetry_metrics.py
+++ b/tests/test_telemetry_metrics.py
@@ -1,0 +1,60 @@
+"""Real telemetry metrics: walks_per_day_30d (scan count / 30) and
+error_counts_30d (anonymous exception-class tally), replacing the old
+hardcoded 0.0 / {}."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+def _migrated_db(tmp_path):
+    from subarr.migrate import run_migrations
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    return db
+
+
+def test_scan_store_count_since(tmp_path):
+    from subarr.scan_store import ScanStore
+    s = ScanStore(_migrated_db(tmp_path))
+    now = time.time()
+    # 3 recent scans
+    for _ in range(3):
+        s.create(["TV/X"], reverse=False)
+    assert s.count_since(now - 86400) == 3
+    # window in the future excludes them
+    assert s.count_since(now + 86400) == 0
+
+
+def test_error_store_record_and_counts(tmp_path):
+    from subarr.error_store import ErrorStore
+    es = ErrorStore(_migrated_db(tmp_path))
+    now = time.time()
+    es.record("SubgenUnavailable", when=now - 10)
+    es.record("SubgenUnavailable", when=now - 5)
+    es.record("ConnectError", when=now - 1)
+    es.record("OldError", when=now - 40 * 86400)  # outside 30d
+    counts = es.counts_since(now - 30 * 86400)
+    assert counts == {"SubgenUnavailable": 2, "ConnectError": 1}
+
+
+def test_error_store_stores_only_class_name(tmp_path):
+    """Anonymity: keys must be bare class identifiers (no messages/paths)."""
+    import re
+    from subarr.error_store import ErrorStore
+    es = ErrorStore(_migrated_db(tmp_path))
+    es.record("ValueError")
+    es.record("x" * 200)  # over-long is truncated, never a message
+    for k in es.counts_since(0):
+        assert len(k) <= 80
+    assert "ValueError" in es.counts_since(0)
+
+
+def test_error_store_record_never_raises(tmp_path):
+    """record() on a closed/broken store must not propagate."""
+    from subarr.error_store import ErrorStore
+    es = ErrorStore(_migrated_db(tmp_path))
+    es.close()
+    es.record("SomethingError")  # should swallow, not raise


### PR DESCRIPTION
Both telemetry fields shipped hardcoded (`0.0` / `{}`) with TODOs, so the public stats dashboard showed zeros.

## Changes
- **walks_per_day_30d**: `ScanStore.count_since(30d) / 30` (fixed divisor → comparable across installs). Scans is the store that records *every* run (manual/auto/approved), unlike `pending_walks` (manual_confirm only).
- **error_counts_30d**: new anonymous `error_events` table (**migration 006**) + `ErrorStore`. `ScanRunner` gets a best-effort `error_recorder` callable (provider pattern, wired in `app.py`), invoked at its two scan error sites. **Anonymity:** only `type(e).__name__` is stored (truncated) — never the message, so no paths/titles/keys leak. `record()` swallows so it can never break a scan.

## Tests
`ScanStore.count_since`; `ErrorStore` record/counts/anonymity/never-raises. Migration 006 + telemetry/scan suites green (55).

## Verification (dev, 9923)
`/api/telemetry/preview` → `walks_per_day_30d=2.7` (real), `error_counts_30d={}` (correctly empty — no recent scan errors). Migration 006 applied; `error_events` table present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)