### PR TITLE
fix(queue): stop in-flight queued files showing in both live + Recently-done

### DIFF
--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -217,8 +217,13 @@ async def get_queue(request: Request, history_window_s: int = _DEFAULT_HISTORY_W
         for r in scan.results:
             basename = os.path.basename(r.path)
             # Skip history row if this path is currently live in subgen —
-            # it'll be visible in the processing/queued section already.
-            if basename in live_paths and r.status == PATH_STATUS_RUNNING:
+            # it's already shown in the processing/queued section. This
+            # covers BOTH a running scan_store row AND a just-submitted OK
+            # row ("subgen queued 1"): without OK here, a freshly-queued
+            # file showed in the live Queued section AND again in
+            # Recently-done. Skipped/error/orphaned rows are kept so real
+            # outcomes still surface even if a newer submission is live.
+            if basename in live_paths and r.status in (PATH_STATUS_RUNNING, PATH_STATUS_OK):
                 continue
             outcome = _path_outcome_chip(
                 r.status, r.subgen_body, r.error, canonical_path=r.path,

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -38,6 +38,39 @@ def test_queue_busy(app_with_stub):
     assert body["processing"][0]["type"] == "transcribe"
 
 
+def _one_queued_handler(req: httpx.Request) -> httpx.Response:
+    if req.url.path == "/queue":
+        return httpx.Response(200, json={
+            "queued": [{"path": "/media/library/TV/Dup/dupfile.mkv", "type": "transcribe"}],
+            "processing": [],
+            "queued_count": 1,
+            "processing_count": 0,
+            "idle": False,
+            "version": "2026.05.3",
+        })
+    return httpx.Response(404)
+
+
+@pytest.mark.subgen(handler=_one_queued_handler)
+def test_inflight_queued_path_not_duplicated_in_history(app_with_stub):
+    """A just-submitted file is live in subgen's queue AND has an OK
+    ('subgen queued 1') scan_store row. It must appear ONLY in the live
+    queued section, not also in history/Recently-done. Regression for the
+    double-listing where 40+ queued files showed in both places."""
+    from subarr.scan_store import PATH_STATUS_OK
+    c = app_with_stub
+    store = c.app.state.scans
+    scan = store.create(["TV/Dup/dupfile.mkv"], reverse=False)
+    scan.results[0].status = PATH_STATUS_OK
+    scan.results[0].subgen_body = {"walked": 1, "queued": 1}
+    store.save(scan)
+
+    body = c.get("/api/queue").json()
+    assert any("dupfile.mkv" in t["path"] for t in body["queued"])
+    assert not any("dupfile.mkv" in h["path"] for h in body["history"]), \
+        "in-flight queued path must not also appear in history"
+
+
 def _down_handler(req: httpx.Request) -> httpx.Response:
     raise httpx.ConnectError("subgen unreachable", request=req)
 


### PR DESCRIPTION
You queued 40+ files and most appeared in **both** the live Queued section and Recently-done. Root cause: the Featured Queue dedup ([queue.py:221](src/subarr/routers/queue.py)) only skipped a history row when its scan-store status was `RUNNING`. A just-submitted file's row is `OK` ("subgen queued 1") *and* it's live in subgen's `queued` list — so it slipped the dedup and double-listed.

(The "skipped" item in **Issues** is the v1.1.1 silent-fail surfacing working as designed, not a fail.)

## Fix
Dedup history rows whose path is live in subgen for `OK` as well as `RUNNING`. `skipped`/`error`/`orphaned` rows are kept so real outcomes still surface even if a newer submission is live.

## Tests / verification
- Unit: a path live in subgen's queue + an `OK` scan-store row appears only in the live queued section, not history.
- Live (dev, 9923): 43 live files, **0 overlap** between live and history (was ~40 duplicated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)