### PR TITLE
fix(subgen): stop false "lost on restart" on connectivity blips

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -223,7 +223,21 @@ async def lifespan(app_: FastAPI):
             # session anyway. Anything completed_at >= cutoff is "real done".
             cutoff = detected_at
             completed = provenance.completed_paths_since(detected_at - 86400)
-            n = scans.mark_orphaned_before(cutoff, completed_paths=completed)
+            # Evidence: if subgen is reachable and still holds these items in
+            # its queue, it was a blip, not a real restart — don't orphan
+            # them. A genuine restart leaves subgen's queue empty.
+            import os as _os
+            live_basenames: set[str] = set()
+            try:
+                q = await app_.state.subgen.queue()
+                for t in (q.get("processing") or []) + (q.get("queued") or []):
+                    if isinstance(t, dict) and t.get("path"):
+                        live_basenames.add(_os.path.basename(t["path"]))
+            except Exception as e:
+                log.debug("orphan reconcile: subgen queue fetch failed: %s", e)
+            n = scans.mark_orphaned_before(
+                cutoff, completed_paths=completed, live_basenames=live_basenames,
+            )
             log.warning(
                 "subgen restart reconciliation: %d in-flight scan_store "
                 "entries marked ORPHANED (provenance confirms %d completed "

--- a/src/subarr/scan_store.py
+++ b/src/subarr/scan_store.py
@@ -8,6 +8,7 @@ just for ordering. JSON columns are cheap and queries against them are rare
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 import time
@@ -208,7 +209,8 @@ class ScanStore:
         ]
 
     def mark_orphaned_before(self, cutoff_epoch: float,
-                             completed_paths: set[str] | None = None) -> int:
+                             completed_paths: set[str] | None = None,
+                             live_basenames: set[str] | None = None) -> int:
         """#229 reconciliation: walk all scans created before cutoff_epoch,
         find PathResult rows with status=PATH_STATUS_OK that aren't in the
         completed_paths set (paths confirmed done via provenance.completed_at),
@@ -220,6 +222,12 @@ class ScanStore:
         orphan items subgen actually finished before the restart.
         """
         completed = completed_paths or set()
+        # Basenames of items still sitting in subgen's live queue. A real
+        # restart empties subgen's queue, so these are absent and get
+        # orphaned; a connectivity blip leaves them present, so we must NOT
+        # mark them lost. This is the evidence that makes "lost on restart"
+        # mean genuinely gone.
+        live = live_basenames or set()
         n_reclassified = 0
         with self._lock:
             rows = self._conn.execute(
@@ -231,7 +239,9 @@ class ScanStore:
                 results = [PathResult.from_dict(d) for d in json.loads(results_json)]
                 changed = False
                 for r in results:
-                    if r.status == PATH_STATUS_OK and r.path not in completed:
+                    if (r.status == PATH_STATUS_OK
+                            and r.path not in completed
+                            and os.path.basename(r.path) not in live):
                         r.status = PATH_STATUS_ORPHANED
                         r.error = (
                             "subgen restarted before transcription completed — "

--- a/src/subarr/subgen_watchdog.py
+++ b/src/subarr/subgen_watchdog.py
@@ -34,6 +34,12 @@ log = logging.getLogger(__name__)
 # Faster polls add noise; slower ones leave orphans in flight longer.
 DEFAULT_INTERVAL_S = 30
 
+# A single missed probe is a transient blip (DNS hiccup, brief network
+# stall), NOT a restart. Require this many consecutive unreachable probes
+# before treating an unreachable→reachable transition as a same-version
+# bounce. Prevents false "subgen restarted / lost on restart" alarms.
+_BOUNCE_MIN_UNREACHABLE = 2
+
 
 class SubgenWatchdog:
     """Owns the periodic re-probe loop. Lifecycle: start() / stop()."""
@@ -62,17 +68,17 @@ class SubgenWatchdog:
         self.last_restart_at: float | None = None
         self.last_restart_from: dict[str, Any] | None = None
         self.last_restart_to: dict[str, Any] | None = None
+        # Consecutive unreachable probes. Detects same-version container
+        # bounces (docker restart with unchanged patch_rev) while ignoring
+        # single transient blips — see _BOUNCE_MIN_UNREACHABLE. (A real
+        # restart is confirmed evidence-side in mark_orphaned_before, which
+        # won't orphan items still present in subgen's live queue.)
+        self._consecutive_unreachable = 0
 
     @property
     def _subgen(self):
         """Current subgen client (resolved live for onboarding reload)."""
         return self._subgen_provider()
-        # Detects same-version container bounces: subgen briefly going
-        # unreachable then becoming reachable again, even if patch_rev
-        # stayed the same. Without this flag, restarting subgen-next
-        # via `docker restart subgen-next` would slip past detection
-        # (patch_rev unchanged) and orphans would stay invisible.
-        self._was_unreachable_since_last_reach = False
 
     def start(self) -> None:
         if self._task and not self._task.done():
@@ -124,7 +130,7 @@ class SubgenWatchdog:
         #       `docker restart subgen-next` with the same image)
         if not new.reachable:
             log.debug("subgen watchdog: not reachable on probe; keeping old caps")
-            self._was_unreachable_since_last_reach = True
+            self._consecutive_unreachable += 1
             return
 
         if old is None or not getattr(old, "reachable", False):
@@ -132,7 +138,7 @@ class SubgenWatchdog:
             # one but don't fire restart (this is initial reachability,
             # not a transition from one-running-version to another).
             self._set_caps(new)
-            self._was_unreachable_since_last_reach = False
+            self._consecutive_unreachable = 0
             log.info("subgen watchdog: subgen reached %s; caps adopted",
                      new.subarr_subgen_patch_rev or new.version)
             return
@@ -140,8 +146,11 @@ class SubgenWatchdog:
         old_identity = self._identity(old)
         new_identity = self._identity(new)
         identity_changed = old_identity != new_identity
-        observed_bounce = self._was_unreachable_since_last_reach
-        self._was_unreachable_since_last_reach = False
+        # Only a SUSTAINED outage (>= threshold consecutive unreachable
+        # probes) counts as a bounce. A single transient blip is ignored,
+        # so we don't falsely declare a restart + orphan a healthy queue.
+        observed_bounce = self._consecutive_unreachable >= _BOUNCE_MIN_UNREACHABLE
+        self._consecutive_unreachable = 0
 
         if not identity_changed and not observed_bounce:
             # Same subgen still running, never lost reachability. Keep

--- a/tests/test_subgen_restart_reconciliation.py
+++ b/tests/test_subgen_restart_reconciliation.py
@@ -1,0 +1,105 @@
+"""subgen restart reconciliation must not cry "lost on restart" when nothing
+was actually lost.
+
+Two layers:
+  - mark_orphaned_before must NOT orphan items still present in subgen's live
+    queue (a connectivity blip leaves the queue intact; only a real restart
+    empties it).
+  - the watchdog must require sustained unreachability, not a single transient
+    probe failure, before declaring a bounce.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+# ─── Layer 2: evidence-based orphaning ──────────────────────────────
+
+def test_mark_orphaned_excludes_live_subgen_queue(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.scan_store import ScanStore, PATH_STATUS_OK, PATH_STATUS_ORPHANED
+
+    db = tmp_path / "s.db"
+    run_migrations(db)
+    s = ScanStore(db)
+    scan = s.create(["TV/Keep/keep.mkv", "TV/Lose/lose.mkv"], reverse=False)
+    for r in scan.results:
+        r.status = PATH_STATUS_OK
+    s.save(scan)
+
+    # keep.mkv is still sitting in subgen's live queue → must be preserved.
+    n = s.mark_orphaned_before(
+        time.time() + 10, completed_paths=set(), live_basenames={"keep.mkv"}
+    )
+    got = s.get(scan.id)
+    st = {r.path: r.status for r in got.results}
+    assert st["TV/Lose/lose.mkv"] == PATH_STATUS_ORPHANED
+    assert st["TV/Keep/keep.mkv"] == PATH_STATUS_OK  # still in subgen → not lost
+    assert n == 1
+
+
+# ─── Layer 1: sustained-unreachability before a bounce ──────────────
+
+def _reachable():
+    from subarr.subgen_client import SubgenCapabilities
+    return SubgenCapabilities(
+        reachable=True, version="2026.05.3", has_queue=True, has_batch=True,
+        is_subarr_subgen=True, subarr_subgen_patch_rev="v4.7",
+    )
+
+
+def _unreachable():
+    from subarr.subgen_client import SubgenCapabilities
+    return SubgenCapabilities.unreachable()
+
+
+class _SeqSubgen:
+    def __init__(self, seq):
+        self._seq = list(seq)
+        self._i = 0
+
+    async def probe_capabilities(self):
+        r = self._seq[min(self._i, len(self._seq) - 1)]
+        self._i += 1
+        return r
+
+
+def _watchdog(subgen, on_restart):
+    from subarr.subgen_watchdog import SubgenWatchdog
+    box = {"caps": _reachable()}  # reachable baseline
+    return SubgenWatchdog(
+        subgen_provider=lambda: subgen,
+        get_caps=lambda: box["caps"],
+        set_caps=lambda c: box.__setitem__("caps", c),
+        on_restart=on_restart,
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_blip_does_not_fire_restart():
+    fired = []
+
+    async def on_restart(old, new, at):
+        fired.append((old, new, at))
+
+    w = _watchdog(_SeqSubgen([_unreachable(), _reachable()]), on_restart)
+    await w._probe_once()  # one unreachable blip
+    await w._probe_once()  # reachable again
+    assert fired == [], "a single transient blip must not be treated as a restart"
+
+
+@pytest.mark.asyncio
+async def test_sustained_outage_fires_restart():
+    fired = []
+
+    async def on_restart(old, new, at):
+        fired.append((old, new, at))
+
+    w = _watchdog(_SeqSubgen([_unreachable(), _unreachable(), _reachable()]), on_restart)
+    await w._probe_once()
+    await w._probe_once()
+    await w._probe_once()
+    assert len(fired) == 1, "a sustained outage (>=2 probes) should count as a restart"


### PR DESCRIPTION
Queue showed "lost on restart" entries overnight, but **nothing restarted** (both containers `RestartCount=0`; subgen up continuously, queue drained clean). The entries were stamped during yesterday's subgen-connectivity turbulence (the wrong-URL clobber window): the watchdog read a single unreachable→reachable transition as a same-version restart and orphaned a healthy in-flight queue. That directly undercuts the survives-restarts claim.

## Fix (two layers)
1. **Evidence-based orphaning** — `mark_orphaned_before` now takes `live_basenames` (items currently in subgen's queue) and never orphans them. A real restart empties subgen's queue (genuinely-gone items still orphan); a blip leaves them present (preserved). `_on_subgen_restart` fetches subgen's live queue and passes it in. **"Lost on restart" now means actually gone.**
2. **Sustained-outage threshold** — the watchdog requires `>= 2` consecutive unreachable probes before treating reachability-return as a bounce, so a single transient blip never triggers a restart.

Also fixes a latent dead-code bug from the live-reload PR: the unreachable-flag init had been orphaned after the `_subgen` property's `return` (worked by accident for the old bool; the counter surfaced it). Moved into `__init__`.

## Tests
`mark_orphaned_before` preserves live-queue items; single blip doesn't fire; sustained outage still does. 98 watchdog/subgen/scan/queue tests green; clean boot on dev.

## Note
Positioning copy should still be made precise (subarr-restart survival is solid; a *subgen* restart loses items because subgen has no persistent queue — subarr catches + offers requeue). A future subarr-subgen persistent-queue patch would make "survives a subgen restart" literally true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)