### PR TITLE
feat(probe): persist probe failures (probe-gate foundation)

### DIFF
--- a/src/subarr/migrations/007_probe_failures.sql
+++ b/src/subarr/migrations/007_probe_failures.sql
@@ -1,0 +1,10 @@
+-- Probe-gate foundation: remember files that FAILED to probe so the
+-- Coverage probe-gate can show a distinct "couldn't analyze" state instead
+-- of silently treating them as never-probed (and silently dropping them).
+-- A successful probe clears the row (see ProbeStore.upsert).
+CREATE TABLE IF NOT EXISTS probe_failures (
+    canonical_path TEXT PRIMARY KEY,
+    error          TEXT NOT NULL,
+    failed_at      REAL NOT NULL,
+    attempts       INTEGER NOT NULL DEFAULT 1
+);

--- a/src/subarr/probe_store.py
+++ b/src/subarr/probe_store.py
@@ -32,6 +32,14 @@ CREATE TABLE IF NOT EXISTS media_probe (
     probed_at       REAL NOT NULL,
     source          TEXT NOT NULL DEFAULT 'ffprobe'
 );
+-- Probe failures (also created by migration 007). Lets the coverage
+-- probe-gate distinguish "couldn't analyze" from "not yet probed".
+CREATE TABLE IF NOT EXISTS probe_failures (
+    canonical_path  TEXT PRIMARY KEY,
+    error           TEXT NOT NULL,
+    failed_at       REAL NOT NULL,
+    attempts        INTEGER NOT NULL DEFAULT 1
+);
 """
 
 # v1.1-A migration: add `source` column to track whether the row came from
@@ -132,6 +140,46 @@ class ProbeStore:
                     time.time(), source,
                 ),
             )
+            # A successful probe clears any prior failure so a recovered file
+            # leaves the "couldn't analyze" bucket.
+            self._conn.execute(
+                "DELETE FROM probe_failures WHERE canonical_path = ?",
+                (canonical_path,),
+            )
+
+    # ─── Probe failures (probe-gate "couldn't analyze") ─────────────
+
+    def record_failure(self, canonical_path: str, error: str) -> None:
+        """Persist that probing this file failed. Idempotent per path:
+        re-failing bumps attempts and refreshes the error/timestamp."""
+        with self._lock:
+            self._conn.execute(
+                "INSERT INTO probe_failures (canonical_path, error, failed_at, attempts) "
+                "VALUES (?, ?, ?, 1) "
+                "ON CONFLICT(canonical_path) DO UPDATE SET "
+                "  error=excluded.error, failed_at=excluded.failed_at, "
+                "  attempts=probe_failures.attempts + 1",
+                (canonical_path, str(error)[:500], time.time()),
+            )
+
+    def failed_paths(self) -> set[str]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT canonical_path FROM probe_failures"
+            ).fetchall()
+        return {r[0] for r in rows}
+
+    def get_failure(self, canonical_path: str) -> dict | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT canonical_path, error, failed_at, attempts "
+                "FROM probe_failures WHERE canonical_path = ?",
+                (canonical_path,),
+            ).fetchone()
+        if not row:
+            return None
+        return {"canonical_path": row[0], "error": row[1],
+                "failed_at": row[2], "attempts": row[3]}
 
     def count_by_source(self) -> dict[str, int]:
         """v1.1-A: telemetry for the arr_mediainfo win. Counts

--- a/src/subarr/probe_walker.py
+++ b/src/subarr/probe_walker.py
@@ -171,8 +171,10 @@ class ProbeWalker:
                         state.probed += 1
                     except ProbeError as e:
                         state.errors.append({"path": canonical, "error": str(e)})
+                        self._store.record_failure(canonical, str(e))
                     except Exception as e:
                         state.errors.append({"path": canonical, "error": repr(e)})
+                        self._store.record_failure(canonical, repr(e))
                     finally:
                         state.processed += 1
 

--- a/tests/test_probe_failures.py
+++ b/tests/test_probe_failures.py
@@ -1,0 +1,46 @@
+"""Persisted probe failures — the foundation for the coverage probe-gate's
+"couldn't analyze" state. A file that fails to probe must be remembered
+(survives restart) and distinguishable from never-probed, and a later
+successful probe must clear the failure.
+"""
+
+from __future__ import annotations
+
+
+def _store(tmp_path):
+    # Mirror the app: run migrations, then the store's init_schema (which
+    # still backfills the media_probe.source column until init_schema removal).
+    from subarr.migrate import run_migrations
+    from subarr.probe_store import ProbeStore
+    db = tmp_path / "p.db"
+    run_migrations(db)
+    s = ProbeStore(db)
+    s.init_schema()
+    return s
+
+
+def test_record_failure_and_failed_paths(tmp_path):
+    s = _store(tmp_path)
+    s.record_failure("TV/X/a.mkv", "ffprobe timeout")
+    s.record_failure("TV/Y/b.mkv", "corrupt container")
+    assert s.failed_paths() == {"TV/X/a.mkv", "TV/Y/b.mkv"}
+
+
+def test_record_failure_upserts_and_counts_attempts(tmp_path):
+    s = _store(tmp_path)
+    s.record_failure("TV/X/a.mkv", "err1")
+    s.record_failure("TV/X/a.mkv", "err2")
+    f = s.get_failure("TV/X/a.mkv")
+    assert f["attempts"] == 2
+    assert f["error"] == "err2"
+    assert s.failed_paths() == {"TV/X/a.mkv"}  # one row, not two
+
+
+def test_successful_probe_clears_failure(tmp_path):
+    from subarr.media_probe import ProbeResult
+    s = _store(tmp_path)
+    s.record_failure("TV/X/a.mkv", "transient")
+    assert "TV/X/a.mkv" in s.failed_paths()
+    s.upsert(canonical_path="TV/X/a.mkv", mtime=1.0, size=100,
+             result=ProbeResult(canonical_path="TV/X/a.mkv"))
+    assert "TV/X/a.mkv" not in s.failed_paths()  # recovered → no longer failed


### PR DESCRIPTION
First slice of the **probe-gate** (PR-A1). Probe failures were in-memory only (`probe_walker.state.errors`, lost on restart), so the coverage probe-gate couldn't distinguish "couldn't analyze" from "never probed" — and a failed file would silently vanish from any gate.

## Changes
- Migration **007** `probe_failures` table (mirrored in `_SCHEMA` during the init_schema transition).
- `ProbeStore.record_failure` / `failed_paths` / `get_failure`. Idempotent per path (bumps `attempts`).
- `probe_walker` records both error paths durably.
- A successful `upsert` **clears** the failure, so a recovered file leaves the bucket.

## Tests
record/failed_paths, attempts-on-refail, success-clears-failure. 40 probe/migration tests green; migration 007 applied + table present on dev (boot clean).

Next: PR-A2 tags coverage rows `verified`/`unprobed`/`probe_failed` using this, then the sticky buckets + eager-probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)