### PR TITLE
feat(coverage): tag rows verification_state (verified/unprobed/probe_failed)

### DIFF
--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -96,6 +96,13 @@ class CoverageItem:
     # Scoring
     score: int = 0
     score_reasons: list[str] = field(default_factory=list)
+    # Probe-gate: has subarr actually analyzed this file?
+    #   verified     — a probe matched this row (audio/embedded data resolved)
+    #   probe_failed — the file is in probe_failures (couldn't analyze)
+    #   unprobed     — no probe + no failure yet (not analyzed)
+    # Only `verified` rows are presented as confident, actionable gaps; the
+    # rest are bucketed and held until the probe runs.
+    verification_state: str = "unprobed"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -130,6 +137,7 @@ class CoverageItem:
             "audio_verified": self.audio_verified,
             "score": self.score,
             "score_reasons": self.score_reasons,
+            "verification_state": self.verification_state,
         }
 
 
@@ -571,20 +579,20 @@ def _episode_filename_pattern(episode_number: str | None) -> str | None:
 
 def _attach_probe_episode(item: CoverageItem, idx: dict[str, list],
                           tautulli_hints: dict[str, str] | None = None,
-                          user_verifications: dict[str, str] | None = None) -> None:
+                          user_verifications: dict[str, str] | None = None,
+                          failed_idx: dict[str, list] | None = None) -> None:
     """Look up a probed file under the series prefix whose basename
     contains S01E03 (or equivalent). On match, copy embedded_en +
-    audio_langs + file_canonical_path onto the item."""
+    audio_langs + file_canonical_path onto the item and mark it verified.
+    On no probe match, mark probe_failed if a probe failure matches the
+    same episode, else leave it unprobed (the probe-gate then buckets it)."""
     from .media_probe import audio_lang_summary_with_titles, english_track_summary
     if not item.canonical_path:
-        return
-    candidates = idx.get(item.canonical_path) or []
-    if not candidates:
         return
     pattern = _episode_filename_pattern(item.episode_number)
     if not pattern:
         return
-    for file_canonical, probe in candidates:
+    for file_canonical, probe in (idx.get(item.canonical_path) or []):
         basename = file_canonical.rsplit("/", 1)[-1].lower()
         if pattern in basename:
             item.file_canonical_path = file_canonical
@@ -595,19 +603,30 @@ def _attach_probe_episode(item: CoverageItem, idx: dict[str, list],
                 item.audio_label_notes.extend(notes)
             _classify_audio_label(item, tautulli_hints=tautulli_hints,
                                   user_verifications=user_verifications)
+            item.verification_state = "verified"
             return
+    # No successful probe matched — was this episode a probe FAILURE?
+    for failed_canonical in ((failed_idx or {}).get(item.canonical_path) or []):
+        if pattern in failed_canonical.rsplit("/", 1)[-1].lower():
+            item.verification_state = "probe_failed"
+            return
+    # else: leave default "unprobed"
 
 
 def _attach_probe_movie(item: CoverageItem, idx: dict[str, list],
                         tautulli_hints: dict[str, str] | None = None,
-                        user_verifications: dict[str, str] | None = None) -> None:
+                        user_verifications: dict[str, str] | None = None,
+                        failed_idx: dict[str, list] | None = None) -> None:
     """Movies: a single video file lives directly under the movie dir.
-    First probe under the movie's canonical wins."""
+    First probe under the movie's canonical wins → verified. No probe but a
+    recorded failure → probe_failed. Otherwise unprobed."""
     from .media_probe import audio_lang_summary_with_titles, english_track_summary
     if not item.canonical_path:
         return
     candidates = idx.get(item.canonical_path) or []
     if not candidates:
+        if (failed_idx or {}).get(item.canonical_path):
+            item.verification_state = "probe_failed"
         return
     file_canonical, probe = candidates[0]
     item.file_canonical_path = file_canonical
@@ -618,6 +637,7 @@ def _attach_probe_movie(item: CoverageItem, idx: dict[str, list],
         item.audio_label_notes.extend(notes)
     _classify_audio_label(item, tautulli_hints=tautulli_hints,
                           user_verifications=user_verifications)
+    item.verification_state = "verified"
 
 
 def _classify_audio_label(item: CoverageItem,
@@ -838,6 +858,20 @@ async def build_coverage(
                 prefix = "/".join(parts[:i])
                 probe_by_series_prefix.setdefault(prefix, []).append((path, entry))
 
+    # Probe-FAILURE index (same prefix scheme). Rows whose file is recorded
+    # as a probe failure get tagged probe_failed rather than appearing as an
+    # un-flagged gap that subgen would then skip.
+    probe_failed_by_prefix: dict[str, list[str]] = {}
+    if probe_store is not None:
+        failed = probe_store.failed_paths()
+        if failed and "probe_cache" in sources:
+            sources["probe_cache"]["failures"] = len(failed)
+        for path in failed:
+            parts = path.split("/")
+            for i in range(2, len(parts)):
+                prefix = "/".join(parts[:i])
+                probe_failed_by_prefix.setdefault(prefix, []).append(path)
+
     # v1.1-O Layer 4: load user verifications. These OVERRIDE all
     # auto-detected signals — user has ground truth.
     user_verifications: dict[str, str] = (
@@ -925,7 +959,8 @@ async def build_coverage(
             item.pending_download = True
         _attach_probe_episode(item, probe_by_series_prefix,
                               tautulli_hints=activity.get("audio_lang_hints") or {},
-                              user_verifications=user_verifications)
+                              user_verifications=user_verifications,
+                              failed_idx=probe_failed_by_prefix)
         _score(
             item, tt_signals,
             now_playing_titles=activity["now_playing_titles"],
@@ -965,7 +1000,8 @@ async def build_coverage(
             item.pending_download = True
         _attach_probe_movie(item, probe_by_series_prefix,
                             tautulli_hints=activity.get("audio_lang_hints") or {},
-                            user_verifications=user_verifications)
+                            user_verifications=user_verifications,
+                            failed_idx=probe_failed_by_prefix)
         _score(
             item, tt_signals,
             now_playing_titles=activity["now_playing_titles"],
@@ -1001,6 +1037,7 @@ async def build_coverage(
             activity=activity,
             tt_signals=tt_signals,
             probe_by_series_prefix=probe_by_series_prefix,
+            failed_idx=probe_failed_by_prefix,
             user_verifications=user_verifications,
             sources=sources,
         )
@@ -1026,6 +1063,7 @@ async def _add_bazarr_blind_synthetic_rows(
     activity: dict,
     tt_signals: dict,
     probe_by_series_prefix: dict[str, list[tuple[str, Any]]],
+    failed_idx: dict[str, list] | None = None,
     user_verifications: dict[str, str],
     sources: dict,
 ) -> list[CoverageItem]:
@@ -1174,6 +1212,7 @@ async def _add_bazarr_blind_synthetic_rows(
                 item, probe_by_series_prefix,
                 tautulli_hints=activity.get("audio_lang_hints") or {},
                 user_verifications=user_verifications,
+                failed_idx=failed_idx,
             )
             # Bazarr-blind requires positive evidence the file is not
             # what Bazarr thinks it is. Two ways to get there:

--- a/tests/test_coverage_verification_state.py
+++ b/tests/test_coverage_verification_state.py
@@ -1,0 +1,69 @@
+"""Probe-gate tagging: every coverage row carries verification_state.
+
+  verified     — a probe matched this row (audio/embedded data resolved)
+  probe_failed — the file is recorded in probe_failures (couldn't analyze)
+  unprobed     — no probe and no failure yet (not analyzed)
+
+Only `verified` rows are confident gaps; the others are bucketed and held
+until the probe runs (see the sticky-bucket PR).
+"""
+
+from __future__ import annotations
+
+
+def _ep(epnum, canonical="TV/Show"):
+    from subarr.coverage_engine import CoverageItem
+    return CoverageItem(media_type="episode", title="Show",
+                        canonical_path=canonical, episode_number=epnum)
+
+
+def _probe(path):
+    from subarr.media_probe import ProbeResult
+    return ProbeResult(canonical_path=path)
+
+
+def test_episode_verified_on_probe_match():
+    from subarr.coverage_engine import _attach_probe_episode
+    item = _ep("1x3")
+    f = "TV/Show/Season 1/Show - S01E03 - x.mkv"
+    _attach_probe_episode(item, {"TV/Show": [(f, _probe(f))]}, failed_idx={})
+    assert item.verification_state == "verified"
+    assert item.file_canonical_path == f
+
+
+def test_episode_probe_failed_when_only_failure_matches():
+    from subarr.coverage_engine import _attach_probe_episode
+    item = _ep("1x4")
+    _attach_probe_episode(
+        item, {}, failed_idx={"TV/Show": ["TV/Show/Season 1/Show - S01E04 - y.mkv"]}
+    )
+    assert item.verification_state == "probe_failed"
+
+
+def test_episode_unprobed_when_no_match():
+    from subarr.coverage_engine import _attach_probe_episode
+    item = _ep("1x5")
+    _attach_probe_episode(item, {}, failed_idx={})
+    assert item.verification_state == "unprobed"
+
+
+def test_movie_states():
+    from subarr.coverage_engine import _attach_probe_movie, CoverageItem
+    mv = CoverageItem(media_type="movie", title="M", canonical_path="Movies/M (2024)")
+    f = "Movies/M (2024)/M.mkv"
+    _attach_probe_movie(mv, {"Movies/M (2024)": [(f, _probe(f))]}, failed_idx={})
+    assert mv.verification_state == "verified"
+
+    mf = CoverageItem(media_type="movie", title="M2", canonical_path="Movies/M2")
+    _attach_probe_movie(mf, {}, failed_idx={"Movies/M2": ["Movies/M2/M2.mkv"]})
+    assert mf.verification_state == "probe_failed"
+
+    mu = CoverageItem(media_type="movie", title="M3", canonical_path="Movies/M3")
+    _attach_probe_movie(mu, {}, failed_idx={})
+    assert mu.verification_state == "unprobed"
+
+
+def test_verification_state_in_to_dict():
+    from subarr.coverage_engine import CoverageItem
+    d = CoverageItem(media_type="episode", title="X").to_dict()
+    assert d["verification_state"] == "unprobed"


### PR DESCRIPTION
Probe-gate PR-A2 — the core tagging. The whole verification chain (embedded-sub detection + audio-language funnel) lives *downstream of a probe match*, so an un-probed Bazarr-wanted row bypassed all of it and showed as a clean gap. That's the No Trespassing case you caught: un-probed → blind to its embedded English sub → false gap → subgen skip.

## Changes
- `CoverageItem.verification_state`: `verified` | `unprobed` | `probe_failed`.
- `_attach_probe_episode` / `_attach_probe_movie` set it — `verified` on a probe match; `probe_failed` when only a recorded probe-failure matches (new `probe_failed_by_prefix` index from `ProbeStore.failed_paths()`); `unprobed` otherwise. Threaded through the Bazarr-blind synthetic path too.
- `build_coverage` builds the failure index alongside the probe-cache index.

## Verification (dev, 671 rows)
**610 verified / 61 unprobed / 0 probe_failed.** No Trespassing is now `verified` (embedded `EN(forced)` → partial coverage, not a clean gap). The 61 unprobed are exactly the false-gap class — tagged now, bucketed next.

Tests: per-state tagging (episode + movie) + to_dict; coverage/blind suites green (31).

Next (PR-B): sticky buckets — route `unprobed`→"Analyzing", `probe_failed`→"Couldn't analyze"; un-hideable by filters, un-queueable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)