### PR TITLE
feat(coverage): probe-gate enforcement — gate auto-queue + sticky buckets

### DIFF
--- a/src/subarr/auto_queue.py
+++ b/src/subarr/auto_queue.py
@@ -82,6 +82,13 @@ def evaluate(
         if _is_in_flight(item, in_flight):
             decisions.append(Decision(item, "skip", "already in flight (scan submitted, awaiting subgen completion)"))
             continue
+        # Probe-gate: never auto-queue a row subarr hasn't verified by
+        # probing the file. An un-probed/probe-failed row can't be trusted
+        # as a real gap (it may already have an embedded sub subgen would
+        # skip) — hold it until the probe runs.
+        if getattr(item, "verification_state", "verified") != "verified":
+            decisions.append(Decision(item, "skip", "unverified — not probed yet"))
+            continue
         skip_reason = _filter_reason(item, rules)
         if skip_reason:
             decisions.append(Decision(item, "skip", skip_reason))

--- a/src/subarr/routers/coverage.py
+++ b/src/subarr/routers/coverage.py
@@ -225,6 +225,13 @@ def _apply_filters_and_pack(
         kept = []
         emb_dropped = stale_dropped = eng_audio_dropped = pending_dropped = wanted_lang_dropped = 0
         for it in items:
+            # Probe-gate: unverified rows are STICKY — no hide/lang filter
+            # may drop them. They stay visible (bucketed by the frontend)
+            # until the probe runs, so nothing the user hasn't seen can
+            # silently disappear. Once verified, the normal filters apply.
+            if it.get("verification_state", "verified") != "verified":
+                kept.append(it)
+                continue
             if hide_pending_download and it.get("pending_download"):
                 pending_dropped += 1
                 continue
@@ -265,6 +272,16 @@ def _apply_filters_and_pack(
         body["totals"]["suppressed_by_wanted_langs"] = wanted_lang_dropped
         body["totals"]["episodes"] = sum(1 for i in kept if i["media_type"] == "episode")
         body["totals"]["movies"] = sum(1 for i in kept if i["media_type"] == "movie")
+    # Probe-gate bucket counts (always, over the items actually returned).
+    # The frontend renders verified rows as the gap list and the rest in
+    # sticky "Analyzing" / "Couldn't analyze" sections.
+    vstates = [it.get("verification_state", "verified") for it in body.get("items", [])]
+    body.setdefault("totals", {})
+    body["totals"]["verification"] = {
+        "verified": sum(1 for v in vstates if v == "verified"),
+        "unprobed": sum(1 for v in vstates if v == "unprobed"),
+        "probe_failed": sum(1 for v in vstates if v == "probe_failed"),
+    }
     body.setdefault("cached", True)
     if body.get("cached") and "generated_at" in body:
         body["cache_age_s"] = round(now - body["generated_at"], 1)

--- a/tests/test_coverage_sticky_bucket.py
+++ b/tests/test_coverage_sticky_bucket.py
@@ -1,0 +1,53 @@
+"""Probe-gate enforcement at the coverage router: unverified rows are
+sticky (no hide/lang filter may drop them) and bucket counts are exposed.
+"""
+
+from __future__ import annotations
+
+
+def _body():
+    return {
+        "items": [
+            # verified, embedded EN + stale disk → the filters SHOULD drop it
+            {"media_type": "episode", "verification_state": "verified",
+             "embedded_en": "EN", "has_sub_on_disk": True,
+             "bazarr": {"missing_subtitles": ["nl"]}},
+            # unprobed — must survive every filter
+            {"media_type": "episode", "verification_state": "unprobed",
+             "embedded_en": "EN", "has_sub_on_disk": True,
+             "bazarr": {"missing_subtitles": ["nl"]}},
+            # probe_failed — must survive every filter
+            {"media_type": "episode", "verification_state": "probe_failed",
+             "embedded_en": "EN", "has_sub_on_disk": True,
+             "bazarr": {"missing_subtitles": ["nl"]}},
+        ],
+        "totals": {"items": 3, "episodes": 3, "movies": 0},
+    }
+
+
+def test_unverified_rows_are_sticky_under_filters():
+    from subarr.routers.coverage import _apply_filters_and_pack
+    out = _apply_filters_and_pack(
+        _body(), now=0.0,
+        hide_embedded_en=True, hide_stale_disk=True,
+        hide_english_audio=True, hide_pending_download=True,
+        only_wanted_langs="eng",  # would also drop the nl-missing rows
+    )
+    states = [i["verification_state"] for i in out["items"]]
+    assert "verified" not in states          # verified row dropped by filters
+    assert states.count("unprobed") == 1     # sticky
+    assert states.count("probe_failed") == 1  # sticky
+
+
+def test_verification_bucket_counts_exposed():
+    from subarr.routers.coverage import _apply_filters_and_pack
+    out = _apply_filters_and_pack(
+        _body(), now=0.0,
+        hide_embedded_en=False, hide_stale_disk=False,
+        hide_english_audio=False, hide_pending_download=False,
+        only_wanted_langs="",
+    )
+    # no filters: all three kept; counts reflect them
+    assert out["totals"]["verification"] == {
+        "verified": 1, "unprobed": 1, "probe_failed": 1,
+    }

--- a/tests/test_scheduler_auto_queue.py
+++ b/tests/test_scheduler_auto_queue.py
@@ -63,14 +63,32 @@ def test_due_disabled_never_fires():
 
 
 def _item(score=300, lang="Korean", monitored=True, has_disk=False, tags=None,
-          ep_id=1, canonical="TV/X/S01E01.mkv", title="X"):
+          ep_id=1, canonical="TV/X/S01E01.mkv", title="X",
+          verification_state="verified"):
     from subarr.coverage_engine import CoverageItem
     return CoverageItem(
         media_type="episode", title=title, episode_number="1x1",
         original_language=lang, monitored=monitored, tags=tags or [],
         canonical_path=canonical, has_sub_on_disk=has_disk,
         bazarr_episode_id=ep_id, score=score,
+        verification_state=verification_state,
     )
+
+
+def test_evaluate_skips_unverified_rows():
+    """Probe-gate: auto-queue must never act on a row subarr hasn't probed,
+    regardless of score — that's how un-probed files end up skipped by subgen."""
+    from subarr.auto_queue import evaluate
+    from subarr.schedule_store import AutoQueueRules, MODE_AUTO_RULES
+    items = [
+        _item(score=2000, verification_state="unprobed"),
+        _item(score=2000, ep_id=2, verification_state="probe_failed"),
+    ]
+    rules = AutoQueueRules(mode=MODE_AUTO_RULES, min_score=0,
+                           deny_languages=[], require_monitored=False)
+    decisions = evaluate(items, rules)
+    assert all(d.action == "skip" for d in decisions)
+    assert all("unverified" in d.reason for d in decisions)
 
 
 def test_evaluate_dashboard_mode_skips_everything():


### PR DESCRIPTION
Probe-gate PR-B1 (backend enforcement) — your "can't fall out of the bucket until handled" rule, with teeth.

- **auto_queue.evaluate** skips any row whose `verification_state != verified`, regardless of score. Auto-queue + the scheduler can no longer feed subgen an un-probed file it would just skip.
- **coverage router**: unverified rows are **sticky** — no `hide_*` / `only_wanted_langs` filter may drop them, so nothing the user hasn't seen can silently vanish. They stay until probed.
- Response exposes `totals.verification {verified, unprobed, probe_failed}` for the frontend buckets.

## Tests / verification
auto-queue skips unprobed + probe_failed; unverified rows survive every filter; counts exposed. 15 + coverage suite (31) green. Dev: `totals.verification = 610 verified / 61 unprobed / 0 failed`.

Next (PR-B2): the frontend — render `unprobed`→"Analyzing", `probe_failed`→"Couldn't analyze", keep them out of the actionable gap list + bulk-select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)