### PR TITLE
fix(coverage): .main-canvas overflow-y:auto so the page scrolls

### DIFF
--- a/src/subarr/static/v1/coverage.html
+++ b/src/subarr/static/v1/coverage.html
@@ -43,6 +43,8 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+    min-height: 0;       /* allow shrink below content height so overflow engages */
+    overflow-y: auto;    /* the page scroller — home.html has this; coverage.html was missing it */
   }
 
   .cov-row:hover {


### PR DESCRIPTION
## Bug
After #41 made the gap table grow to its content height (`flexShrink:0`), the Coverage page's content exceeds the viewport — but the page wouldn't scroll, so the larger table + Analyzing bucket were clipped and unreachable. Reported on real hardware (persisted through hard-refresh **and** incognito → not cache).

## Root cause
`coverage.html`'s `.main-canvas` rule was **missing `overflow-y: auto`** (and `min-height: 0`). `home.html` has both. Default `overflow-y: visible` → content overflows, never scrolls, and `.app-body { overflow: hidden }` clips the bottom.

## Fix
Add `overflow-y: auto` + `min-height: 0` to `.main-canvas`. Pure CSS in the HTML — no bundle rebuild.

## Verification
Inspected the live page in a real Chrome (extension): `overflow-y: auto`, `scrollHeight 3532 > clientHeight 780`, and a programmatic `scrollTop = 600` sticks → the container genuinely scrolls. Left chrome stays static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)