### PR TITLE
feat(coverage): eager-probe unprobed wanted files (finish the probe-gate)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -160,6 +160,9 @@ async def lifespan(app_: FastAPI):
             bundle_provider=lambda: app_.state.integrations,
             probe_store=app_.state.probe_store,
             audio_lang_store=app_.state.audio_lang,
+            # PR-C: eager-probe unprobed wanted files each refresh so the
+            # probe-gate's gap list populates regardless of probe_roots.
+            probe_walker=app_.state.probe_walker,
         )
     )
     # Dashboard cache background refresh — passes a build closure that

--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .paths import VIDEO_EXTS
+
 log = logging.getLogger(__name__)
 
 
@@ -42,6 +44,50 @@ CREATE TABLE IF NOT EXISTS coverage_snapshot (
     item_count      INTEGER
 );
 """
+
+
+# Cap the eager-probe fan-out per build. A fresh library can have
+# thousands of unprobed rows; probing all at once would hammer ffprobe.
+# We probe up to this many per build — the rest drain over subsequent
+# builds (each build re-derives the still-unprobed set). 4-wide at the
+# walker means this is a few minutes of ffprobe, comfortably inside the
+# 5-min refresh cadence.
+_EAGER_PROBE_CAP = 400
+
+
+def eager_probe_targets(items: list[dict[str, Any]], cap: int = _EAGER_PROBE_CAP) -> list[str]:
+    """Canonical paths of rows the probe-gate is hiding because they're
+    unprobed — i.e. the 'Analyzing' bucket. These are exactly the files we
+    must probe to turn them into real gaps (or confirm they're covered).
+
+    Excludes:
+    - "probe_failed" rows: those already tried and errored, so re-probing
+      every build would be a tight failing loop. They surface in the
+      "Couldn't analyze" bucket for manual attention instead.
+    - Rows whose canonical_path is NOT a video file — i.e. a show/series
+      folder, which happens when the coverage engine couldn't resolve an
+      episode file at build time. Probing a folder always errors ("not a
+      file") and would manufacture false "couldn't analyze" rows. (The
+      underlying "why is a wanted row pointing at a folder?" is a
+      coverage-engine resolution gap, handled separately — eager-probe
+      just must not act on un-probeable paths.)
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for it in items:
+        if it.get("verification_state") != "unprobed":
+            continue
+        c = it.get("canonical_path")
+        if not c or c in seen:
+            continue
+        # Must point at an actual video file, not a directory.
+        if Path(c).suffix.lower() not in VIDEO_EXTS:
+            continue
+        seen.add(c)
+        out.append(c)
+        if len(out) >= cap:
+            break
+    return out
 
 
 @dataclass
@@ -154,11 +200,20 @@ class CoverageCache:
         return snap
 
     async def refresh(self, bundle, probe_store, audio_lang_store,
-                       use_tautulli: bool = True) -> CachedSnapshot:
+                       use_tautulli: bool = True, probe_walker=None) -> CachedSnapshot:
         """Run build_coverage and store the result. Uses an asyncio.Lock
         so a parallel refresh waits for the in-flight one instead of
         duplicating the expensive build. Notifications dispatched after
-        store so SSE consumers update."""
+        store so SSE consumers update.
+
+        When `probe_walker` is supplied (PR-C), the build's unprobed rows
+        are eager-probed: their files are queued for a targeted ffprobe so
+        they flip to verified on a later build. This is what keeps the gap
+        list from being silently empty when the user's probe_roots don't
+        cover every wanted file. Fire-and-forget — kicking the walker is
+        cheap (it backgrounds the actual probing); the next refresh picks
+        up the results.
+        """
         async with self._refresh_lock:
             self._refreshing = True
             started = time.time()
@@ -179,9 +234,23 @@ class CoverageCache:
                 )
                 log.info("coverage cache refreshed in %.1fs (%d items)",
                          duration, snap.item_count)
+                if probe_walker is not None:
+                    await self._kick_eager_probe(probe_walker, body["items"])
                 return snap
             finally:
                 self._refreshing = False
+
+    async def _kick_eager_probe(self, probe_walker, items: list[dict[str, Any]]) -> None:
+        """Queue a targeted probe of the build's unprobed rows. Never lets a
+        probe-walker hiccup break the refresh — eager-probe is best-effort."""
+        try:
+            targets = eager_probe_targets(items)
+            if not targets:
+                return
+            log.info("eager-probe: queueing %d unprobed wanted files", len(targets))
+            await probe_walker.probe_paths(targets)
+        except Exception as e:
+            log.warning("eager-probe kick failed (non-fatal): %s", e)
 
 
 # Background scheduler — fires refresh on a fixed interval. Started by
@@ -198,12 +267,17 @@ async def background_refresh_loop(
     audio_lang_store=None,
     interval_s: int = DEFAULT_INTERVAL_S,
     bundle_provider=None,
+    probe_walker=None,
 ) -> None:
     """Sleep, refresh, repeat. Exits on cancellation.
 
     The integration bundle is resolved per-refresh via bundle_provider
     (falling back to a directly-passed bundle) so onboarding live-reload
     can swap clients on app.state without restarting this loop.
+
+    `probe_walker` (PR-C) enables eager-probe of unprobed wanted files on
+    every refresh, so the probe-gate's gap list populates regardless of
+    the user's probe_roots config.
     """
     get_bundle = bundle_provider or (lambda: bundle)
     # Initial refresh on boot if nothing cached yet — fills the snapshot
@@ -212,13 +286,15 @@ async def background_refresh_loop(
     if cache.get_cached() is None:
         log.info("coverage cache: no snapshot found; warming on boot")
         try:
-            await cache.refresh(get_bundle(), probe_store, audio_lang_store)
+            await cache.refresh(get_bundle(), probe_store, audio_lang_store,
+                                probe_walker=probe_walker)
         except Exception as e:
             log.warning("coverage cache: initial warm failed: %s", e)
     while True:
         await asyncio.sleep(interval_s)
         try:
-            await cache.refresh(get_bundle(), probe_store, audio_lang_store)
+            await cache.refresh(get_bundle(), probe_store, audio_lang_store,
+                                probe_walker=probe_walker)
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/src/subarr/probe_walker.py
+++ b/src/subarr/probe_walker.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncIterator
 
 from .config import settings
 from .media_probe import ProbeError, parse_ffprobe_json, probe
-from .paths import VIDEO_EXTS, fs_to_canonical
+from .paths import VIDEO_EXTS, PathOutsideRootError, canonical_to_fs, fs_to_canonical
 from .probe_store import ProbeStore
 
 log = logging.getLogger(__name__)
@@ -160,23 +160,7 @@ class ProbeWalker:
                         state.cached_hits += 1
                         state.processed += 1
                         return
-                    try:
-                        result = await probe(p)
-                        result.canonical_path = canonical
-                        self._store.upsert(
-                            canonical_path=canonical,
-                            mtime=st.st_mtime, size=st.st_size,
-                            result=result,
-                        )
-                        state.probed += 1
-                    except ProbeError as e:
-                        state.errors.append({"path": canonical, "error": str(e)})
-                        self._store.record_failure(canonical, str(e))
-                    except Exception as e:
-                        state.errors.append({"path": canonical, "error": repr(e)})
-                        self._store.record_failure(canonical, repr(e))
-                    finally:
-                        state.processed += 1
+                    await self._probe_and_record(state, canonical, p, st)
 
             await asyncio.gather(*(_one(p) for p in video_files))
             state.status = "done"
@@ -191,6 +175,115 @@ class ProbeWalker:
             raise
         except Exception as e:
             log.exception("probe walk %s failed: %s", state.id, e)
+            state.status = "error"
+            state.errors.append({"error": repr(e)})
+            state.finished_at = time.time()
+
+    async def _probe_and_record(self, state: WalkState, canonical: str,
+                                p: Path, st: Any) -> None:
+        """Probe one resolved file and upsert on success / record_failure on
+        error. Caller holds the concurrency sem and has done the cached
+        check. Always bumps state.processed. Shared by the root walk and the
+        targeted eager-probe walk so both treat failures identically."""
+        try:
+            result = await probe(p)
+            result.canonical_path = canonical
+            self._store.upsert(
+                canonical_path=canonical,
+                mtime=st.st_mtime, size=st.st_size,
+                result=result,
+            )
+            state.probed += 1
+        except ProbeError as e:
+            state.errors.append({"path": canonical, "error": str(e)})
+            self._store.record_failure(canonical, str(e))
+        except Exception as e:
+            state.errors.append({"path": canonical, "error": repr(e)})
+            self._store.record_failure(canonical, repr(e))
+        finally:
+            state.processed += 1
+
+    # ------------------------------------------------------------------
+    # Targeted eager-probe (PR-C). Probes a specific list of canonical
+    # paths rather than rglob-ing a root. Drives the probe-gate: after a
+    # coverage build, the unprobed (Analyzing) rows' files are probed here
+    # so they flip to verified on the next build — regardless of whether
+    # the user configured probe_roots that happen to cover them.
+    # ------------------------------------------------------------------
+    _EAGER_LABEL = "__eager__"
+
+    async def probe_paths(self, canonical_paths: list[str]) -> WalkState:
+        """Probe a specific set of canonical paths. Skips files already
+        cached (mtime/size match) and records failures. Deduped: if an
+        eager walk is already running, the existing WalkState is returned
+        instead of starting a parallel one (so back-to-back coverage
+        refreshes don't stack identical probe passes)."""
+        for existing in self._walks.values():
+            if existing.root == self._EAGER_LABEL and existing.status == "running":
+                log.info(
+                    "probe_paths: eager walk %s already running (%d/%d) — reusing",
+                    existing.id, existing.processed, existing.total_files,
+                )
+                return existing
+
+        # Dedupe + drop blanks while preserving order.
+        seen: set[str] = set()
+        paths: list[str] = []
+        for c in canonical_paths:
+            if c and c not in seen:
+                seen.add(c)
+                paths.append(c)
+
+        walk_id = uuid.uuid4().hex[:16]
+        state = WalkState(walk_id, self._EAGER_LABEL)
+        self._walks[walk_id] = state
+        task = asyncio.create_task(
+            self._run_targeted(state, paths), name=f"probe-eager-{walk_id}"
+        )
+        self._tasks[walk_id] = task
+        task.add_done_callback(lambda t, wid=walk_id: self._tasks.pop(wid, None))
+        return state
+
+    async def _run_targeted(self, state: WalkState, canonical_paths: list[str]) -> None:
+        try:
+            state.total_files = len(canonical_paths)
+            log.info("eager probe %s: %d wanted files", state.id, state.total_files)
+            sem = asyncio.Semaphore(WALK_CONCURRENCY)
+
+            async def _one(canonical: str):
+                async with sem:
+                    try:
+                        p = canonical_to_fs(canonical)
+                    except PathOutsideRootError:
+                        state.errors.append({"path": canonical, "error": "outside media root"})
+                        state.processed += 1
+                        return
+                    try:
+                        st = p.stat()
+                    except OSError as e:
+                        state.errors.append({"path": canonical, "error": f"stat: {e}"})
+                        state.processed += 1
+                        return
+                    cached = self._store.get(canonical, mtime=st.st_mtime, size=st.st_size)
+                    if cached is not None:
+                        state.cached_hits += 1
+                        state.processed += 1
+                        return
+                    await self._probe_and_record(state, canonical, p, st)
+
+            await asyncio.gather(*(_one(c) for c in canonical_paths))
+            state.status = "done"
+            state.finished_at = time.time()
+            log.info(
+                "eager probe %s done: %d files, %d cached, %d probed, %d errors",
+                state.id, state.total_files, state.cached_hits, state.probed, len(state.errors),
+            )
+        except asyncio.CancelledError:
+            state.status = "cancelled"
+            state.finished_at = time.time()
+            raise
+        except Exception as e:
+            log.exception("eager probe %s failed: %s", state.id, e)
             state.status = "error"
             state.errors.append({"error": repr(e)})
             state.finished_at = time.time()

--- a/src/subarr/routers/coverage.py
+++ b/src/subarr/routers/coverage.py
@@ -45,9 +45,12 @@ async def refresh_coverage(request: Request) -> dict[str, Any]:
     probe_store = request.app.state.probe_store
     audio_lang_store = getattr(request.app.state, "audio_lang", None)
 
+    probe_walker = getattr(request.app.state, "probe_walker", None)
+
     async def _do():
         try:
-            await cov_cache.refresh(bundle, probe_store, audio_lang_store)
+            await cov_cache.refresh(bundle, probe_store, audio_lang_store,
+                                    probe_walker=probe_walker)
         except Exception as e:
             log.warning("manual coverage refresh failed: %s", e)
 
@@ -174,6 +177,7 @@ async def get_coverage(
     if cov_cache is not None and fresh:
         snap = await cov_cache.refresh(
             bundle, probe_store, audio_lang_store, use_tautulli=tautulli,
+            probe_walker=getattr(request.app.state, "probe_walker", None),
         )
         body = {
             "generated_at": snap.generated_at,

--- a/tests/test_eager_probe.py
+++ b/tests/test_eager_probe.py
@@ -1,0 +1,222 @@
+"""PR-C: eager-probe of unprobed (Bazarr-wanted) files.
+
+The probe-gate hides every row whose file hasn't been probed yet
+(verification_state != "verified"). The scheduled walk only probes the
+user's configured probe_roots — so if a wanted file lives outside those
+roots (or probe_roots is unset), its row stays "unprobed" forever and the
+gap list is silently empty. Eager-probe closes that gap: after each
+coverage build we probe exactly the unprobed rows' files, regardless of
+probe_roots config.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+# ---- target selection -------------------------------------------------
+
+def test_eager_probe_targets_picks_only_unprobed_deduped():
+    from subarr.coverage_cache import eager_probe_targets
+    items = [
+        {"canonical_path": "TV/A/a.mkv", "verification_state": "verified"},
+        {"canonical_path": "TV/B/b.mkv", "verification_state": "unprobed"},
+        {"canonical_path": "TV/B/b.mkv", "verification_state": "unprobed"},  # dup
+        {"canonical_path": "TV/C/c.mkv", "verification_state": "probe_failed"},
+        {"canonical_path": "", "verification_state": "unprobed"},   # no path
+        {"verification_state": "unprobed"},                         # missing key
+    ]
+    # only B is unprobed-with-path; probe_failed is excluded (already tried)
+    assert eager_probe_targets(items) == ["TV/B/b.mkv"]
+
+
+def test_eager_probe_targets_caps():
+    from subarr.coverage_cache import eager_probe_targets
+    items = [
+        {"canonical_path": f"TV/X/{i}.mkv", "verification_state": "unprobed"}
+        for i in range(50)
+    ]
+    assert len(eager_probe_targets(items, cap=10)) == 10
+
+
+def test_eager_probe_targets_skips_non_file_paths():
+    """Rows whose canonical_path is a show/series FOLDER (the coverage
+    engine couldn't resolve an episode file at build time) have nothing to
+    probe. Probing the folder just errors ("not a file") and manufactures
+    false 'couldn't analyze' rows — so they must be excluded."""
+    from subarr.coverage_cache import eager_probe_targets
+    items = [
+        {"canonical_path": "TV/Klovn", "verification_state": "unprobed"},          # folder
+        {"canonical_path": "TV/Klovn/", "verification_state": "unprobed"},         # folder w/ slash
+        {"canonical_path": "TV/Show/S01E01.mkv", "verification_state": "unprobed"},  # real file
+        {"canonical_path": "Movies/Film (2024)", "verification_state": "unprobed"},  # folder
+        {"canonical_path": "Movies/Film (2024)/film.mp4", "verification_state": "unprobed"},  # file
+    ]
+    assert eager_probe_targets(items) == ["TV/Show/S01E01.mkv", "Movies/Film (2024)/film.mp4"]
+
+
+# ---- ProbeWalker.probe_paths -----------------------------------------
+
+@pytest.fixture
+def walker(subarr_env, tmp_path):
+    from subarr.probe_store import ProbeStore
+    from subarr.probe_walker import ProbeWalker
+    store = ProbeStore(tmp_path / "probe.db")
+    store.init_schema()
+    return ProbeWalker(store), store
+
+
+def _make_file(canonical: str, data: bytes = b"data"):
+    from subarr.config import settings
+    p = settings.media_root / canonical
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    return p
+
+
+def _stub_probe(monkeypatch, duration=123.0):
+    from subarr import probe_walker as pw
+    from subarr.media_probe import ProbeResult
+
+    async def fake_probe(path, timeout_s=30.0):
+        pr = ProbeResult(canonical_path="")  # caller fills canonical_path
+        pr.duration_s = duration
+        return pr
+
+    monkeypatch.setattr(pw, "probe", fake_probe)
+
+
+async def _drain(state):
+    while state.status == "running":
+        await asyncio.sleep(0.01)
+    return state
+
+
+def test_probe_paths_probes_listed_files(walker, monkeypatch):
+    wk, store = walker
+    _make_file("TV/A/a.mkv")
+    _make_file("TV/B/b.mkv")
+    _stub_probe(monkeypatch)
+
+    async def go():
+        return await _drain(await wk.probe_paths(["TV/A/a.mkv", "TV/B/b.mkv"]))
+
+    state = asyncio.run(go())
+    assert state.status == "done"
+    assert state.probed == 2
+    assert store.get("TV/A/a.mkv") is not None
+    assert store.get("TV/B/b.mkv") is not None
+
+
+def test_probe_paths_skips_already_cached(walker, monkeypatch):
+    wk, store = walker
+    p = _make_file("TV/A/a.mkv")
+    st = p.stat()
+    from subarr.media_probe import ProbeResult
+    store.upsert(
+        canonical_path="TV/A/a.mkv", mtime=st.st_mtime, size=st.st_size,
+        result=ProbeResult(canonical_path="TV/A/a.mkv"),
+    )
+    _stub_probe(monkeypatch)
+
+    async def go():
+        return await _drain(await wk.probe_paths(["TV/A/a.mkv"]))
+
+    state = asyncio.run(go())
+    assert state.cached_hits == 1
+    assert state.probed == 0
+
+
+def test_probe_paths_records_missing_file_as_error(walker, monkeypatch):
+    wk, store = walker
+    _stub_probe(monkeypatch)
+
+    async def go():
+        return await _drain(await wk.probe_paths(["TV/Ghost/missing.mkv"]))
+
+    state = asyncio.run(go())
+    assert state.status == "done"
+    assert state.processed == 1
+    assert state.probed == 0
+    assert len(state.errors) == 1
+
+
+def test_probe_paths_dedupes_concurrent_walk(walker, monkeypatch):
+    wk, store = walker
+    _make_file("TV/A/a.mkv")
+
+    from subarr import probe_walker as pw
+    from subarr.media_probe import ProbeResult
+
+    async def slow_probe(path, timeout_s=30.0):
+        await asyncio.sleep(0.05)
+        return ProbeResult(canonical_path="")
+
+    monkeypatch.setattr(pw, "probe", slow_probe)
+
+    async def go():
+        s1 = await wk.probe_paths(["TV/A/a.mkv"])
+        s2 = await wk.probe_paths(["TV/A/a.mkv"])  # should reuse s1, not start a 2nd
+        same = s1.id == s2.id
+        await _drain(s1)
+        return same
+
+    assert asyncio.run(go()) is True
+
+
+# ---- CoverageCache.refresh eager-probe trigger -----------------------
+
+class _FakeReport:
+    def __init__(self, items):
+        self._items = items
+
+    def to_dict(self):
+        return {"items": self._items, "totals": {"items": len(self._items)}, "sources": {}}
+
+
+def _patch_build(monkeypatch, items):
+    from subarr import coverage_engine
+
+    async def fake_build(*a, **k):
+        return _FakeReport(items)
+
+    monkeypatch.setattr(coverage_engine, "build_coverage", fake_build)
+
+
+def test_refresh_fires_eager_probe_for_unprobed(subarr_env, tmp_path, monkeypatch):
+    from subarr.coverage_cache import CoverageCache
+    _patch_build(monkeypatch, [
+        {"canonical_path": "TV/A/a.mkv", "verification_state": "unprobed", "media_type": "episode"},
+        {"canonical_path": "TV/B/b.mkv", "verification_state": "verified", "media_type": "episode"},
+    ])
+
+    calls = []
+
+    class FakeWalker:
+        async def probe_paths(self, paths, **k):
+            calls.append(list(paths))
+            class _S:
+                id = "x"
+                status = "done"
+            return _S()
+
+    cache = CoverageCache(tmp_path / "cov.db")
+    cache.init_schema()
+    asyncio.run(cache.refresh(
+        bundle=None, probe_store=None, audio_lang_store=None,
+        probe_walker=FakeWalker(),
+    ))
+    assert calls == [["TV/A/a.mkv"]]
+
+
+def test_refresh_no_walker_does_not_crash(subarr_env, tmp_path, monkeypatch):
+    from subarr.coverage_cache import CoverageCache
+    _patch_build(monkeypatch, [
+        {"canonical_path": "TV/A/a.mkv", "verification_state": "unprobed", "media_type": "episode"},
+    ])
+    cache = CoverageCache(tmp_path / "cov.db")
+    cache.init_schema()
+    # No probe_walker passed — back-compat path, must just store + return.
+    snap = asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
+    assert snap.item_count == 1

--- a/tests/test_library_probe.py
+++ b/tests/test_library_probe.py
@@ -197,15 +197,17 @@ def test_auto_queue_skip_embedded_en(subarr_env):
     from subarr.coverage_engine import CoverageItem
     from subarr.schedule_store import AutoQueueRules, MODE_AUTO_RULES
 
+    # verification_state="verified" — these rows passed the probe-gate, so
+    # evaluate() reaches the embedded-EN skip logic this test exercises.
     items = [
         CoverageItem(media_type="episode", title="A", episode_number="1x1",
                      original_language="Korean", monitored=True,
                      canonical_path="TV/A", embedded_en="EN", score=500,
-                     bazarr_episode_id=1),
+                     bazarr_episode_id=1, verification_state="verified"),
         CoverageItem(media_type="episode", title="B", episode_number="1x1",
                      original_language="Korean", monitored=True,
                      canonical_path="TV/B", embedded_en=None, score=500,
-                     bazarr_episode_id=2),
+                     bazarr_episode_id=2, verification_state="verified"),
     ]
     rules = AutoQueueRules(mode=MODE_AUTO_RULES, min_score=0,
                            deny_languages=[], require_monitored=True,
@@ -226,7 +228,7 @@ def test_auto_queue_skip_embedded_en_off(subarr_env):
         CoverageItem(media_type="episode", title="A", episode_number="1x1",
                      original_language="Korean", monitored=True,
                      canonical_path="TV/A", embedded_en="EN", score=500,
-                     bazarr_episode_id=1),
+                     bazarr_episode_id=1, verification_state="verified"),
     ]
     rules = AutoQueueRules(mode=MODE_AUTO_RULES, min_score=0,
                            deny_languages=[], require_monitored=True,

--- a/tests/test_manual_confirm.py
+++ b/tests/test_manual_confirm.py
@@ -58,9 +58,21 @@ def manconf_setup(app_with_stub):
     """Set mode=manual_confirm + a rule that lets ManConf through, plant
     the resolved file so _enqueue's exists() check passes."""
     from subarr.config import settings
+    from subarr.media_probe import ProbeResult
     folder = settings.media_root / "TV" / "ManConf" / "Season 1"
     folder.mkdir(parents=True, exist_ok=True)
-    (folder / "manconf.S01E01.mkv").write_bytes(b"x")
+    f = folder / "manconf.S01E01.mkv"
+    f.write_bytes(b"x")
+    # Probe-gate (#39): only verified rows are actionable. Seed a probe
+    # result for the wanted file so build_coverage marks it verified and
+    # evaluate() considers it — mirrors production, where a wanted file is
+    # eager-probed before it can become a queue decision.
+    canonical = "TV/ManConf/Season 1/manconf.S01E01.mkv"
+    st = f.stat()
+    app_with_stub.app.state.probe_store.upsert(
+        canonical_path=canonical, mtime=st.st_mtime, size=st.st_size,
+        result=ProbeResult(canonical_path=canonical),
+    )
     app_with_stub.put("/api/schedule/rules", json={
         "mode": "manual_confirm",
         "min_score": 0,


### PR DESCRIPTION
## Why
The probe-gate (#38/#39) hides every coverage row whose file hasn't been probed (`verification_state != "verified"`). The scheduled walk only probes the user's configured `probe_roots` — so **any wanted file outside those roots (or with `probe_roots` unset) stays `unprobed` forever and the gap list is silently empty**, which reads as "broken". This finishes the gate by probing the wanted files directly, regardless of `probe_roots`.

## What
- **`ProbeWalker.probe_paths()`** — targeted probe of a specific canonical-path list (not a root rglob). Skips cached files, records failures, dedupes a concurrent eager walk. Extracted a shared `_probe_and_record` helper so the root walk and eager walk handle failures identically.
- **`coverage_cache.eager_probe_targets()`** — selects the unprobed rows to probe. Excludes `probe_failed` (no tight re-probe loop) **and rows whose `canonical_path` is not a video file** — a show/series *folder* (coverage engine couldn't resolve an episode file at build time) can't be probed and would manufacture false "couldn't analyze" rows.
- **`CoverageCache.refresh(probe_walker=…)`** — fire-and-forget eager-probe of the build's unprobed rows. Wired into the background refresh loop (main driver) and the manual-refresh / `?fresh` paths (snappy drain on click).

## Verified live (real library, 9923)
Eager-probe fires on refresh, targets only genuine file rows, records **zero** false failures. The file-only guard was added *after* live testing surfaced 61 wanted rows resolving to show folders (a separate coverage-engine resolution gap, flagged for follow-up — not patched here).

## Also: repairs a red suite
6 tests were left failing on `main` by the #39 gate (items seeded as `unprobed`, which the gate now skips before the logic under test): `test_auto_queue_skip_embedded_en{,_off}` + 4 `manual_confirm` tests. Fixed to match production (a wanted file is probed before it's actionable).

**316 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)