### PR TITLE
feat(migrate): migration 008 — full parity with init_schema (step 1 of removal)

### DIFF
--- a/src/subarr/migrate.py
+++ b/src/subarr/migrate.py
@@ -181,7 +181,26 @@ class MigrationRunner:
         conn.execute("BEGIN IMMEDIATE")
         try:
             for stmt in statements:
-                conn.execute(stmt)
+                try:
+                    conn.execute(stmt)
+                except sqlite3.OperationalError as e:
+                    # ADD COLUMN is not idempotent and SQLite has no
+                    # "ADD COLUMN IF NOT EXISTS". On a TRANSITIONAL DB — one
+                    # a prior init_schema() already extended — a parity
+                    # migration's ADD COLUMN raises "duplicate column name".
+                    # Treat ONLY that as a no-op for this statement so the
+                    # migration still completes + records. A duplicate-column
+                    # error does not abort the SQLite transaction, so the
+                    # remaining statements + the version INSERT still commit.
+                    # Any OTHER OperationalError re-raises → rollback + abort
+                    # (the atomic contract is preserved).
+                    if "duplicate column name" in str(e).lower():
+                        log.info(
+                            "migration %s: column already present, skipping: %s",
+                            m.name, stmt.split("\n", 1)[0][:80],
+                        )
+                        continue
+                    raise
             conn.execute(
                 "INSERT INTO schema_versions (version, name, applied_at) "
                 "VALUES (?, ?, ?)",

--- a/src/subarr/migrations/008_init_schema_parity.sql
+++ b/src/subarr/migrations/008_init_schema_parity.sql
@@ -1,0 +1,64 @@
+-- 008_init_schema_parity.sql
+--
+-- Bring the migration set to FULL parity with the per-store init_schema()
+-- methods, so migrations become the single source of truth for the schema
+-- and init_schema() can be removed (see follow-up PR).
+--
+-- Everything here is idempotent on a transitional DB (one a prior
+-- init_schema already built):
+--   - CREATE TABLE / INDEX IF NOT EXISTS  → no-op if present.
+--   - ALTER TABLE ADD COLUMN              → raises "duplicate column name"
+--                                           when present; the migration
+--                                           runner tolerates exactly that
+--                                           error per-statement (see
+--                                           migrate.py _apply_one).
+--   - INSERT OR IGNORE                    → no-op if the row exists.
+
+-- ─── audio_lang_store: per-file verifications + series-level intent ──
+CREATE TABLE IF NOT EXISTS audio_lang_verifications (
+    canonical_path  TEXT PRIMARY KEY,
+    lang_code       TEXT NOT NULL,
+    source          TEXT NOT NULL DEFAULT 'user',
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    verified_at     REAL NOT NULL,
+    verified_by     TEXT,
+    evidence        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_audio_lang_verifications_lang
+    ON audio_lang_verifications(lang_code);
+
+CREATE TABLE IF NOT EXISTS series_lang_intent (
+    series_prefix   TEXT PRIMARY KEY,
+    lang_code       TEXT NOT NULL,
+    source          TEXT NOT NULL DEFAULT 'user',
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    declared_at     REAL NOT NULL,
+    declared_by     TEXT,
+    note            TEXT
+);
+
+-- ─── coverage_cache: single-row coverage snapshot ───────────────────
+CREATE TABLE IF NOT EXISTS coverage_snapshot (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    generated_at    REAL NOT NULL,
+    items_json      TEXT NOT NULL,
+    totals_json     TEXT NOT NULL,
+    sources_json    TEXT NOT NULL,
+    build_duration_s REAL,
+    item_count      INTEGER
+);
+
+-- ─── enrichment #156: structured-output columns ─────────────────────
+-- Nullable so legacy free-text rows stay valid until eviction.
+ALTER TABLE lang_enrichment ADD COLUMN confidence REAL;
+ALTER TABLE lang_enrichment ADD COLUMN reasoning TEXT;
+
+-- ─── probe_store: probe source column (v1.1-A) ──────────────────────
+ALTER TABLE media_probe ADD COLUMN source TEXT NOT NULL DEFAULT 'ffprobe';
+
+-- ─── seed: default coverage_walk schedule (disabled, user opts in) ──
+-- auto_queue_rules needs no seed — ScheduleStore.get_rules() returns a
+-- default AutoQueueRules() when the row is absent.
+INSERT OR IGNORE INTO schedule_config
+    (name, enabled, kind, interval_minutes, daily_hhmm, day_of_week, probe_roots)
+    VALUES ('coverage_walk', 0, 'daily', 360, '03:00', 0, '');

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -162,6 +162,101 @@ def test_run_migrations_helper_uses_bundled_dir(db_path: Path):
     assert expected.issubset(tables), f"missing: {expected - tables}"
 
 
+def test_bundled_migrations_full_parity(db_path: Path):
+    """Migrations alone must build the COMPLETE schema — every table,
+    gap column, and seed row the per-store init_schema() methods create.
+    This is the precondition for removing init_schema: migrations become
+    the single source of truth, so a fresh DB built by migrations only
+    must be fully functional."""
+    run_migrations(db_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        expected = {
+            # 001 baseline
+            "scans", "subs_generated", "schedule_config", "auto_queue_rules",
+            "lang_enrichment", "media_probe", "pending_walks", "pending_decisions",
+            # 002-007
+            "update_checks", "telemetry_state", "onboarding_state",
+            "error_events", "probe_failures",
+            # 008 parity (previously created ONLY by init_schema)
+            "audio_lang_verifications", "series_lang_intent", "coverage_snapshot",
+            "schema_versions",
+        }
+        assert expected.issubset(tables), f"missing tables: {expected - tables}"
+
+        # Gap columns (added only by init_schema before 008).
+        enr_cols = {r[1] for r in conn.execute("PRAGMA table_info(lang_enrichment)")}
+        assert {"confidence", "reasoning"}.issubset(enr_cols), f"lang_enrichment cols: {enr_cols}"
+        probe_cols = {r[1] for r in conn.execute("PRAGMA table_info(media_probe)")}
+        assert "source" in probe_cols, f"media_probe cols: {probe_cols}"
+
+        # Seed: the default coverage_walk schedule row (disabled, opt-in).
+        n = conn.execute(
+            "SELECT COUNT(*) FROM schedule_config WHERE name='coverage_walk'"
+        ).fetchone()[0]
+        assert n == 1
+    finally:
+        conn.close()
+
+
+def test_runner_tolerates_duplicate_column(db_path: Path, tmp_migrations: Path):
+    """ADD COLUMN is not idempotent in SQLite and there's no IF NOT EXISTS.
+    On a transitional DB (one a prior init_schema already extended), a
+    parity migration's ADD COLUMN hits 'duplicate column name'. The runner
+    must treat that as a no-op for that statement, still record the
+    migration as applied, and NOT abort boot."""
+    write_migration(tmp_migrations, 1, "base",
+                    "CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT);")
+    write_migration(tmp_migrations, 2, "addcol",
+                    "ALTER TABLE t ADD COLUMN a TEXT;")  # 'a' already exists
+    runner = MigrationRunner(db_path, tmp_migrations)
+    applied = runner.run()  # must NOT raise
+    assert [m.version for m in applied] == [1, 2]
+    # recorded as applied so it doesn't retry forever
+    assert runner.applied_versions() == [1, 2]
+
+
+def test_runner_still_aborts_on_real_error(db_path: Path, tmp_migrations: Path):
+    """Tolerating duplicate-column must NOT swallow genuine SQL errors —
+    those still roll back + abort, preserving the atomic contract."""
+    write_migration(tmp_migrations, 1, "good", "CREATE TABLE g (id INTEGER PRIMARY KEY);")
+    write_migration(tmp_migrations, 2, "bad", "ALTER TABLE does_not_exist ADD COLUMN x TEXT;")
+    runner = MigrationRunner(db_path, tmp_migrations)
+    with pytest.raises(sqlite3.OperationalError):
+        runner.run()
+    assert runner.applied_versions() == [1]  # version 2 NOT recorded
+
+
+def test_bundled_migrations_idempotent_on_init_schema_db(subarr_env, tmp_path: Path):
+    """Truest transitional test: build a DB exactly as the legacy
+    init_schema path does (all stores), then run the bundled migrations.
+    Migration 008's ADD COLUMNs hit columns init_schema already created —
+    the runner must tolerate them and finish clean."""
+    from subarr.audio_lang_store import AudioLangStore
+    from subarr.coverage_cache import CoverageCache
+    from subarr.enrichment import EnrichmentStore
+    from subarr.pending_store import PendingStore
+    from subarr.probe_store import ProbeStore
+    from subarr.provenance import ProvenanceStore
+    from subarr.scan_store import ScanStore
+    from subarr.schedule_store import ScheduleStore
+
+    db = tmp_path / "transitional.db"
+    for store in (
+        ScanStore(db), ProvenanceStore(db), ScheduleStore(db), AudioLangStore(db),
+        CoverageCache(db), EnrichmentStore(db), ProbeStore(db), PendingStore(db),
+    ):
+        store.init_schema()
+
+    # Now run the real bundled migrations on this init_schema-built DB.
+    applied = run_migrations(db)  # must NOT raise on duplicate columns/tables
+    # 008 must be among those applied (older ones were never recorded here).
+    assert 8 in [m.version for m in applied]
+
+
 def test_existing_v0x_db_upgrades_cleanly(db_path: Path):
     """A user upgrading from v0.x already has the tables. The baseline
     migration uses IF NOT EXISTS so it's a no-op against their data, but


### PR DESCRIPTION
## Why
Migrations 001–007 were **incomplete**. Three tables (`audio_lang_verifications`, `series_lang_intent`, `coverage_snapshot`) and three columns (`lang_enrichment.confidence/reasoning`, `media_probe.source`) plus the default `coverage_walk` schedule row were created **only** by per-store `init_schema()`. A fresh DB built from migrations alone was missing them. Step 1 toward removing `init_schema`: make migrations the single source of truth.

## What
- **`migrations/008_init_schema_parity.sql`** — gap tables (`CREATE … IF NOT EXISTS`), gap columns (`ALTER … ADD COLUMN`), and the `coverage_walk` seed (`INSERT OR IGNORE`). `auto_queue_rules` needs no seed — `get_rules()` returns a default `AutoQueueRules()` when the row is absent.
- **`migrate.py`** — per-statement **duplicate-column tolerance**. `ADD COLUMN` isn't idempotent and SQLite has no `IF NOT EXISTS`; on a *transitional* DB (one a prior `init_schema` already extended) 008's ALTERs raise `duplicate column name`. The runner now treats **only** that error as a per-statement no-op, still records the migration, and commits. Every other error still rolls back + aborts — the atomic contract is preserved (test included).

## Verified three ways
1. **11 migration tests** — fresh parity, dup-column tolerance, real-error still aborts, and a DB built by the legacy `init_schema` path migrates clean.
2. **A copy of the live dev DB** — only 008 applied; all rows preserved (4538 probes / 313 audio verifications / 126 scans); idempotent on re-run.
3. **Live container boot** — 008 applied, ALTERs logged `column already present, skipping`, zero tracebacks.

**320 passing.** Follow-up PR physically removes `init_schema` from the 8 stores + app.py now that migrations are proven complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)