### PR TITLE
refactor(schema): remove init_schema — migrations are the single source of truth

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -85,8 +85,9 @@ async def lifespan(app_: FastAPI):
     app_.state.subgen_restart_detected_at = None
     app_.state.subgen_restart_from = None
     app_.state.subgen_restart_to = None
+    # All schema is owned by migrations (run_migrations above, before any
+    # store is constructed). Stores no longer self-create tables.
     app_.state.scans = ScanStore(settings.db_path)
-    app_.state.scans.init_schema()
     # Anonymous error-class log for telemetry (schema via migration 006).
     app_.state.errors = ErrorStore(settings.db_path)
     app_.state.runner = ScanRunner(
@@ -101,7 +102,6 @@ async def lifespan(app_: FastAPI):
     app_.state.docker = DockerOps()
     app_.state.integrations = IntegrationBundle()
     app_.state.provenance = ProvenanceStore(settings.db_path)
-    app_.state.provenance.init_schema()
     app_.state.watcher = CompletionWatcher(
         provenance=app_.state.provenance,
         caps_provider=lambda: getattr(app_.state, "subgen_caps", None),
@@ -115,26 +115,21 @@ async def lifespan(app_: FastAPI):
     )
     app_.state.watcher.start()
     app_.state.schedule = ScheduleStore(settings.db_path)
-    app_.state.schedule.init_schema()
     app_.state.ollama = OllamaClient()
     # v1.1-O Layer 4: user audio-language verifications (manual review queue).
     from .audio_lang_store import AudioLangStore
     app_.state.audio_lang = AudioLangStore(settings.db_path)
-    app_.state.audio_lang.init_schema()
     # v1.1 ARCH: coverage cache + background refresh (kills 60-90s page loads).
     from .coverage_cache import CoverageCache, background_refresh_loop
     app_.state.coverage_cache = CoverageCache(settings.db_path)
-    app_.state.coverage_cache.init_schema()
+    app_.state.coverage_cache.load()  # warm in-memory mirror; table via migrations
     # v1.1 ARCH: dashboard cache (30s refresh, in-memory only).
     from .dashboard_cache import DashboardCache, background_refresh_loop as dash_refresh_loop
     app_.state.dashboard_cache = DashboardCache()
     app_.state.enrichment = EnrichmentStore(settings.db_path)
-    app_.state.enrichment.init_schema()
     app_.state.probe_store = ProbeStore(settings.db_path)
-    app_.state.probe_store.init_schema()
     app_.state.probe_walker = ProbeWalker(app_.state.probe_store)
     app_.state.pending = PendingStore(settings.db_path)
-    app_.state.pending.init_schema()
     app_.state.onboarding = OnboardingStore(settings.db_path)
     app_.state.scheduler = Scheduler(
         schedule_store=app_.state.schedule,

--- a/src/subarr/audio_lang_store.py
+++ b/src/subarr/audio_lang_store.py
@@ -33,35 +33,14 @@ from pathlib import Path
 from typing import Any
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS audio_lang_verifications (
-    canonical_path  TEXT PRIMARY KEY,
-    lang_code       TEXT NOT NULL,
-    source          TEXT NOT NULL DEFAULT 'user',
-    confidence      REAL NOT NULL DEFAULT 1.0,
-    verified_at     REAL NOT NULL,
-    verified_by     TEXT,
-    evidence        TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_audio_lang_verifications_lang
-    ON audio_lang_verifications(lang_code);
-
--- #226: series-level intent. When the user says "every Cheers episode
--- is English", we record that fact ONCE here rather than spamming the
--- per-file table with a row for every episode. Future episodes added
--- to the library inherit the intent automatically on first lookup.
--- canonical_path series_prefix MUST end with '/' to disambiguate
--- "TV/Cheers/" from "TV/Cheers Reboot/".
-CREATE TABLE IF NOT EXISTS series_lang_intent (
-    series_prefix   TEXT PRIMARY KEY,
-    lang_code       TEXT NOT NULL,
-    source          TEXT NOT NULL DEFAULT 'user',
-    confidence      REAL NOT NULL DEFAULT 1.0,
-    declared_at     REAL NOT NULL,
-    declared_by     TEXT,
-    note            TEXT
-);
-"""
+# Schema (audio_lang_verifications + idx, series_lang_intent) is owned by
+# migrations/008_init_schema_parity.sql. run_migrations() runs at boot
+# before this store — no per-store init_schema().
+#
+# #226 note: series_lang_intent records series-level intent ONCE ("every
+# Cheers episode is English") instead of spamming the per-file table.
+# series_prefix MUST end with '/' to disambiguate "TV/Cheers/" from
+# "TV/Cheers Reboot/".
 
 
 @dataclass
@@ -94,10 +73,6 @@ class AudioLangStore:
         )
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
 
     def upsert(self, *, canonical_path: str, lang_code: str,
                source: str = "user", confidence: float = 1.0,

--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -33,17 +33,11 @@ from .paths import VIDEO_EXTS
 log = logging.getLogger(__name__)
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS coverage_snapshot (
-    id              INTEGER PRIMARY KEY CHECK (id = 1),
-    generated_at    REAL NOT NULL,
-    items_json      TEXT NOT NULL,
-    totals_json     TEXT NOT NULL,
-    sources_json    TEXT NOT NULL,
-    build_duration_s REAL,
-    item_count      INTEGER
-);
-"""
+# Schema (coverage_snapshot, single-row) is owned by
+# migrations/008_init_schema_parity.sql. run_migrations() runs at boot
+# before this cache is constructed, so the table always exists. This cache
+# keeps a load() method (not init_schema) purely to warm its in-memory
+# mirror from the persisted snapshot on boot.
 
 
 # Cap the eager-probe fan-out per build. A fresh library can have
@@ -133,11 +127,10 @@ class CoverageCache:
         self._refresh_lock = asyncio.Lock()
         self._refreshing = False
 
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
-        # Warm the in-memory mirror from disk so the first request after
-        # boot returns immediately (no cold start).
+    def load(self) -> None:
+        """Warm the in-memory mirror from the persisted snapshot so the
+        first request after boot returns immediately (no cold start). The
+        coverage_snapshot table itself is created by migrations."""
         self._load_from_db()
 
     def _load_from_db(self) -> None:

--- a/src/subarr/enrichment.py
+++ b/src/subarr/enrichment.py
@@ -68,30 +68,12 @@ _LANG_SCHEMA = {
 _ISO_RE = re.compile(r"^[a-z]{2,3}$")
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS lang_enrichment (
-    canonical_path  TEXT PRIMARY KEY,
-    title           TEXT NOT NULL,
-    raw_response    TEXT,
-    iso_code        TEXT,
-    model           TEXT,
-    inferred_at     REAL NOT NULL,
-    error           TEXT,
-    -- #156: structured-output additions. confidence is 0.0-1.0; reasoning
-    -- is the one-sentence model explanation. Both nullable so legacy rows
-    -- from the free-text era stay valid until they cycle through eviction.
-    confidence      REAL,
-    reasoning       TEXT
-);
--- #156: add columns if upgrading from the v1.1 free-text schema.
--- ALTER TABLE … IF NOT EXISTS doesn't exist in SQLite; we tolerate the
--- "duplicate column" error at runtime via init_schema's try/except.
-"""
-
-_SCHEMA_MIGRATIONS = [
-    "ALTER TABLE lang_enrichment ADD COLUMN confidence REAL",
-    "ALTER TABLE lang_enrichment ADD COLUMN reasoning TEXT",
-]
+# Schema (lang_enrichment incl. the #156 confidence/reasoning columns) is
+# owned by migrations/001_baseline.sql + 008_init_schema_parity.sql.
+# run_migrations() runs at boot before this store — no per-store
+# init_schema(). confidence is 0.0-1.0; reasoning is the model's
+# one-sentence explanation. Both nullable so legacy free-text rows stay
+# valid until they cycle through eviction.
 
 
 @dataclass
@@ -127,19 +109,6 @@ class EnrichmentStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
-            # #156: idempotent column additions for installs that came in
-            # before structured JSON. SQLite has no IF NOT EXISTS for
-            # ALTER ADD COLUMN; the per-statement try/except is the
-            # idiomatic pattern.
-            for stmt in _SCHEMA_MIGRATIONS:
-                try:
-                    self._conn.execute(stmt)
-                except sqlite3.OperationalError:
-                    pass  # already exists
 
     def close(self) -> None:
         with self._lock:

--- a/src/subarr/pending_store.py
+++ b/src/subarr/pending_store.py
@@ -77,26 +77,9 @@ class PendingWalk:
         }
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS pending_walks (
-    id                TEXT PRIMARY KEY,
-    created_at        REAL NOT NULL,
-    status            TEXT NOT NULL,
-    considered        INTEGER NOT NULL DEFAULT 0,
-    decisions_total   INTEGER NOT NULL DEFAULT 0,
-    approved_count    INTEGER NOT NULL DEFAULT 0
-);
-CREATE TABLE IF NOT EXISTS pending_decisions (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    walk_id      TEXT NOT NULL,
-    item_json    TEXT NOT NULL,
-    approved     INTEGER,
-    scan_id      TEXT,
-    FOREIGN KEY (walk_id) REFERENCES pending_walks(id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_pending_decisions_walk ON pending_decisions (walk_id);
-CREATE INDEX IF NOT EXISTS idx_pending_walks_status ON pending_walks (status);
-"""
+# Schema (pending_walks + pending_decisions + indexes) is owned by
+# migrations/001_baseline.sql. run_migrations() runs at boot before this
+# store — no per-store init_schema().
 
 
 class PendingStore:
@@ -106,10 +89,6 @@ class PendingStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
 
     def close(self) -> None:
         with self._lock:

--- a/src/subarr/probe_store.py
+++ b/src/subarr/probe_store.py
@@ -21,35 +21,11 @@ from pathlib import Path
 from .media_probe import AudioStream, ProbeResult, SubtitleStream
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS media_probe (
-    canonical_path  TEXT PRIMARY KEY,
-    mtime           REAL NOT NULL,
-    size            INTEGER NOT NULL,
-    duration_s      REAL,
-    audio_json      TEXT NOT NULL,
-    sub_json        TEXT NOT NULL,
-    probed_at       REAL NOT NULL,
-    source          TEXT NOT NULL DEFAULT 'ffprobe'
-);
--- Probe failures (also created by migration 007). Lets the coverage
--- probe-gate distinguish "couldn't analyze" from "not yet probed".
-CREATE TABLE IF NOT EXISTS probe_failures (
-    canonical_path  TEXT PRIMARY KEY,
-    error           TEXT NOT NULL,
-    failed_at       REAL NOT NULL,
-    attempts        INTEGER NOT NULL DEFAULT 1
-);
-"""
-
-# v1.1-A migration: add `source` column to track whether the row came from
-# our own ffprobe or from Sonarr/Radarr's pre-computed mediaInfo. Cheap to
-# add with DEFAULT; older rows get 'ffprobe' which is what they actually
-# were. New 'arr_mediainfo' rows are upgradable to 'ffprobe' on next walk
-# (richer data wins).
-_MIGRATE_SOURCE_COL = """
-ALTER TABLE media_probe ADD COLUMN source TEXT NOT NULL DEFAULT 'ffprobe'
-"""
+# Schema (media_probe incl. the v1.1-A `source` column, and probe_failures)
+# is owned by migrations/001_baseline.sql + 007_probe_failures.sql +
+# 008_init_schema_parity.sql. run_migrations() runs at boot before this
+# store — no per-store init_schema(). `source` distinguishes our own
+# ffprobe rows from Sonarr/Radarr pre-computed mediaInfo ('arr_mediainfo').
 
 
 class ProbeStore:
@@ -58,16 +34,6 @@ class ProbeStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
-            # Best-effort migration for pre-v1.1-A DBs. ALTER fails harmlessly
-            # if the column already exists (SQLite raises OperationalError).
-            try:
-                self._conn.execute(_MIGRATE_SOURCE_COL)
-            except sqlite3.OperationalError:
-                pass
 
     def close(self) -> None:
         with self._lock:

--- a/src/subarr/provenance.py
+++ b/src/subarr/provenance.py
@@ -67,23 +67,8 @@ class LedgerEntry:
         }
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS subs_generated (
-    id                           INTEGER PRIMARY KEY AUTOINCREMENT,
-    canonical_path               TEXT NOT NULL,
-    series_id                    INTEGER,
-    sonarr_episode_id            INTEGER,
-    radarr_movie_id              INTEGER,
-    scan_id                      TEXT,
-    source                       TEXT NOT NULL,
-    subgen_version               TEXT,
-    queued_at                    REAL NOT NULL,
-    completed_at                 REAL,
-    bazarr_scan_triggered_at     REAL
-);
-CREATE INDEX IF NOT EXISTS idx_subs_generated_path ON subs_generated (canonical_path);
-CREATE INDEX IF NOT EXISTS idx_subs_generated_pending ON subs_generated (completed_at) WHERE completed_at IS NULL;
-"""
+# Schema (subs_generated + indexes) is owned by migrations/001_baseline.sql.
+# run_migrations() runs at boot before this store — no per-store init_schema().
 
 
 class ProvenanceStore:
@@ -97,10 +82,6 @@ class ProvenanceStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
 
     def close(self) -> None:
         with self._lock:

--- a/src/subarr/scan_store.py
+++ b/src/subarr/scan_store.py
@@ -88,18 +88,9 @@ class Scan:
         }
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS scans (
-    id            TEXT PRIMARY KEY,
-    created_at    REAL NOT NULL,
-    status        TEXT NOT NULL,
-    reverse       INTEGER NOT NULL DEFAULT 0,
-    current_index INTEGER NOT NULL DEFAULT 0,
-    paths_json    TEXT NOT NULL,
-    results_json  TEXT NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_scans_created_at ON scans (created_at DESC);
-"""
+# Schema (scans table + index) is owned by migrations/001_baseline.sql.
+# run_migrations() runs at boot before this store is constructed, so the
+# table always exists — no per-store init_schema().
 
 
 class ScanStore:
@@ -112,10 +103,6 @@ class ScanStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
 
     def close(self) -> None:
         with self._lock:

--- a/src/subarr/schedule_store.py
+++ b/src/subarr/schedule_store.py
@@ -102,43 +102,12 @@ class AutoQueueRules:
         return cls(**{k: v for k, v in d.items() if k in valid})
 
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS schedule_config (
-    name             TEXT PRIMARY KEY,
-    enabled          INTEGER NOT NULL DEFAULT 0,
-    kind             TEXT NOT NULL,
-    interval_minutes INTEGER NOT NULL DEFAULT 360,
-    daily_hhmm       TEXT NOT NULL DEFAULT '03:00',
-    day_of_week      INTEGER NOT NULL DEFAULT 0,
-    last_run_at      REAL,
-    next_run_at      REAL,
-    last_result      TEXT,
-    probe_roots      TEXT NOT NULL DEFAULT ''
-);
-CREATE TABLE IF NOT EXISTS auto_queue_rules (
-    id               INTEGER PRIMARY KEY CHECK (id = 1),
-    payload_json     TEXT NOT NULL,
-    updated_at       REAL NOT NULL
-);
-"""
-
-# Cheap idempotent migration for installs predating the probe_roots column.
-_MIGRATIONS = [
-    "ALTER TABLE schedule_config ADD COLUMN probe_roots TEXT NOT NULL DEFAULT ''",
-]
-
-
-_DEFAULT_SCHEDULE = ScheduleConfig(
-    name="coverage_walk",
-    enabled=False,                # off by default — user opts in
-    kind=KIND_DAILY,
-    interval_minutes=360,
-    daily_hhmm="03:00",
-    day_of_week=0,
-    last_run_at=None,
-    next_run_at=None,
-    last_result=None,
-)
+# Schema (schedule_config, auto_queue_rules) is owned by
+# migrations/001_baseline.sql, and the default disabled 'coverage_walk'
+# schedule row is seeded by migrations/008_init_schema_parity.sql.
+# run_migrations() runs at boot before this store — no per-store
+# init_schema(). auto_queue_rules needs no seed: get_rules() returns a
+# default AutoQueueRules() when the row is absent.
 
 
 class ScheduleStore:
@@ -147,45 +116,6 @@ class ScheduleStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
-
-    def init_schema(self) -> None:
-        with self._lock:
-            self._conn.executescript(_SCHEMA)
-            # Apply additive column migrations; ignore "duplicate column" errors
-            # so we don't fail on fresh DBs where _SCHEMA already created them.
-            for stmt in _MIGRATIONS:
-                try:
-                    self._conn.execute(stmt)
-                except sqlite3.OperationalError as e:
-                    if "duplicate column" not in str(e).lower():
-                        raise
-            row = self._conn.execute(
-                "SELECT name FROM schedule_config WHERE name = ?",
-                (_DEFAULT_SCHEDULE.name,),
-            ).fetchone()
-            if not row:
-                self._conn.execute(
-                    "INSERT INTO schedule_config "
-                    "(name, enabled, kind, interval_minutes, daily_hhmm, day_of_week) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (
-                        _DEFAULT_SCHEDULE.name,
-                        1 if _DEFAULT_SCHEDULE.enabled else 0,
-                        _DEFAULT_SCHEDULE.kind,
-                        _DEFAULT_SCHEDULE.interval_minutes,
-                        _DEFAULT_SCHEDULE.daily_hhmm,
-                        _DEFAULT_SCHEDULE.day_of_week,
-                    ),
-                )
-            rules_row = self._conn.execute(
-                "SELECT id FROM auto_queue_rules WHERE id = 1"
-            ).fetchone()
-            if not rules_row:
-                self._conn.execute(
-                    "INSERT INTO auto_queue_rules (id, payload_json, updated_at) "
-                    "VALUES (1, ?, ?)",
-                    (json.dumps(AutoQueueRules().to_dict()), time.time()),
-                )
 
     def close(self) -> None:
         with self._lock:
@@ -279,9 +209,17 @@ class ScheduleStore:
             return AutoQueueRules()
 
     def set_rules(self, rules: AutoQueueRules) -> AutoQueueRules:
+        # Upsert: auto_queue_rules is no longer seeded at boot (init_schema
+        # removed; get_rules() defaults when absent), so an UPDATE-only would
+        # silently no-op the first time a user saves rules. INSERT the id=1
+        # row if missing, otherwise replace its payload.
         with self._lock:
             self._conn.execute(
-                "UPDATE auto_queue_rules SET payload_json=?, updated_at=? WHERE id=1",
+                "INSERT INTO auto_queue_rules (id, payload_json, updated_at) "
+                "VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET "
+                "  payload_json=excluded.payload_json, "
+                "  updated_at=excluded.updated_at",
                 (json.dumps(rules.to_dict()), time.time()),
             )
         return rules

--- a/tests/test_eager_probe.py
+++ b/tests/test_eager_probe.py
@@ -60,10 +60,12 @@ def test_eager_probe_targets_skips_non_file_paths():
 
 @pytest.fixture
 def walker(subarr_env, tmp_path):
+    from subarr.migrate import run_migrations
     from subarr.probe_store import ProbeStore
     from subarr.probe_walker import ProbeWalker
-    store = ProbeStore(tmp_path / "probe.db")
-    store.init_schema()
+    db = tmp_path / "probe.db"
+    run_migrations(db)  # schema is migration-owned now (no init_schema)
+    store = ProbeStore(db)
     return ProbeWalker(store), store
 
 
@@ -201,8 +203,10 @@ def test_refresh_fires_eager_probe_for_unprobed(subarr_env, tmp_path, monkeypatc
                 status = "done"
             return _S()
 
-    cache = CoverageCache(tmp_path / "cov.db")
-    cache.init_schema()
+    from subarr.migrate import run_migrations
+    db = tmp_path / "cov.db"
+    run_migrations(db)
+    cache = CoverageCache(db)
     asyncio.run(cache.refresh(
         bundle=None, probe_store=None, audio_lang_store=None,
         probe_walker=FakeWalker(),
@@ -215,8 +219,10 @@ def test_refresh_no_walker_does_not_crash(subarr_env, tmp_path, monkeypatch):
     _patch_build(monkeypatch, [
         {"canonical_path": "TV/A/a.mkv", "verification_state": "unprobed", "media_type": "episode"},
     ])
-    cache = CoverageCache(tmp_path / "cov.db")
-    cache.init_schema()
+    from subarr.migrate import run_migrations
+    db = tmp_path / "cov.db"
+    run_migrations(db)
+    cache = CoverageCache(db)
     # No probe_walker passed — back-compat path, must just store + return.
     snap = asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
     assert snap.item_count == 1

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -230,30 +230,38 @@ def test_runner_still_aborts_on_real_error(db_path: Path, tmp_migrations: Path):
     assert runner.applied_versions() == [1]  # version 2 NOT recorded
 
 
-def test_bundled_migrations_idempotent_on_init_schema_db(subarr_env, tmp_path: Path):
-    """Truest transitional test: build a DB exactly as the legacy
-    init_schema path does (all stores), then run the bundled migrations.
-    Migration 008's ADD COLUMNs hit columns init_schema already created —
-    the runner must tolerate them and finish clean."""
-    from subarr.audio_lang_store import AudioLangStore
-    from subarr.coverage_cache import CoverageCache
-    from subarr.enrichment import EnrichmentStore
-    from subarr.pending_store import PendingStore
-    from subarr.probe_store import ProbeStore
-    from subarr.provenance import ProvenanceStore
-    from subarr.scan_store import ScanStore
-    from subarr.schedule_store import ScheduleStore
-
+def test_bundled_migrations_idempotent_on_init_schema_db(tmp_path: Path):
+    """Transitional DB: one a prior (now-removed) init_schema already
+    extended, so the 008 tables/columns exist BEFORE 008 runs. The runner
+    must tolerate the duplicate columns and finish clean. Built via raw SQL
+    that mirrors the legacy init_schema result for the tables 008 touches."""
     db = tmp_path / "transitional.db"
-    for store in (
-        ScanStore(db), ProvenanceStore(db), ScheduleStore(db), AudioLangStore(db),
-        CoverageCache(db), EnrichmentStore(db), ProbeStore(db), PendingStore(db),
-    ):
-        store.init_schema()
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE lang_enrichment (
+            canonical_path TEXT PRIMARY KEY, title TEXT NOT NULL, raw_response TEXT,
+            iso_code TEXT, model TEXT, inferred_at REAL NOT NULL, error TEXT,
+            confidence REAL, reasoning TEXT);
+        CREATE TABLE media_probe (
+            canonical_path TEXT PRIMARY KEY, mtime REAL NOT NULL, size INTEGER NOT NULL,
+            duration_s REAL, audio_json TEXT NOT NULL, sub_json TEXT NOT NULL,
+            probed_at REAL NOT NULL, source TEXT NOT NULL DEFAULT 'ffprobe');
+        CREATE TABLE audio_lang_verifications (
+            canonical_path TEXT PRIMARY KEY, lang_code TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'user', confidence REAL NOT NULL DEFAULT 1.0,
+            verified_at REAL NOT NULL, verified_by TEXT, evidence TEXT);
+        CREATE TABLE coverage_snapshot (
+            id INTEGER PRIMARY KEY CHECK (id = 1), generated_at REAL NOT NULL,
+            items_json TEXT NOT NULL, totals_json TEXT NOT NULL, sources_json TEXT NOT NULL,
+            build_duration_s REAL, item_count INTEGER);
+        """
+    )
+    conn.close()
 
-    # Now run the real bundled migrations on this init_schema-built DB.
-    applied = run_migrations(db)  # must NOT raise on duplicate columns/tables
-    # 008 must be among those applied (older ones were never recorded here).
+    # Run the real bundled migrations. 008's ADD COLUMNs hit columns that
+    # already exist → duplicate-column → must be tolerated, not aborted.
+    applied = run_migrations(db)
     assert 8 in [m.version for m in applied]
 
 

--- a/tests/test_probe_failures.py
+++ b/tests/test_probe_failures.py
@@ -8,15 +8,13 @@ from __future__ import annotations
 
 
 def _store(tmp_path):
-    # Mirror the app: run migrations, then the store's init_schema (which
-    # still backfills the media_probe.source column until init_schema removal).
+    # Mirror the app: migrations own the schema; the store no longer
+    # self-creates tables (init_schema removed).
     from subarr.migrate import run_migrations
     from subarr.probe_store import ProbeStore
     db = tmp_path / "p.db"
     run_migrations(db)
-    s = ProbeStore(db)
-    s.init_schema()
-    return s
+    return ProbeStore(db)
 
 
 def test_record_failure_and_failed_paths(tmp_path):

--- a/tests/test_schedule_store_rules.py
+++ b/tests/test_schedule_store_rules.py
@@ -1,0 +1,44 @@
+"""ScheduleStore rules persistence.
+
+Regression guard for the init_schema removal: auto_queue_rules is no
+longer seeded at boot (get_rules() defaults when the row is absent), so
+set_rules() MUST upsert — an UPDATE-only would silently no-op against an
+empty table and the user's rule change would vanish.
+"""
+from __future__ import annotations
+
+
+def _store(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.schedule_store import ScheduleStore
+    db = tmp_path / "sched.db"
+    run_migrations(db)
+    return ScheduleStore(db)
+
+
+def test_get_rules_defaults_when_row_absent(tmp_path):
+    from subarr.schedule_store import MODE_DASHBOARD
+    rules = _store(tmp_path).get_rules()
+    assert rules.mode == MODE_DASHBOARD
+    assert rules.min_score == 200
+
+
+def test_set_rules_persists_with_no_seed_row(tmp_path):
+    """The auto_queue_rules row does not exist on a fresh migrated DB.
+    set_rules must create it, not silently no-op."""
+    from subarr.schedule_store import AutoQueueRules, MODE_MANUAL_CONFIRM
+    store = _store(tmp_path)
+    store.set_rules(AutoQueueRules(mode=MODE_MANUAL_CONFIRM, min_score=42))
+    got = store.get_rules()
+    assert got.mode == MODE_MANUAL_CONFIRM
+    assert got.min_score == 42
+
+
+def test_set_rules_updates_existing_row(tmp_path):
+    from subarr.schedule_store import AutoQueueRules, MODE_AUTO_RULES, MODE_MANUAL_CONFIRM
+    store = _store(tmp_path)
+    store.set_rules(AutoQueueRules(mode=MODE_MANUAL_CONFIRM, min_score=42))
+    store.set_rules(AutoQueueRules(mode=MODE_AUTO_RULES, min_score=99))
+    got = store.get_rules()
+    assert got.mode == MODE_AUTO_RULES
+    assert got.min_score == 99

--- a/tests/test_series_lang_intent.py
+++ b/tests/test_series_lang_intent.py
@@ -6,10 +6,11 @@ import pytest
 
 @pytest.fixture
 def store(tmp_path):
+    from subarr.migrate import run_migrations
     from subarr.audio_lang_store import AudioLangStore
-    s = AudioLangStore(tmp_path / "audio_lang.db")
-    s.init_schema()
-    yield s
+    db = tmp_path / "audio_lang.db"
+    run_migrations(db)  # schema is migration-owned now (no init_schema)
+    yield AudioLangStore(db)
 
 
 def test_get_returns_per_file_verification_when_present(store):


### PR DESCRIPTION
Step 2 of init_schema removal (step 1 = migration 008 parity, [#46](https://github.com/coaxk/subarr/pull/46)). Now that migrations build the **complete** schema, the per-store `init_schema()` methods are redundant.

## What
- **8 stores** no longer self-create tables. `scan` / `provenance` / `pending` / `audio_lang` / `probe` / `enrichment` / `schedule` drop `init_schema()` + their now-dead `_SCHEMA` / `_MIGRATIONS` / `_DEFAULT_SCHEDULE` / `_MIGRATE_SOURCE_COL` constants. `CoverageCache` keeps a small `load()` (warms its boot in-memory mirror only; the table comes from migration 008).
- **app.py**: dropped the 8 `init_schema()` calls. `run_migrations()` (already first in lifespan) is the only schema path. `coverage_cache.load()`.
- `onboarding` already followed this pattern (migration 004, no `init_schema`) — now every store does.

## `set_rules()` upsert fix (caught by the suite)
Removing the `auto_queue_rules` seed (`get_rules()` defaults when absent) exposed that `set_rules` did `UPDATE … WHERE id=1`, which **silently no-ops against an empty table** — the user's first rule save would vanish (broke `manual_confirm`). Now `INSERT … ON CONFLICT(id) DO UPDATE`. Regression test added.

## Verified
**323 passing.** Clean migrations-only boot on a **fresh DB** (suite) **and** the **live dev DB** — no missing tables/columns, scheduler up, coverage reads 715 items, `get_rules()` defaults to dashboard/200, migration-008 `coverage_walk` seed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)