### PR TITLE
fix(coverage): propagate Sonarr episode-file path so wanted rows aren't dead folder paths

### DIFF
--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -71,7 +71,10 @@ def eager_probe_targets(items: list[dict[str, Any]], cap: int = _EAGER_PROBE_CAP
     for it in items:
         if it.get("verification_state") != "unprobed":
             continue
-        c = it.get("canonical_path")
+        # Prefer the resolved episode/movie FILE path over canonical_path
+        # (which for episodes is the series FOLDER — un-probeable). The
+        # folder-row fix propagates file_canonical_path from Sonarr.
+        c = it.get("file_canonical_path") or it.get("canonical_path")
         if not c or c in seen:
             continue
         # Must point at an actual video file, not a directory.

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -332,6 +332,26 @@ def _langs_in_sidecars(sidecars: list[str]) -> set[str]:
     return langs
 
 
+def _episode_file_canonical(
+    sonarr_episode_id: int | None,
+    ep_file_paths: dict[int, str],
+    sonarr_eps_by_id: dict[int, dict],
+) -> str | None:
+    """Resolve a wanted episode's actual file to a canonical path via the
+    prefetched Sonarr maps (sonarrEpisodeId → episodeFileId → episodeFile
+    .path → strip ARR prefix). Returns None when Sonarr has no file for the
+    episode (not yet downloaded) — callers must treat that as pending, not
+    fabricate a path."""
+    if sonarr_episode_id is None:
+        return None
+    ep = sonarr_eps_by_id.get(sonarr_episode_id) or {}
+    ep_file_id = ep.get("episodeFileId")
+    abs_path = ep_file_paths.get(ep_file_id) if ep_file_id else None
+    if not abs_path:
+        return None
+    return _strip_arr_prefix(abs_path) or abs_path
+
+
 def _stale_for_episode(
     *, sonarr_episode_id: int | None,
     ep_file_paths: dict[int, str],
@@ -352,14 +372,11 @@ def _stale_for_episode(
     file path (episode not yet downloaded, or pre-Sonarr-v3 cluster)."""
     if sonarr_episode_id is None or not series_srt_paths:
         return _match_episode_srt_pattern(series_srt_paths, episode_number) if not missing_subs else (False, [])
-    ep = sonarr_eps_by_id.get(sonarr_episode_id) or {}
-    ep_file_id = ep.get("episodeFileId")
-    abs_path = ep_file_paths.get(ep_file_id) if ep_file_id else None
-    if not abs_path:
+    file_canonical = _episode_file_canonical(sonarr_episode_id, ep_file_paths, sonarr_eps_by_id)
+    if not file_canonical:
         # No file on disk yet → can't be stale; fall back to pattern only
         # if Bazarr's view might be wrong (rare).
         return _match_episode_srt_pattern(series_srt_paths, episode_number)
-    file_canonical = _strip_arr_prefix(abs_path) or abs_path
     sidecars = _sidecars_for_file(series_srt_paths, file_canonical)
     if not sidecars:
         # [2026-05-30] Basename-stem match failed (common when the
@@ -997,6 +1014,15 @@ async def build_coverage(
         # v1.1-B: Sonarr knows this episode has no file yet.
         if item.bazarr_episode_id and item.bazarr_episode_id in sonarr_missing_ids:
             item.pending_download = True
+        # Folder-row fix: attach the actual episode-file path Sonarr already
+        # resolved. canonical_path stays the series folder (the probe-match
+        # search prefix); file_canonical_path is the real file so the row
+        # isn't a dead folder-path and eager-probe can target it. Only set
+        # when Sonarr has a file — fileless episodes stay pending_download.
+        if not item.file_canonical_path:
+            item.file_canonical_path = _episode_file_canonical(
+                item.bazarr_episode_id, ep_file_paths, sonarr_eps_by_id,
+            )
         _attach_probe_episode(item, probe_by_series_prefix,
                               tautulli_hints=activity.get("audio_lang_hints") or {},
                               user_verifications=user_verifications,

--- a/tests/test_coverage_verification_state.py
+++ b/tests/test_coverage_verification_state.py
@@ -67,3 +67,19 @@ def test_verification_state_in_to_dict():
     from subarr.coverage_engine import CoverageItem
     d = CoverageItem(media_type="episode", title="X").to_dict()
     assert d["verification_state"] == "unprobed"
+
+
+# ── folder-row fix: propagate Sonarr episodeFile path onto the row ──────
+
+def test_episode_file_canonical_resolves_from_sonarr(subarr_env):
+    from subarr.coverage_engine import _episode_file_canonical
+    eps = {9001: {"id": 9001, "episodeFileId": 555}}
+    paths = {555: "/data/Media/TV/Klovn/Season 1/Klovn.S01E01.mkv"}  # ARR_PATH_PREFIX=/data/Media/
+    assert _episode_file_canonical(9001, paths, eps) == "TV/Klovn/Season 1/Klovn.S01E01.mkv"
+
+
+def test_episode_file_canonical_none_when_fileless(subarr_env):
+    from subarr.coverage_engine import _episode_file_canonical
+    assert _episode_file_canonical(9001, {}, {9001: {"id": 9001}}) is None  # no episodeFileId
+    assert _episode_file_canonical(9001, {}, {9001: {"id": 9001, "episodeFileId": 5}}) is None  # id but no path
+    assert _episode_file_canonical(None, {}, {}) is None

--- a/tests/test_eager_probe.py
+++ b/tests/test_eager_probe.py
@@ -226,3 +226,16 @@ def test_refresh_no_walker_does_not_crash(subarr_env, tmp_path, monkeypatch):
     # No probe_walker passed — back-compat path, must just store + return.
     snap = asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
     assert snap.item_count == 1
+
+
+def test_eager_probe_targets_prefers_file_canonical_path():
+    """Folder-row fix: when the Sonarr episode-file path is propagated onto
+    file_canonical_path, eager-probe must target THAT (a real video file),
+    not the folder-level canonical_path (which the file-only guard skips)."""
+    from subarr.coverage_cache import eager_probe_targets
+    items = [
+        {"canonical_path": "TV/Klovn", "file_canonical_path": "TV/Klovn/Season 1/S01E01.mkv",
+         "verification_state": "unprobed"},
+        {"canonical_path": "TV/ILied", "verification_state": "unprobed"},  # folder only → skipped
+    ]
+    assert eager_probe_targets(items) == ["TV/Klovn/Season 1/S01E01.mkv"]


### PR DESCRIPTION
## Bug
Bazarr-wanted **episode** rows set `canonical_path` to the **series folder** (the probe-match search prefix, by design) and only got a `file_canonical_path` when a probe-cache entry happened to match under that prefix. For episodes not yet probed, the row was a **dead folder path**: the probe-gate held it forever in "Analyzing", and eager-probe (PR-C) skipped it (it's a directory, not a file). Nothing could ever probe it. (This is the 61-row "Klovn/I Lied" issue from the live investigation.)

## Fix
The real file path is already resolved by Sonarr (`episodeFileId → episodeFile.path`) — `_stale_for_episode` computed it and discarded it.
- **`_episode_file_canonical()`** — extracted resolution helper; `_stale_for_episode` refactored to share it (DRY).
- **`build_coverage`** — attach `file_canonical_path` to every wanted episode that has a Sonarr file. Fileless episodes leave it `None` and stay `pending_download` (hidden) — no fabricated paths.
- **`eager_probe_targets`** — prefer `file_canonical_path` over the folder-level `canonical_path`.

## Verified
TDD (helper resolution, fileless→None, eager-probe preference) + **live**: 61/61 formerly-folder rows now carry real file paths; eager-probe targets the real video file and **correctly skips a multi-episode DVD `.iso`** (inherently un-ffprobeable). **333 passing.**

**Follow-up (noted):** route unsupported formats (`.iso`, etc.) to a distinct "couldn't analyze: unsupported format" bucket instead of leaving them in "Analyzing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)