### PR TITLE
fix(schedule): preview reads warm coverage cache (68s → sub-second) + E2E green

### DIFF
--- a/src/subarr/routers/schedule.py
+++ b/src/subarr/routers/schedule.py
@@ -8,9 +8,15 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from dataclasses import fields as _dc_fields
+
 from ..auto_queue import evaluate
-from ..coverage_engine import build_coverage
+from ..coverage_engine import CoverageItem, build_coverage
 from ..schedule_store import AutoQueueRules
+
+# Constructor fields of CoverageItem — used to rebuild items from the
+# cached coverage snapshot (stored as dicts) without a fresh 60-90s build.
+_COVERAGE_ITEM_FIELDS = {f.name for f in _dc_fields(CoverageItem)}
 
 router = APIRouter(prefix="/api", tags=["schedule"])
 log = logging.getLogger(__name__)
@@ -133,11 +139,29 @@ async def reject_pending(walk_id: str, req: ApproveRequest, request: Request) ->
 
 @router.post("/schedule/preview")
 async def preview(request: Request) -> dict[str, Any]:
-    """Dry-run: pull coverage + evaluate current rules WITHOUT enqueueing.
-    Lets the UI show 'what would be auto-queued right now?'."""
+    """Dry-run: evaluate current rules against the latest coverage WITHOUT
+    enqueueing. Lets the UI show 'what would be auto-queued right now?'.
+
+    Reads the background-refreshed coverage snapshot (sub-second) and
+    reconstructs CoverageItem objects from it, rather than triggering a
+    fresh 60-90s build on every click. Falls back to a synchronous build
+    only when the cache hasn't warmed yet (first boot)."""
     bundle = request.app.state.integrations
     rules = request.app.state.schedule.get_rules()
-    report = await build_coverage(bundle, use_tautulli=True)
+    cov_cache = getattr(request.app.state, "coverage_cache", None)
+    snap = cov_cache.get_cached() if cov_cache is not None else None
+    if snap is not None:
+        items = [
+            CoverageItem(**{k: v for k, v in d.items() if k in _COVERAGE_ITEM_FIELDS})
+            for d in snap.items
+        ]
+
+        class _Report:
+            pass
+        report = _Report()
+        report.items = items
+    else:
+        report = await build_coverage(bundle, use_tautulli=True)
     decisions = evaluate(report.items, rules)
     queue = [d.to_dict() for d in decisions if d.action == "queue"]
     skip_sample = [d.to_dict() for d in decisions if d.action == "skip"][:20]

--- a/tests/e2e/tests/smoke.spec.ts
+++ b/tests/e2e/tests/smoke.spec.ts
@@ -193,7 +193,9 @@ test.describe('Settings page (wired to /api/integrations/health + telemetry + up
     );
     await page.getByRole('button', { name: /^Telemetry$/ }).click();
     await telemetryReq;
-    await expect(page.getByText(/Install ID/i)).toBeVisible({ timeout: 5000 });
+    // Exact match: /Install ID/i also matches the helper text "random
+    // per-install identifier", tripping strict mode on two elements.
+    await expect(page.getByText('Install ID', { exact: true })).toBeVisible({ timeout: 5000 });
   });
 
   test('switching to Updates view fetches /api/updates', async ({ page }) => {

--- a/tests/test_schedule_preview.py
+++ b/tests/test_schedule_preview.py
@@ -1,0 +1,61 @@
+"""/api/schedule/preview reconstructs CoverageItem objects from the cached
+coverage snapshot (dicts) so it can evaluate rules without a 60-90s
+rebuild. This guards that reconstruction against to_dict / dataclass-field
+drift — if a field evaluate() relies on stops round-tripping, this fails.
+"""
+from __future__ import annotations
+
+
+def test_reconstruct_coverage_item_from_snapshot_dict(subarr_env):
+    from subarr.coverage_engine import CoverageItem
+    from subarr.routers.schedule import _COVERAGE_ITEM_FIELDS
+
+    # A snapshot dict carries extra computed keys (reason, score_reasons,
+    # cache_age_s, …) that are NOT constructor fields. Reconstruction must
+    # drop them and preserve the fields evaluate() reads.
+    snap_dict = {
+        "media_type": "episode", "title": "Foreign Show",
+        "verification_state": "verified", "score": 500, "monitored": True,
+        "canonical_path": "TV/Foreign", "missing_subtitles": ["en"],
+        "tags": ["premium"], "audio_langs": ["kor"], "original_language": "Korean",
+        "embedded_en": None, "has_sub_on_disk": False, "pending_download": False,
+        "audio_label_suspect": False,
+        # computed-only keys that must NOT break the constructor:
+        "reason": "no-track", "score_reasons": ["foreign"], "cache_age_s": 12.3,
+    }
+    item = CoverageItem(**{k: v for k, v in snap_dict.items() if k in _COVERAGE_ITEM_FIELDS})
+
+    # Fields evaluate() depends on survived the round-trip.
+    assert item.verification_state == "verified"
+    assert item.score == 500
+    assert item.monitored is True
+    assert item.tags == ["premium"]
+    assert item.missing_subtitles == ["en"]
+    assert item.canonical_path == "TV/Foreign"
+    assert item.original_language == "Korean"
+
+
+def test_evaluate_runs_on_reconstructed_items(subarr_env):
+    """End-to-end of the reconstruction → evaluate path (auto_rules mode so
+    the score/monitored filters actually run)."""
+    from subarr.auto_queue import evaluate
+    from subarr.coverage_engine import CoverageItem
+    from subarr.routers.schedule import _COVERAGE_ITEM_FIELDS
+    from subarr.schedule_store import AutoQueueRules, MODE_AUTO_RULES
+
+    dicts = [
+        {"media_type": "episode", "title": "A", "verification_state": "verified",
+         "score": 500, "monitored": True, "canonical_path": "TV/A",
+         "deny_key": "ignored"},
+        {"media_type": "episode", "title": "B", "verification_state": "unprobed",
+         "score": 500, "monitored": True, "canonical_path": "TV/B"},
+    ]
+    items = [CoverageItem(**{k: v for k, v in d.items() if k in _COVERAGE_ITEM_FIELDS})
+             for d in dicts]
+    rules = AutoQueueRules(mode=MODE_AUTO_RULES, min_score=0,
+                           deny_languages=[], require_monitored=True)
+    decisions = evaluate(items, rules)
+    by_title = {d.item.title: d for d in decisions}
+    assert by_title["A"].action == "queue"           # verified + passes filters
+    assert by_title["B"].action == "skip"            # unprobed → gated out
+    assert "unverified" in by_title["B"].reason


### PR DESCRIPTION
## What
`POST /api/schedule/preview` backs the Rules-page "preview what would auto-queue" button. It ran a full synchronous `build_coverage()` (60-90s, 4 upstream services) **on every click** — the button hung, and the E2E smoke timed out at 30s.

- **preview now reads the background-refreshed coverage snapshot** and reconstructs `CoverageItem` objects from it (dropping computed-only keys via the dataclass field set), falling back to a build only on a cold cache. **Live: 68s → 0.34s.**
- Regression test guards the dict→`CoverageItem` reconstruction against `to_dict`/field drift + the reconstruction→`evaluate` path.

## Also: telemetry-view E2E fix
`getByText(/Install ID/i)` matched **two** elements (the label *and* the helper "random per-**install id**entifier") → strict-mode violation. Tightened to an exact-match locator. The product was always correct.

## Verified
E2E smoke **22/22 green** against the live stack; Python suite **335 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)