### PR TITLE
fix(ci): scope check:frontend to shipped artifacts (unblock build-and-publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:frontend": "node scripts/build-frontend.mjs",
     "dev:frontend": "node scripts/build-frontend.mjs --watch",
-    "check:frontend": "node scripts/build-frontend.mjs && git diff --exit-code -- src/subarr/static/v1/home-hifi"
+    "check:frontend": "node scripts/build-frontend.mjs && git diff --exit-code -- 'src/subarr/static/v1/home-hifi/*.bundle.js' 'src/subarr/static/v1/home-hifi/*.html'"
   },
   "devDependencies": {
     "esbuild": "0.25.0"


### PR DESCRIPTION
## Problem
`build-and-publish`'s `test` job runs `npm run check:frontend`, which diffed the **entire** `home-hifi` dir — including esbuild `.map` sourcemaps. Sourcemaps embed source paths and are **not byte-deterministic across Windows/Linux**, so a Windows-committed `.map` never matches CI's Linux rebuild → the gate failed even when the shipped bundles were byte-identical (the standalone `frontend` gate, which checks only `.bundle.js`+`.html`, passed on the same commit).

## Fix
Align `check:frontend` with the standalone `frontend.yml` gate: diff only `*.bundle.js` + `*.html` (the actual shipped artifacts, which **are** deterministic). Sourcemaps stay tracked for devtools but aren't gated.

Verified `npm run check:frontend` exits 0 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)