### PR TITLE
fix(queue): cancel passes the subgen path verbatim (was silently failing)

### DIFF
--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -273,14 +273,19 @@ async def cancel_queued(req: CancelRequest, request: Request) -> dict:
     Response body mirrors what subgen returns:
       { cancelled: bool, reason?: str, path: str }
     """
-    canonical = (req.path or "").strip().strip("/")
+    # The path here is a SUBGEN queue key — it lives in subgen's path space
+    # (e.g. /media/...), which is NOT the same mount as subarr's media root
+    # (/media/library/...). It comes straight from GET /api/queue, and
+    # subgen matches its queue by EXACT path. So pass it through verbatim:
+    # stripping the leading slash or canonicalising it against subarr's root
+    # (the previous behaviour) made every cancel miss with "not in queue".
+    # subgen only does an in-memory queue lookup here, so this never touches
+    # the filesystem; a basic traversal guard is the only check that applies.
+    canonical = (req.path or "").strip()
     if not canonical:
         raise HTTPException(400, detail="path required")
-    # Reject path-escape attempts, consistent with /queue/requeue.
-    try:
-        canonical_to_fs(canonical)
-    except (PathOutsideRootError, OSError):
-        raise HTTPException(400, detail=f"path escapes media root: {canonical!r}")
+    if ".." in canonical:
+        raise HTTPException(400, detail=f"invalid path: {canonical!r}")
     caps = getattr(request.app.state, "subgen_caps", None)
     if caps is None or not getattr(caps, "queue_cancel", False):
         raise HTTPException(

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -90,3 +90,37 @@ def test_queue_history_only_when_subgen_down(app_with_stub):
     assert "subgen" in body["subgen_error"].lower()
     assert "history" in body
     assert "history_counts" in body
+
+
+# ── #queue-cancel: subgen-space path must pass through verbatim ──────────
+# Regression: the cancel endpoint used to strip("/") + canonicalise the
+# path as if it were subarr-relative. But /api/queue returns subgen's OWN
+# path space (e.g. /media/...), and subgen matches its queue by exact path
+# — stripping the leading slash made every cancel fail "not in queue".
+
+_CANCEL_SEEN = {}
+
+
+def _cancel_handler(req):
+    if req.url.path == "/queue/cancel":
+        _CANCEL_SEEN["path"] = req.url.params.get("path")
+        return httpx.Response(200, json={"cancelled": True, "path": _CANCEL_SEEN["path"]})
+    # keep boot + GET /queue happy
+    return httpx.Response(200, json={"active": None, "queue": []})
+
+
+@pytest.mark.subgen(handler=_cancel_handler)
+def test_cancel_passes_subgen_path_verbatim(app_with_stub):
+    import dataclasses
+    from subarr.subgen_client import SubgenCapabilities
+    c = app_with_stub
+    base = c.app.state.subgen_caps or SubgenCapabilities()
+    c.app.state.subgen_caps = dataclasses.replace(base, queue_cancel=True)
+    _CANCEL_SEEN.clear()
+
+    full = "/media/TV/Innato/Season 1/Innate - S01E06 - x.mkv"
+    r = c.post("/api/queue/cancel", json={"path": full})
+    assert r.status_code == 200, r.text
+    assert r.json().get("cancelled") is True
+    # The exact subgen path (leading slash + all) must reach subgen.
+    assert _CANCEL_SEEN["path"] == full


### PR DESCRIPTION
## Bug (found in manual testing)
Cancelling a queued job did nothing — the row stayed. `POST /api/queue/cancel` treated the path as a subarr-relative canonical and `strip("/")`-ed + re-rooted it. But `/api/queue` returns **subgen's own path space** (`/media/...`), a *different mount* than subarr's media root (`/media/library/...`), and subgen matches its queue by **exact path** — so the mangled `media/...` (no leading slash) always missed: subgen replied `{cancelled:false, reason:"not in queue"}` and the UI showed the job still there.

## Fix
Pass the path through **verbatim** (it's subgen's queue key; subgen does an in-memory lookup only — never touches the filesystem, so the wrong-root canonicalization was both incorrect and unnecessary). Kept a `..` traversal guard.

## Verified
- **Live** on the dev stack: cancelling a queued item via `/api/queue/cancel` now returns `cancelled: true` and the queue count drops (also confirmed subgen cancels with the verbatim path).
- Regression test asserts the leading slash reaches subgen.
- **336 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)