### PR TITLE
docs(readme): tests badge 335 → 336

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The coordination layer for the *arr subtitle stack. Stands beside Bazarr.
 Subarr decides what subtitles are actually missing across your library, which providers are worth your time, and when it is worth running Whisper. Bazarr finds and downloads. Subgen transcribes. Subarr coordinates.
 
 [![status](https://img.shields.io/badge/status-v1.0-violet)](https://github.com/coaxk/subarr)
-[![tests](https://img.shields.io/badge/tests-335_passing-22d3ee)](https://github.com/coaxk/subarr/actions/workflows/ci.yml)
+[![tests](https://img.shields.io/badge/tests-336_passing-22d3ee)](https://github.com/coaxk/subarr/actions/workflows/ci.yml)
 [![security](https://img.shields.io/badge/Bandit_%2B_Semgrep_%2B_Trivy_%2B_pip--audit-22c55e)](#security)
 [![license](https://img.shields.io/badge/license-MIT-c8c8cc)](LICENSE)
 


### PR DESCRIPTION
Off-by-one after the cancel-fix regression test landed (#58). 🤖 Generated with [Claude Code](https://claude.com/claude-code)