### PR TITLE
chore(ci): add CodeQL code scanning + Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+# Version-update PRs (security alerts already enabled separately). Weekly,
+# grouped, labelled `dependencies` so they triage cleanly.
+updates:
+  # Python backend (pyproject.toml)
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+    groups:
+      python:
+        patterns: ["*"]
+
+  # Frontend build tooling (root package.json — esbuild)
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+    groups:
+      frontend-build:
+        patterns: ["*"]
+
+  # E2E tooling (Playwright)
+  - package-ecosystem: npm
+    directory: "/tests/e2e"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+    groups:
+      e2e:
+        patterns: ["*"]
+
+  # GitHub Actions versions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: codeql
+
+# GitHub-native semantic code scanning (Python + JS/TS), complementing the
+# pattern/CVE scanners in security.yml (Bandit · Semgrep · pip-audit · Trivy).
+# Results upload to the GitHub Security tab. Free on public repos.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+          queries: security-extended
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Post-launch GH hygiene: CodeQL (Python + JS/TS) to the Security tab, and Dependabot weekly version-update PRs (pip / npm root + e2e / actions, grouped, labelled `dependencies`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)