### PR TITLE
feat(tournament): judging engine — score + rank config entrants (#65)

### DIFF
--- a/src/subarr/subtitle_readability.py
+++ b/src/subarr/subtitle_readability.py
@@ -1,0 +1,179 @@
+"""#92 — deterministic subtitle readability linter.
+
+Pure SRT math against Netflix/BBC-style norms: reading speed (CPS), line
+length (CPL), line count, cue duration, and overlaps. No model, no GPU, no
+network — it works on any `.srt` already on disk (downloaded, generated, or
+translated).
+
+This is the *high-certainty* half of subtitle quality: "this line is
+measurably too fast to read" or "this cue overlaps the next one" are facts,
+not guesses. It complements (later, separately) reference-free QE for the
+fuzzy translation-quality half — see the banked quality-measurement concept.
+The whole point: the *arr stack scores subtitles on release-MATCH and never
+on whether they're actually readable. This measures the thing nobody else does.
+
+Thresholds follow common professional guidance (Netflix Timed Text General
+Requirements / BBC subtitle guidelines):
+  - reading speed (CPS): <= 20 comfortable; > 25 critical
+  - line length (CPL): <= 42 characters
+  - <= 2 lines per cue
+  - cue duration: >= 0.833s (5/6 sec) and <= 7s
+  - consecutive cues must not overlap
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# Named so they're easy to tune or expose in Settings later.
+MAX_CPS = 20.0
+CRITICAL_CPS = 25.0
+MAX_CPL = 42
+MAX_LINES = 2
+MIN_DURATION_S = 0.833
+MAX_DURATION_S = 7.0
+
+# HH:MM:SS,mmm --> HH:MM:SS,mmm  (accepts ',' or '.' as the ms separator)
+_TS = re.compile(
+    r"(\d{1,2}):(\d{2}):(\d{2})[,.](\d{1,3})\s*-->\s*"
+    r"(\d{1,2}):(\d{2}):(\d{2})[,.](\d{1,3})"
+)
+
+
+def _ts_to_ms(h: str, m: str, s: str, ms: str) -> int:
+    return (int(h) * 3600 + int(m) * 60 + int(s)) * 1000 + int(ms.ljust(3, "0")[:3])
+
+
+@dataclass
+class Cue:
+    index: int
+    start_ms: int
+    end_ms: int
+    lines: list[str]
+
+    @property
+    def text(self) -> str:
+        return " ".join(self.lines)
+
+    @property
+    def duration_s(self) -> float:
+        return max(0.0, (self.end_ms - self.start_ms) / 1000.0)
+
+    @property
+    def char_count(self) -> int:
+        # Reading load: visible chars per line + the implicit space between
+        # lines. Newlines themselves don't count.
+        return sum(len(ln) for ln in self.lines) + max(0, len(self.lines) - 1)
+
+    @property
+    def max_cpl(self) -> int:
+        return max((len(ln) for ln in self.lines), default=0)
+
+    @property
+    def line_count(self) -> int:
+        return len(self.lines)
+
+    @property
+    def cps(self) -> float:
+        d = self.duration_s
+        return (self.char_count / d) if d > 0 else float("inf")
+
+
+@dataclass
+class CueIssue:
+    cue_index: int
+    kind: str        # cps | cpl | lines | too_short | too_long | overlap
+    severity: str    # warn | critical
+    detail: str
+
+
+@dataclass
+class ReadabilityReport:
+    cue_count: int
+    issues: list[CueIssue] = field(default_factory=list)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        out: dict[str, int] = {}
+        for i in self.issues:
+            out[i.kind] = out.get(i.kind, 0) + 1
+        return out
+
+    @property
+    def clean(self) -> bool:
+        return not self.issues
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cue_count": self.cue_count,
+            "clean": self.clean,
+            "counts": self.counts,
+            "issues": [
+                {"cue": i.cue_index, "kind": i.kind,
+                 "severity": i.severity, "detail": i.detail}
+                for i in self.issues
+            ],
+        }
+
+
+def parse_srt(text: str) -> list[Cue]:
+    """Minimal, lenient SRT parser. Blocks split on blank lines; the index
+    line is optional. Malformed blocks (no timestamp) are skipped, not raised
+    on — a real-world .srt with one junk block still gets analysed."""
+    cues: list[Cue] = []
+    normalised = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+    for block in re.split(r"\n\s*\n", normalised):
+        raw = block.split("\n")
+        ts_i = next((i for i, ln in enumerate(raw) if _TS.search(ln)), None)
+        if ts_i is None:
+            continue
+        m = _TS.search(raw[ts_i])
+        start = _ts_to_ms(*m.group(1, 2, 3, 4))
+        end = _ts_to_ms(*m.group(5, 6, 7, 8))
+        idx = len(cues) + 1
+        if ts_i > 0 and raw[ts_i - 1].strip().isdigit():
+            idx = int(raw[ts_i - 1].strip())
+        lines = [ln for ln in raw[ts_i + 1:] if ln.strip() != ""]
+        cues.append(Cue(index=idx, start_ms=start, end_ms=end, lines=lines))
+    return cues
+
+
+def analyze_cues(cues: list[Cue]) -> ReadabilityReport:
+    report = ReadabilityReport(cue_count=len(cues))
+    for n, c in enumerate(cues):
+        if c.line_count > MAX_LINES:
+            report.issues.append(CueIssue(
+                c.index, "lines", "warn",
+                f"{c.line_count} lines (max {MAX_LINES})"))
+        if c.max_cpl > MAX_CPL:
+            report.issues.append(CueIssue(
+                c.index, "cpl", "warn",
+                f"{c.max_cpl} chars on a line (max {MAX_CPL})"))
+        if c.duration_s > 0:
+            if c.cps > CRITICAL_CPS:
+                report.issues.append(CueIssue(
+                    c.index, "cps", "critical",
+                    f"{c.cps:.0f} chars/sec (critical > {CRITICAL_CPS:.0f})"))
+            elif c.cps > MAX_CPS:
+                report.issues.append(CueIssue(
+                    c.index, "cps", "warn",
+                    f"{c.cps:.0f} chars/sec (comfortable <= {MAX_CPS:.0f})"))
+        if 0 < c.duration_s < MIN_DURATION_S:
+            report.issues.append(CueIssue(
+                c.index, "too_short", "warn",
+                f"{c.duration_s:.2f}s on screen (min {MIN_DURATION_S:.2f}s)"))
+        elif c.duration_s > MAX_DURATION_S:
+            report.issues.append(CueIssue(
+                c.index, "too_long", "warn",
+                f"{c.duration_s:.1f}s on screen (max {MAX_DURATION_S:.0f}s)"))
+        if n + 1 < len(cues) and c.end_ms > cues[n + 1].start_ms:
+            report.issues.append(CueIssue(
+                c.index, "overlap", "critical",
+                f"overlaps cue {cues[n + 1].index}"))
+    return report
+
+
+def analyze_srt(text: str) -> ReadabilityReport:
+    """Parse + analyse an SRT string in one call."""
+    return analyze_cues(parse_srt(text))

--- a/src/subarr/tournament.py
+++ b/src/subarr/tournament.py
@@ -1,0 +1,111 @@
+"""#65 — tournament judging engine.
+
+The scoring/ranking HEART of the Whisper-tuning tournament. Given several
+config "entrants" (each a candidate SRT output for the SAME source audio), it
+judges each objectively and ranks them so the winner can be adopted.
+
+This is the UNBLOCKED half. The "arena" — running the same audio through each
+config variant live via subgen — is blocked on #88 (per-request kwargs; today
+SUBGEN_KWARGS is global-only). The judges here operate on already-produced
+outputs, so they're fully buildable + testable now.
+
+Judges (composable):
+  - readability (#92, deterministic): CPS/CPL/timing/overlap.
+  - SRT integrity: did it parse to real cues at all? A config that produces
+    garbage / no cues is DISQUALIFIED, not merely low-scored.
+  - reference-free QE (#94): HOOK only — wire when the QE experiment lands.
+  - speed: wall-clock, used as a tiebreak.
+
+The RUBRIC (weights/penalties below) is the v1 PROPOSAL — tune with Judd. The
+*shape* is intentional and what the tests pin: integrity is a gate,
+readability dominates, speed breaks ties, QE slots in as an advisory
+contributor later.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .subtitle_readability import ReadabilityReport, analyze_srt, parse_srt
+
+# --- v1 proposed rubric (TUNABLE) ---------------------------------------
+CRITICAL_PENALTY = 2.0   # weight of a 'critical' readability issue
+WARN_PENALTY = 1.0       # weight of a 'warn' readability issue
+READABILITY_WEIGHT = 0.85
+SPEED_WEIGHT = 0.15
+# QE_WEIGHT reserved for #94; renormalise READABILITY/SPEED when it's added.
+
+
+@dataclass
+class Entrant:
+    label: str                  # config name, e.g. "large-v3 / beam5 / vad"
+    srt_text: str               # candidate output for the shared source
+    gen_time_s: float | None = None
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Scorecard:
+    entrant_label: str
+    disqualified: bool
+    composite: float            # 0-100 (0 if disqualified)
+    readability_score: float    # 0-100
+    cue_count: int
+    gen_time_s: float | None
+    readability: dict[str, Any] | None   # the #92 report.to_dict()
+    notes: str = ""
+
+
+@dataclass
+class TournamentResult:
+    scorecards: list[Scorecard]           # ranked best-first
+    winner_label: str | None
+
+
+def _readability_score(report: ReadabilityReport) -> float:
+    """0-100. Penalise issues PER CUE so a config that produces more (or
+    longer) cues isn't unfairly punished — entrants share a source but
+    segment it differently, so absolute issue counts aren't comparable."""
+    critical = sum(1 for i in report.issues if i.severity == "critical")
+    warn = sum(1 for i in report.issues if i.severity == "warn")
+    cues = max(report.cue_count, 1)
+    load_per_cue = (critical * CRITICAL_PENALTY + warn * WARN_PENALTY) / cues
+    return max(0.0, 100.0 - load_per_cue * 100.0)
+
+
+def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scorecard:
+    if not parse_srt(entrant.srt_text):
+        return Scorecard(
+            entrant_label=entrant.label, disqualified=True, composite=0.0,
+            readability_score=0.0, cue_count=0, gen_time_s=entrant.gen_time_s,
+            readability=None, notes="no parseable subtitle cues (disqualified)",
+        )
+    report = analyze_srt(entrant.srt_text)
+    r_score = _readability_score(report)
+    if entrant.gen_time_s and fastest_time_s and entrant.gen_time_s > 0:
+        speed_score = min(100.0, (fastest_time_s / entrant.gen_time_s) * 100.0)
+        composite = r_score * READABILITY_WEIGHT + speed_score * SPEED_WEIGHT
+    else:
+        composite = r_score
+    return Scorecard(
+        entrant_label=entrant.label, disqualified=False,
+        composite=round(composite, 2), readability_score=round(r_score, 2),
+        cue_count=report.cue_count, gen_time_s=entrant.gen_time_s,
+        readability=report.to_dict(),
+    )
+
+
+def run_tournament(entrants: list[Entrant]) -> TournamentResult:
+    if not entrants:
+        return TournamentResult(scorecards=[], winner_label=None)
+    times = [e.gen_time_s for e in entrants if e.gen_time_s]
+    fastest = min(times) if times else None
+    cards = [score_entrant(e, fastest_time_s=fastest) for e in entrants]
+    # Disqualified always last; otherwise composite desc, faster breaks ties.
+    cards.sort(key=lambda c: (
+        c.disqualified,
+        -c.composite,
+        c.gen_time_s if c.gen_time_s is not None else float("inf"),
+    ))
+    winner = next((c.entrant_label for c in cards if not c.disqualified), None)
+    return TournamentResult(scorecards=cards, winner_label=winner)

--- a/src/subarr/tournament.py
+++ b/src/subarr/tournament.py
@@ -27,13 +27,27 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .subtitle_readability import ReadabilityReport, analyze_srt, parse_srt
+from .transcript_signals import (
+    canned_phrase_hits,
+    repeated_line_ratio,
+    silence_text_ratio,
+)
 
 # --- v1 proposed rubric (TUNABLE) ---------------------------------------
 CRITICAL_PENALTY = 2.0   # weight of a 'critical' readability issue
 WARN_PENALTY = 1.0       # weight of a 'warn' readability issue
-READABILITY_WEIGHT = 0.85
+QUALITY_WEIGHT = 0.85    # quality (readability − QE penalties) vs speed
 SPEED_WEIGHT = 0.15
-# QE_WEIGHT reserved for #94; renormalise READABILITY/SPEED when it's added.
+
+# QE (reference-free) penalties — the real discriminators (#65 research). A
+# quality score starts from readability (0-100) and these subtract from it, so
+# a hallucinating/looping entrant tanks regardless of how "readable" its
+# fabricated text is. Tuned so a fully-hallucinated or fully-looping output
+# drops to ~0.
+SILENCE_TEXT_PENALTY = 100.0   # × fraction of text over silence (hallucination)
+REPEAT_PENALTY = 100.0         # × fraction of duplicate lines (looping)
+CANNED_PENALTY = 40.0          # × canned-phrase cues (capped)
+CANNED_CAP = 3
 
 
 @dataclass
@@ -42,6 +56,10 @@ class Entrant:
     srt_text: str               # candidate output for the shared source
     gen_time_s: float | None = None
     config: dict[str, Any] = field(default_factory=dict)
+    # silero speech ranges (s) for the SOURCE audio (#111). Shared across
+    # entrants of one tournament (same source); enables the text-over-silence
+    # hallucination judge. None → that judge is skipped (no penalty).
+    speech_ranges: list[tuple[float, float]] | None = None
 
 
 @dataclass
@@ -53,6 +71,7 @@ class Scorecard:
     cue_count: int
     gen_time_s: float | None
     readability: dict[str, Any] | None   # the #92 report.to_dict()
+    signals: dict[str, Any] | None = None  # QE signals (silence/repeat/canned)
     notes: str = ""
 
 
@@ -74,24 +93,45 @@ def _readability_score(report: ReadabilityReport) -> float:
 
 
 def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scorecard:
-    if not parse_srt(entrant.srt_text):
+    cues = parse_srt(entrant.srt_text)
+    if not cues:
         return Scorecard(
             entrant_label=entrant.label, disqualified=True, composite=0.0,
             readability_score=0.0, cue_count=0, gen_time_s=entrant.gen_time_s,
-            readability=None, notes="no parseable subtitle cues (disqualified)",
+            readability=None, signals=None,
+            notes="no parseable subtitle cues (disqualified)",
         )
     report = analyze_srt(entrant.srt_text)
     r_score = _readability_score(report)
+
+    # Reference-free QE signals (#65): the real discriminators. Subtract them
+    # from the readability base so a hallucinating/looping entrant can't win
+    # on "readable" fabricated text.
+    sil = silence_text_ratio(cues, entrant.speech_ranges)
+    rep = repeated_line_ratio(cues)
+    canned = canned_phrase_hits(cues)
+    qe_penalty = (
+        sil * SILENCE_TEXT_PENALTY
+        + rep * REPEAT_PENALTY
+        + min(canned, CANNED_CAP) * CANNED_PENALTY
+    )
+    quality = max(0.0, r_score - qe_penalty)
+    signals = {
+        "silence_text_ratio": round(sil, 4),
+        "repeated_line_ratio": round(rep, 4),
+        "canned_phrase_hits": canned,
+    }
+
     if entrant.gen_time_s and fastest_time_s and entrant.gen_time_s > 0:
         speed_score = min(100.0, (fastest_time_s / entrant.gen_time_s) * 100.0)
-        composite = r_score * READABILITY_WEIGHT + speed_score * SPEED_WEIGHT
+        composite = quality * QUALITY_WEIGHT + speed_score * SPEED_WEIGHT
     else:
-        composite = r_score
+        composite = quality
     return Scorecard(
         entrant_label=entrant.label, disqualified=False,
         composite=round(composite, 2), readability_score=round(r_score, 2),
         cue_count=report.cue_count, gen_time_s=entrant.gen_time_s,
-        readability=report.to_dict(),
+        readability=report.to_dict(), signals=signals,
     )
 
 

--- a/src/subarr/transcript_signals.py
+++ b/src/subarr/transcript_signals.py
@@ -1,0 +1,85 @@
+"""#65 — reference-free transcript quality signals.
+
+The discriminating judges for the Whisper-tuning tournament. Per the research
+synthesis (#65), configs TIE on clean dialogue and DIVERGE on the failure
+modes below — so these, not readability, are what actually rank entrants. All
+are reference-free (no ground-truth transcript needed):
+
+  - silence_text_ratio: subtitle text sitting where there's NO speech (the
+    highest-value hallucination signal) — rides on the silero VAD ranges (#111).
+  - repeated_line_ratio: looping / stuck-decoder output.
+  - canned_phrase_hits: the canonical non-speech hallucinations
+    ("thanks for watching", "subtitles by amara.org", …).
+
+Cross-config CONSENSUS (segments most entrants agree on) is the other big
+signal, but it's inherently cross-entrant so it lives in the tournament
+runner, not here.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+# Canonical Whisper non-speech hallucinations (lower-cased substring match).
+# These appear over music/silence/credits across countless real outputs.
+_CANNED_PATTERNS = (
+    "thank you for watching",
+    "thanks for watching",
+    "thank you for your watching",
+    "subtitles by",
+    "amara.org",
+    "subscribe to",
+    "please subscribe",
+    "like and subscribe",
+    "see you in the next",
+    "thanks for listening",
+)
+
+
+def _cue_text(cue) -> str:
+    return " ".join(getattr(cue, "lines", []) or []).strip()
+
+
+def silence_text_ratio(cues, speech_ranges) -> float:
+    """Fraction of total cue time that falls OUTSIDE detected speech — i.e.
+    subtitle text where the audio has no voice (hallucination). 0.0 when
+    there's no cue time or no speech data (don't penalize on missing VAD)."""
+    if not cues or not speech_ranges:
+        return 0.0
+    total = 0.0
+    outside = 0.0
+    for c in cues:
+        start = c.start_ms / 1000.0
+        end = c.end_ms / 1000.0
+        dur = end - start
+        if dur <= 0:
+            continue
+        total += dur
+        overlap = 0.0
+        for s, e in speech_ranges:
+            lo = max(start, s)
+            hi = min(end, e)
+            if hi > lo:
+                overlap += hi - lo
+        outside += max(0.0, dur - overlap)
+    return outside / total if total > 0 else 0.0
+
+
+def repeated_line_ratio(cues) -> float:
+    """Fraction of cue lines that are duplicates of an earlier line. A stuck
+    decoder repeats the same phrase; varied dialogue scores near 0."""
+    texts = [t.lower() for t in (_cue_text(c) for c in cues) if t]
+    if len(texts) <= 1:
+        return 0.0
+    counts = Counter(texts)
+    duplicates = sum(n - 1 for n in counts.values())
+    return duplicates / len(texts)
+
+
+def canned_phrase_hits(cues) -> int:
+    """Count cues containing a known non-speech hallucination phrase."""
+    hits = 0
+    for c in cues:
+        t = _cue_text(c).lower()
+        if any(p in t for p in _CANNED_PATTERNS):
+            hits += 1
+    return hits

--- a/tests/test_subtitle_readability.py
+++ b/tests/test_subtitle_readability.py
@@ -1,0 +1,93 @@
+"""#92 — deterministic subtitle readability linter.
+
+Pure SRT math against Netflix/BBC-style norms (CPS / CPL / line count /
+duration / overlap). No model, no GPU, no network. These tests pin the
+parser and the thresholds.
+"""
+from __future__ import annotations
+
+
+def _mod():
+    from subarr import subtitle_readability as sr
+    return sr
+
+
+SAMPLE = """1
+00:00:01,000 --> 00:00:03,000
+Hello there.
+
+2
+00:00:04,000 --> 00:00:05,000
+This is fine.
+"""
+
+
+def test_parse_srt_basic():
+    sr = _mod()
+    cues = sr.parse_srt(SAMPLE)
+    assert len(cues) == 2
+    assert cues[0].index == 1
+    assert cues[0].start_ms == 1000
+    assert cues[0].end_ms == 3000
+    assert cues[0].lines == ["Hello there."]
+    assert cues[0].duration_s == 2.0
+
+
+def test_clean_subtitle_has_no_issues():
+    sr = _mod()
+    # ~22 chars over 3s = ~7 CPS, 1 line, comfortable duration
+    srt = "1\n00:00:00,000 --> 00:00:03,000\nA calm, readable line.\n"
+    report = sr.analyze_srt(srt)
+    assert report.issues == []
+    assert report.cue_count == 1
+    assert report.clean is True
+
+
+def test_cps_flagged_when_too_fast():
+    sr = _mod()
+    srt = "1\n00:00:00,000 --> 00:00:01,000\n" + ("x" * 80) + "\n"  # 80 CPS
+    report = sr.analyze_srt(srt)
+    assert any(i.kind == "cps" for i in report.issues)
+    assert report.clean is False
+
+
+def test_cpl_flagged_when_line_too_long():
+    sr = _mod()
+    srt = f"1\n00:00:00,000 --> 00:00:05,000\n{'y' * 60}\n"  # 60 > 42 CPL
+    report = sr.analyze_srt(srt)
+    assert any(i.kind == "cpl" for i in report.issues)
+
+
+def test_too_many_lines_flagged():
+    sr = _mod()
+    srt = "1\n00:00:00,000 --> 00:00:05,000\nline one\nline two\nline three\n"
+    report = sr.analyze_srt(srt)
+    assert any(i.kind == "lines" for i in report.issues)
+
+
+def test_overlap_flagged():
+    sr = _mod()
+    srt = (
+        "1\n00:00:00,000 --> 00:00:03,000\nfirst\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nsecond\n"
+    )
+    report = sr.analyze_srt(srt)
+    assert any(i.kind == "overlap" for i in report.issues)
+
+
+def test_too_short_and_too_long_duration():
+    sr = _mod()
+    rep_s = sr.analyze_srt("1\n00:00:00,000 --> 00:00:00,300\nflash\n")
+    assert any(i.kind == "too_short" for i in rep_s.issues)
+    rep_l = sr.analyze_srt("1\n00:00:00,000 --> 00:00:09,000\nlingers\n")
+    assert any(i.kind == "too_long" for i in rep_l.issues)
+
+
+def test_report_counts_and_to_dict():
+    sr = _mod()
+    report = sr.analyze_srt("1\n00:00:00,000 --> 00:00:01,000\n" + ("z" * 90) + "\n")
+    assert report.counts.get("cps", 0) >= 1
+    d = report.to_dict()
+    assert d["clean"] is False
+    assert d["cue_count"] == 1
+    assert "cps" in d["counts"]

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,0 +1,75 @@
+"""#65 — tournament judging engine (the scoring/ranking heart).
+
+Given several config "entrants" (each = a candidate SRT output for the SAME
+source), score each objectively and rank them. Unblocked half of the
+tournament: reuses the deterministic readability linter (#92); the live
+per-variant generation (the "arena") is blocked on #88.
+
+Rubric here is the v1 PROPOSAL (tunable) — these tests pin the *behaviour*
+(clean beats sloppy, broken SRT is disqualified, faster wins a tie), not the
+exact weights.
+"""
+from __future__ import annotations
+
+
+def _t():
+    from subarr import tournament as t
+    return t
+
+
+CLEAN = "1\n00:00:00,000 --> 00:00:03,000\nA calm, readable line.\n"
+# Same content but flashed too fast (high CPS) — should score lower.
+SLOPPY = "1\n00:00:00,000 --> 00:00:00,500\nA calm, readable line that flashes by far too fast to read.\n"
+BROKEN = "not a subtitle file at all\njust noise\n"
+
+
+def test_clean_beats_sloppy():
+    t = _t()
+    result = t.run_tournament([
+        t.Entrant(label="sloppy", srt_text=SLOPPY),
+        t.Entrant(label="clean", srt_text=CLEAN),
+    ])
+    assert result.winner_label == "clean"
+    # ranked best-first
+    assert result.scorecards[0].entrant_label == "clean"
+    assert result.scorecards[0].composite > result.scorecards[1].composite
+
+
+def test_broken_srt_is_disqualified_and_last():
+    t = _t()
+    result = t.run_tournament([
+        t.Entrant(label="clean", srt_text=CLEAN),
+        t.Entrant(label="broken", srt_text=BROKEN),
+    ])
+    broken = next(s for s in result.scorecards if s.entrant_label == "broken")
+    assert broken.disqualified is True
+    assert broken.composite == 0
+    assert result.scorecards[-1].entrant_label == "broken"
+    assert result.winner_label == "clean"
+
+
+def test_faster_entrant_wins_a_readability_tie():
+    t = _t()
+    # identical output → readability ties → speed is the tiebreak
+    result = t.run_tournament([
+        t.Entrant(label="slow", srt_text=CLEAN, gen_time_s=120.0),
+        t.Entrant(label="fast", srt_text=CLEAN, gen_time_s=20.0),
+    ])
+    assert result.winner_label == "fast"
+
+
+def test_scorecard_exposes_readability_and_composite():
+    t = _t()
+    result = t.run_tournament([t.Entrant(label="only", srt_text=CLEAN)])
+    sc = result.scorecards[0]
+    assert 0 <= sc.composite <= 100
+    assert sc.readability is not None
+    assert "clean" in sc.readability  # the #92 report dict, embedded
+    assert sc.disqualified is False
+
+
+def test_empty_tournament_is_safe():
+    t = _t()
+    result = t.run_tournament([])
+    assert result.scorecards == []
+    assert result.winner_label is None

--- a/tests/test_tournament_validation.py
+++ b/tests/test_tournament_validation.py
@@ -1,0 +1,68 @@
+"""#65 — TOURNAMENT VALIDATION (Tier A, synthetic).
+
+Does the judging methodology actually rank a good transcript above the
+failure modes Whisper configs produce? We feed a clean, speech-aligned
+transcript against deliberately-degraded variants (text over silence,
+looping, canned hallucinations) and assert the clean one wins.
+
+This validates that the JUDGES detect what they're supposed to — the
+prerequisite for trusting a real (Tier B) tournament verdict. No subgen, no
+ground truth: synthetic speech_ranges stand in for the VAD pass.
+"""
+from __future__ import annotations
+
+
+def _t():
+    from subarr import tournament as t
+    return t
+
+
+# Clean, speech-aligned dialogue across the whole 6s clip.
+CLEAN = (
+    "1\n00:00:00,000 --> 00:00:02,000\nWhere are you going tonight?\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nI'm meeting a friend downtown.\n\n"
+    "3\n00:00:04,000 --> 00:00:06,000\nWe'll be back before midnight.\n"
+)
+SPEECH_FULL = [(0.0, 6.0)]
+
+
+def test_clean_beats_hallucination_over_silence():
+    t = _t()
+    # Canned phrases stamped over a clip that's almost entirely silent
+    # (speech only 0–0.5s) — the classic non-speech hallucination.
+    halluc = (
+        "1\n00:00:00,000 --> 00:00:02,000\nThank you for watching.\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nThank you for watching.\n\n"
+        "3\n00:00:04,000 --> 00:00:06,000\nSubtitles by amara.org\n"
+    )
+    res = t.run_tournament([
+        t.Entrant(label="halluc", srt_text=halluc, speech_ranges=[(0.0, 0.5)]),
+        t.Entrant(label="clean", srt_text=CLEAN, speech_ranges=SPEECH_FULL),
+    ])
+    assert res.winner_label == "clean"
+    halluc_card = next(s for s in res.scorecards if s.entrant_label == "halluc")
+    clean_card = next(s for s in res.scorecards if s.entrant_label == "clean")
+    assert clean_card.composite > halluc_card.composite
+
+
+def test_clean_beats_looping_decoder():
+    t = _t()
+    loop = ""
+    for i in range(1, 7):
+        loop += f"{i}\n00:00:0{i-1},000 --> 00:00:0{i},000\nyou\n\n"
+    res = t.run_tournament([
+        t.Entrant(label="loop", srt_text=loop, speech_ranges=SPEECH_FULL),
+        t.Entrant(label="clean", srt_text=CLEAN, speech_ranges=SPEECH_FULL),
+    ])
+    assert res.winner_label == "clean"
+
+
+def test_signals_surface_on_scorecard():
+    t = _t()
+    res = t.run_tournament([t.Entrant(label="only", srt_text=CLEAN, speech_ranges=SPEECH_FULL)])
+    sc = res.scorecards[0]
+    # the QE signals are exposed for inspection / the future arena UI
+    assert sc.signals is not None
+    assert "silence_text_ratio" in sc.signals
+    assert "repeated_line_ratio" in sc.signals
+    assert "canned_phrase_hits" in sc.signals

--- a/tests/test_transcript_signals.py
+++ b/tests/test_transcript_signals.py
@@ -1,0 +1,91 @@
+"""#65 — reference-free transcript quality signals (the tournament's real
+discriminators, per the research synthesis on #65).
+
+These need no ground truth: they flag the failure modes Whisper configs
+diverge on — text over silence (hallucination), looping repetition, canned
+"thanks for watching"-style phrases. The hallucination signal rides on the
+silero speech ranges from #111.
+
+Tests pin behaviour (a clean cue scores ~0, a hallucinated/looping one scores
+high), not exact magnitudes.
+"""
+from __future__ import annotations
+
+
+def _sig():
+    from subarr import transcript_signals as s
+    return s
+
+
+def _cues(srt):
+    from subarr.subtitle_readability import parse_srt
+    return parse_srt(srt)
+
+
+# --- silence_text_ratio: fraction of cue time with no underlying speech ---
+
+def test_silence_text_ratio_zero_when_cues_sit_in_speech():
+    s = _sig()
+    cues = _cues("1\n00:00:00,000 --> 00:00:02,000\nreal dialogue\n")
+    # speech covers the whole cue → not hallucinated
+    assert s.silence_text_ratio(cues, [(0.0, 2.0)]) == 0.0
+
+
+def test_silence_text_ratio_one_when_text_over_silence():
+    s = _sig()
+    cues = _cues("1\n00:00:10,000 --> 00:00:12,000\nThank you for watching\n")
+    # speech is elsewhere; the cue sits entirely in a silent span → hallucination
+    assert s.silence_text_ratio(cues, [(0.0, 2.0)]) == 1.0
+
+
+def test_silence_text_ratio_partial_overlap():
+    s = _sig()
+    cues = _cues("1\n00:00:00,000 --> 00:00:04,000\nhalf over silence\n")
+    # 2s of the 4s cue overlaps speech → 0.5 outside
+    assert abs(s.silence_text_ratio(cues, [(0.0, 2.0)]) - 0.5) < 1e-6
+
+
+def test_silence_text_ratio_no_speech_data_returns_zero():
+    s = _sig()
+    cues = _cues("1\n00:00:00,000 --> 00:00:02,000\nx\n")
+    # no VAD ranges → can't judge → 0.0 (don't penalize on missing data)
+    assert s.silence_text_ratio(cues, None) == 0.0
+    assert s.silence_text_ratio(cues, []) == 0.0
+
+
+# --- repeated_line_ratio: looping / stuck-decoder detection ----------------
+
+def test_repeated_line_ratio_flags_loops():
+    s = _sig()
+    srt = ""
+    for i in range(1, 6):
+        srt += f"{i}\n00:00:0{i-1},000 --> 00:00:0{i},000\nyou\n\n"
+    # 5 identical lines → highly repetitive
+    assert s.repeated_line_ratio(_cues(srt)) >= 0.7
+
+
+def test_repeated_line_ratio_low_for_varied_dialogue():
+    s = _sig()
+    srt = (
+        "1\n00:00:00,000 --> 00:00:02,000\nWhere are you going?\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nTo the market.\n\n"
+        "3\n00:00:04,000 --> 00:00:06,000\nI'll come with you.\n"
+    )
+    assert s.repeated_line_ratio(_cues(srt)) < 0.4
+
+
+# --- canned_phrase_hits: known non-speech hallucination phrases ------------
+
+def test_canned_phrase_hits_detects_known_phrases():
+    s = _sig()
+    srt = (
+        "1\n00:00:00,000 --> 00:00:02,000\nThanks for watching!\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nSubtitles by amara.org\n"
+    )
+    assert s.canned_phrase_hits(_cues(srt)) >= 2
+
+
+def test_canned_phrase_hits_zero_for_real_dialogue():
+    s = _sig()
+    cues = _cues("1\n00:00:00,000 --> 00:00:02,000\nThe reactor is overheating.\n")
+    assert s.canned_phrase_hits(cues) == 0


### PR DESCRIPTION
**The unblocked scoring HEART of the tournament. Stacked on #108 (#92) — review/merge that first; this rebases clean onto main after.**

Given several config `Entrant`s (each a candidate SRT for the same source), `run_tournament()` judges each and ranks best-first:
- **SRT integrity** gate — no parseable cues = disqualified (catches a config that produces garbage).
- **Readability** (reuses #92) — the dominant score.
- **Speed** — tiebreak.
- **QE (#94)** — documented hook, wire when the experiment lands.

Rubric weights/penalties are **clearly marked TUNABLE** — 13 tests pin the *behaviour* (clean beats sloppy, broken disqualified, faster wins a tie), not the weights. That's your call to shape (see the design blueprint on #65).

⛔ The **arena** (live per-variant generation) + **adoption** are blocked on **#88**. This layer isn't.

Refs #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)