### PR TITLE
Tier-B tournament harness — rank real candidate SRTs (#65)

### DIFF
--- a/src/subarr/tournament_harness.py
+++ b/src/subarr/tournament_harness.py
@@ -1,0 +1,89 @@
+"""#65 — Tier-B tournament harness.
+
+Turns the validated judge (`tournament.run_tournament`) into a runnable
+comparison over REAL candidate SRTs for one source clip. Candidates can come
+from anywhere — a subgen config sweep, existing library subtitles, whatever —
+the harness just judges and ranks them, optionally using the clip's silero
+VAD speech ranges (#111) so the text-over-silence hallucination judge fires.
+
+CLI:
+    python -m subarr.tournament_harness --srt-dir ./candidates \
+        [--speech-ranges ranges.json]   # JSON: [[start,end], ...]
+
+Each *.srt in the dir is one entrant (labelled by filename stem). Prints a
+ranked scorecard with the QE signals that decided it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .tournament import Entrant, TournamentResult, run_tournament
+
+
+def judge_candidates(
+    candidates: dict[str, str],
+    speech_ranges: list[tuple[float, float]] | None = None,
+    gen_times: dict[str, float] | None = None,
+) -> TournamentResult:
+    """Rank candidate SRTs (label → srt_text) with the validated judge."""
+    gen_times = gen_times or {}
+    entrants = [
+        Entrant(
+            label=label, srt_text=srt,
+            speech_ranges=speech_ranges, gen_time_s=gen_times.get(label),
+        )
+        for label, srt in candidates.items()
+    ]
+    return run_tournament(entrants)
+
+
+def load_candidates(srt_dir) -> dict[str, str]:
+    """Load every *.srt in a directory, labelled by filename stem."""
+    d = Path(srt_dir)
+    return {
+        p.stem: p.read_text(encoding="utf-8", errors="replace")
+        for p in sorted(d.glob("*.srt"))
+    }
+
+
+def format_result(result: TournamentResult) -> str:
+    lines = [
+        f"WINNER: {result.winner_label or '(none — all disqualified)'}",
+        "",
+        f"{'rank':<5}{'entrant':<24}{'composite':>10}   signals",
+        "-" * 72,
+    ]
+    for i, sc in enumerate(result.scorecards, 1):
+        sig = sc.signals or {}
+        sigtxt = (
+            f"silence={sig.get('silence_text_ratio', '-')} "
+            f"repeat={sig.get('repeated_line_ratio', '-')} "
+            f"canned={sig.get('canned_phrase_hits', '-')}"
+        )
+        flag = "  [DISQUALIFIED]" if sc.disqualified else ""
+        lines.append(f"{i:<5}{sc.entrant_label:<24}{sc.composite:>10.2f}   {sigtxt}{flag}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Tier-B tournament: rank candidate SRTs for one clip.")
+    ap.add_argument("--srt-dir", required=True, help="directory of candidate *.srt files")
+    ap.add_argument("--speech-ranges", help="JSON file of [[start,end],...] VAD speech ranges (s)")
+    args = ap.parse_args(argv)
+
+    candidates = load_candidates(args.srt_dir)
+    if not candidates:
+        print(f"No *.srt candidates found in {args.srt_dir}")
+        return 1
+    ranges = None
+    if args.speech_ranges:
+        ranges = [tuple(r) for r in json.loads(Path(args.speech_ranges).read_text("utf-8"))]
+    result = judge_candidates(candidates, speech_ranges=ranges)
+    print(format_result(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tournament_harness.py
+++ b/tests/test_tournament_harness.py
@@ -1,0 +1,63 @@
+"""#65 Tier-B harness — judge REAL candidate SRTs for one source clip.
+
+The reusable core: given candidate SRTs (however produced — subgen config
+sweep, existing library subs, etc.) + the clip's VAD speech ranges, rank them
+with the validated tournament judge and render a scorecard. This is what turns
+"we have a validated judge" into "we can run a real comparison".
+"""
+from __future__ import annotations
+
+
+def _h():
+    from subarr import tournament_harness as h
+    return h
+
+
+CLEAN = (
+    "1\n00:00:00,000 --> 00:00:02,000\nWhere are you going tonight?\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nI'm meeting a friend downtown.\n"
+)
+HALLUC = (
+    "1\n00:00:00,000 --> 00:00:02,000\nThank you for watching.\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nThank you for watching.\n"
+)
+
+
+def test_judge_candidates_ranks_and_picks_winner():
+    h = _h()
+    result = h.judge_candidates(
+        {"clean": CLEAN, "halluc": HALLUC},
+        speech_ranges=[(0.0, 4.0)],
+    )
+    assert result.winner_label == "clean"
+    assert [s.entrant_label for s in result.scorecards][0] == "clean"
+
+
+def test_judge_candidates_threads_gen_times_for_tiebreak():
+    h = _h()
+    # identical output → speed breaks the tie
+    result = h.judge_candidates(
+        {"slow": CLEAN, "fast": CLEAN},
+        speech_ranges=[(0.0, 4.0)],
+        gen_times={"slow": 100.0, "fast": 10.0},
+    )
+    assert result.winner_label == "fast"
+
+
+def test_load_candidates_reads_srt_files(tmp_path):
+    h = _h()
+    (tmp_path / "default.srt").write_text(CLEAN, encoding="utf-8")
+    (tmp_path / "noisy_robust.srt").write_text(HALLUC, encoding="utf-8")
+    cands = h.load_candidates(tmp_path)
+    assert set(cands.keys()) == {"default", "noisy_robust"}
+    assert cands["default"] == CLEAN
+
+
+def test_format_result_shows_winner_and_signals():
+    h = _h()
+    result = h.judge_candidates({"clean": CLEAN, "halluc": HALLUC}, speech_ranges=[(0.0, 4.0)])
+    text = h.format_result(result)
+    assert "clean" in text and "halluc" in text
+    assert "WINNER" in text.upper()
+    # the QE signals that decided it are visible
+    assert "silence" in text.lower()


### PR DESCRIPTION
Follow-up to #109/#113 (now both on main). Adds the runnable Tier-B comparison entry point on top of the validated judge.

- `tournament_harness.judge_candidates(label→srt, speech_ranges, gen_times)` → ranked `TournamentResult`
- `load_candidates(dir)` — one entrant per `*.srt`
- `format_result()` — scorecard with the QE signals that decided it
- CLI: `python -m subarr.tournament_harness --srt-dir DIR [--speech-ranges ranges.json]`

Demonstrated end-to-end: clean=100 (winner), looping=25 (repeat 0.75 caught), canned-hallucination=0 (canned 3 caught). Candidates can come from a subgen config sweep or existing library subs.

4 tests; needs the VAD (#113) + tournament (#109) work that just landed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)