### PR TITLE
fix(tournament): QE-primary rubric so good fast-dialogue subs aren't floored

### DIFF
--- a/src/subarr/tournament.py
+++ b/src/subarr/tournament.py
@@ -36,8 +36,17 @@ from .transcript_signals import (
 # --- v1 proposed rubric (TUNABLE) ---------------------------------------
 CRITICAL_PENALTY = 2.0   # weight of a 'critical' readability issue
 WARN_PENALTY = 1.0       # weight of a 'warn' readability issue
-QUALITY_WEIGHT = 0.85    # quality (readability − QE penalties) vs speed
+QUALITY_WEIGHT = 0.85    # quality (100 − QE − readability penalties) vs speed
 SPEED_WEIGHT = 0.15
+
+# Readability is the SECONDARY judge (#65 research: QE signals are the real
+# discriminators; readability is advisory). It can shave at most
+# READABILITY_CAP points off an otherwise-good transcript — never floor it.
+# Tier-B 2026-06-04 showed the old "readability IS the base" rubric scored
+# accurate, speech-aligned transcripts of rapid dialogue at ~0 (high CPS trips
+# the linter), masking the QE signals that decide a tournament.
+READABILITY_K = 25.0     # readability penalty = load_per_cue × K …
+READABILITY_CAP = 20.0   # … capped here so readability stays secondary
 
 # QE (reference-free) penalties — the real discriminators (#65 research). A
 # quality score starts from readability (0-100) and these subtract from it, so
@@ -81,15 +90,21 @@ class TournamentResult:
     winner_label: str | None
 
 
-def _readability_score(report: ReadabilityReport) -> float:
-    """0-100. Penalise issues PER CUE so a config that produces more (or
-    longer) cues isn't unfairly punished — entrants share a source but
-    segment it differently, so absolute issue counts aren't comparable."""
+def _readability_load(report: ReadabilityReport) -> float:
+    """Issue load PER CUE so a config that produces more (or longer) cues
+    isn't unfairly punished — entrants share a source but segment it
+    differently, so absolute issue counts aren't comparable."""
     critical = sum(1 for i in report.issues if i.severity == "critical")
     warn = sum(1 for i in report.issues if i.severity == "warn")
     cues = max(report.cue_count, 1)
-    load_per_cue = (critical * CRITICAL_PENALTY + warn * WARN_PENALTY) / cues
-    return max(0.0, 100.0 - load_per_cue * 100.0)
+    return (critical * CRITICAL_PENALTY + warn * WARN_PENALTY) / cues
+
+
+def _readability_score(report: ReadabilityReport) -> float:
+    """0-100, for display on the scorecard. NOTE: this is informational only —
+    the composite uses a CAPPED readability *penalty* (see score_entrant), not
+    this score as its base. Kept so the UI can still show a readability grade."""
+    return max(0.0, 100.0 - _readability_load(report) * 100.0)
 
 
 def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scorecard:
@@ -104,9 +119,12 @@ def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scor
     report = analyze_srt(entrant.srt_text)
     r_score = _readability_score(report)
 
-    # Reference-free QE signals (#65): the real discriminators. Subtract them
-    # from the readability base so a hallucinating/looping entrant can't win
-    # on "readable" fabricated text.
+    # QE-PRIMARY scoring (#65 research). Quality starts at 100 and the
+    # reference-free QE signals — the real discriminators — subtract from it,
+    # so a hallucinating/looping/canned entrant tanks regardless of how
+    # "readable" its fabricated text is. Readability contributes only a CAPPED
+    # secondary penalty, so an accurate transcript of fast dialogue (high CPS)
+    # stays a high score instead of being floored.
     sil = silence_text_ratio(cues, entrant.speech_ranges)
     rep = repeated_line_ratio(cues)
     canned = canned_phrase_hits(cues)
@@ -115,7 +133,8 @@ def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scor
         + rep * REPEAT_PENALTY
         + min(canned, CANNED_CAP) * CANNED_PENALTY
     )
-    quality = max(0.0, r_score - qe_penalty)
+    readability_penalty = min(_readability_load(report) * READABILITY_K, READABILITY_CAP)
+    quality = max(0.0, 100.0 - qe_penalty - readability_penalty)
     signals = {
         "silence_text_ratio": round(sil, 4),
         "repeated_line_ratio": round(rep, 4),

--- a/tests/test_tournament_validation.py
+++ b/tests/test_tournament_validation.py
@@ -66,3 +66,58 @@ def test_signals_surface_on_scorecard():
     assert "silence_text_ratio" in sc.signals
     assert "repeated_line_ratio" in sc.signals
     assert "canned_phrase_hits" in sc.signals
+
+
+# Real, accurate, speech-aligned transcript of RAPID film dialogue: short cue
+# durations push CPS over the readability ceiling, but the text is correct and
+# the QE discriminators are all clean. (Lifted from the Tier-B 2026-06-04 run:
+# Air (2023) @1000s — every preset produced exactly this and the judge scored
+# it 0.00, masking the QE signals.)
+FAST_CLEAN = (
+    "1\n00:00:00,000 --> 00:00:00,740\nYou know what I do here.\n\n"
+    "2\n00:00:01,900 --> 00:00:03,040\nYou're losing, Sonny.\n\n"
+    "3\n00:00:03,060 --> 00:00:05,560\nJust because you lose doesn't mean it wasn't a good bet.\n\n"
+    "4\n00:00:05,940 --> 00:00:07,480\nThat perfect result is nonsense.\n\n"
+    "5\n00:00:07,720 --> 00:00:08,350\nIt is not nonsense.\n"
+)
+FAST_RANGES = [(0.0, 8.5)]
+
+
+def test_accurate_fast_dialogue_is_not_floored_by_readability():
+    """Tier-B bug (2026-06-04): an accurate, speech-aligned transcript of fast
+    dialogue scored ~0 purely because high CPS tripped the readability linter.
+    Readability is the SECONDARY judge (#65 research) — a transcript with no
+    hallucination, looping, or canned text must score as a GOOD result even
+    when its cues flash fast. It must not be floored."""
+    t = _t()
+    sc = t.run_tournament([
+        t.Entrant(label="fast_clean", srt_text=FAST_CLEAN, speech_ranges=FAST_RANGES),
+    ]).scorecards[0]
+    assert not sc.disqualified
+    # QE signals are clean — this is genuinely good output.
+    assert sc.signals["repeated_line_ratio"] == 0.0
+    assert sc.signals["canned_phrase_hits"] == 0
+    assert sc.signals["silence_text_ratio"] < 0.2
+    # ...so it must NOT be floored by readability alone.
+    assert sc.composite > 50, f"good fast-dialogue floored to {sc.composite}"
+
+
+def test_readability_is_secondary_to_qe():
+    """A QE-clean transcript with POOR readability (fast CPS) must outrank a
+    perfectly-readable transcript that is actually a hallucination over
+    silence. Pins the re-architecture: QE drives the score, readability is a
+    capped secondary penalty — not the dominant base that can floor everything."""
+    t = _t()
+    # well-timed, low-CPS cues (great readability) but canned text stamped over
+    # a clip that is almost entirely silent — the classic hallucination.
+    readable_halluc = (
+        "1\n00:00:00,000 --> 00:00:02,000\nThank you for watching.\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nPlease subscribe to the channel.\n\n"
+        "3\n00:00:04,000 --> 00:00:06,000\nSubtitles by amara.org\n"
+    )
+    res = t.run_tournament([
+        # readable hallucination listed FIRST so a naive tie resolves to it.
+        t.Entrant(label="readable_halluc", srt_text=readable_halluc, speech_ranges=[(0.0, 0.5)]),
+        t.Entrant(label="fast_clean", srt_text=FAST_CLEAN, speech_ranges=FAST_RANGES),
+    ])
+    assert res.winner_label == "fast_clean"


### PR DESCRIPTION
## What
Re-architects the #65 tournament rubric so the QE discriminators drive the composite and readability is a **capped secondary penalty**, not the dominant base.

## Why (found in Tier-B validation, 2026-06-04)
Running the judge on **real library clips**, accurate speech-aligned transcripts of rapid film dialogue scored **~0**. Cause:
- `quality = readability − qe_penalty` — readability was the base.
- `_readability_score = 100 − load_per_cue×100` floors to 0 at ~1 issue/cue, which is **normal for fast dialogue** (CPS over the readability ceiling).
- Once floored, the QE signals (silence-over-text, repetition, canned phrases — the research's *real* discriminators) became invisible.

This contradicts the #65 research conclusion: **readability is the secondary judge, not primary.**

## Fix
```
quality = max(0, 100 − qe_penalty − min(readability_penalty, READABILITY_CAP))
READABILITY_CAP = 20,  readability_penalty = load_per_cue × 25
```
Readability can shave at most 20 pts; QE drives the score. Integrity gate (no cues → DQ) and speed tiebreak unchanged. `_readability_score` retained for display.

## Result on the real clips
- `air_clean` (accurate, fast dialogue): **0.00 → 77.25**
- A looping Korean→English mistranslation still correctly ranks **last (5.10)** via the repeat + silence judges — ranking matches the ear.

## Tests
Two new validation tests pin the behaviour: (1) accurate fast-dialogue must not be floored (`composite > 50`); (2) a QE-clean transcript must outrank a perfectly-readable hallucination-over-silence. All existing behaviour tests still pass — **22 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)