### PR TITLE
feat(tournament): cross-config CONSENSUS judge (no-ground-truth pseudo-reference)

### DIFF
--- a/src/subarr/tournament.py
+++ b/src/subarr/tournament.py
@@ -23,7 +23,9 @@ contributor later.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+from itertools import combinations
 from typing import Any
 
 from .subtitle_readability import ReadabilityReport, analyze_srt, parse_srt
@@ -58,6 +60,18 @@ REPEAT_PENALTY = 100.0         # × fraction of duplicate lines (looping)
 CANNED_PENALTY = 40.0          # × canned-phrase cues (capped)
 CANNED_CAP = 3
 
+# CONSENSUS judge (#65) — the cross-config pseudo-reference. The per-entrant
+# judges above score each output in isolation, so they miss a fluent, well-formed
+# but DIVERGENT output (a unique mistranslation, or a hallucinated end-card no
+# other config produced). With ≥2 entrants on the SAME clip, agreement across
+# them stands in for ground truth: build a majority content-word vocabulary, then
+# score each entrant on precision (only says agreed things — low = divergence/
+# hallucination) and recall (covers the agreed content — low = dropout/loop
+# collapse). The penalty subtracts from the composite by (1 − f1). No ground
+# truth required; robust to translation wording/timing variance (content-word
+# sets, not cue alignment).
+CONSENSUS_PENALTY = 40.0   # × (1 − consensus F1)
+
 
 @dataclass
 class Entrant:
@@ -81,6 +95,7 @@ class Scorecard:
     gen_time_s: float | None
     readability: dict[str, Any] | None   # the #92 report.to_dict()
     signals: dict[str, Any] | None = None  # QE signals (silence/repeat/canned)
+    consensus: dict[str, Any] | None = None  # vs-majority precision/recall/f1
     notes: str = ""
 
 
@@ -88,6 +103,10 @@ class Scorecard:
 class TournamentResult:
     scorecards: list[Scorecard]           # ranked best-first
     winner_label: str | None
+    # mean pairwise content-word agreement across entrants (0-1). Low → the
+    # configs disagree about what was said → flag the clip for human review.
+    # None when fewer than 2 scorable entrants (no consensus possible).
+    clip_agreement: float | None = None
 
 
 def _readability_load(report: ReadabilityReport) -> float:
@@ -154,12 +173,80 @@ def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scor
     )
 
 
+_WORD = re.compile(r"[0-9a-z]+")
+
+
+def _content_tokens(srt_text: str) -> set[str]:
+    """Lower-cased word set from a candidate's cue text. Word SETS (not counts)
+    so a looped phrase doesn't inflate agreement — the repeat judge owns looping;
+    consensus is about WHICH words are agreed, not how often."""
+    return {w for cue in parse_srt(srt_text) for w in _WORD.findall(cue.text.lower())}
+
+
+def consensus_scores(
+    label_to_srt: dict[str, str],
+) -> tuple[dict[str, dict[str, float]], float | None]:
+    """Cross-config consensus (#65). Build a majority content-word vocabulary
+    (words present in > half the entrants), then score each entrant's precision
+    (its words that are agreed), recall (agreed words it covers), and F1 against
+    it. Also return clip-level agreement = mean pairwise Jaccard of the vocabs.
+
+    Needs ≥2 entrants; returns ({}, None) otherwise (no consensus possible)."""
+    if len(label_to_srt) < 2:
+        return {}, None
+    vocabs = {label: _content_tokens(srt) for label, srt in label_to_srt.items()}
+    n = len(vocabs)
+    threshold = n // 2 + 1            # strict majority; for n=2 → both must agree
+    doc_freq: dict[str, int] = {}
+    for v in vocabs.values():
+        for tok in v:
+            doc_freq[tok] = doc_freq.get(tok, 0) + 1
+    consensus_vocab = {tok for tok, c in doc_freq.items() if c >= threshold}
+
+    reports: dict[str, dict[str, float]] = {}
+    for label, v in vocabs.items():
+        agreed = len(v & consensus_vocab)
+        precision = agreed / len(v) if v else 0.0
+        recall = agreed / len(consensus_vocab) if consensus_vocab else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+        reports[label] = {
+            "precision": round(precision, 4),
+            "recall": round(recall, 4),
+            "f1": round(f1, 4),
+        }
+
+    # clip agreement: mean pairwise Jaccard of the vocabs (how much the configs
+    # say the same things at all).
+    pair_sims = []
+    for a, b in combinations(vocabs.values(), 2):
+        union = a | b
+        pair_sims.append(len(a & b) / len(union) if union else 0.0)
+    clip_agreement = round(sum(pair_sims) / len(pair_sims), 4) if pair_sims else None
+    return reports, clip_agreement
+
+
 def run_tournament(entrants: list[Entrant]) -> TournamentResult:
     if not entrants:
         return TournamentResult(scorecards=[], winner_label=None)
     times = [e.gen_time_s for e in entrants if e.gen_time_s]
     fastest = min(times) if times else None
     cards = [score_entrant(e, fastest_time_s=fastest) for e in entrants]
+
+    # CONSENSUS pass (#65): the cross-config pseudo-reference. Only scorable
+    # (non-disqualified) entrants form the consensus; the divergence penalty
+    # then subtracts from each composite by (1 − F1).
+    by_label = {e.label: e for e in entrants}
+    scorable = {c.entrant_label: by_label[c.entrant_label].srt_text
+                for c in cards if not c.disqualified}
+    reports, clip_agreement = consensus_scores(scorable)
+    for c in cards:
+        rep = reports.get(c.entrant_label)
+        if rep is None:
+            continue
+        c.consensus = rep
+        penalty = (1.0 - rep["f1"]) * CONSENSUS_PENALTY
+        c.composite = round(max(0.0, c.composite - penalty), 2)
+
     # Disqualified always last; otherwise composite desc, faster breaks ties.
     cards.sort(key=lambda c: (
         c.disqualified,
@@ -167,4 +254,6 @@ def run_tournament(entrants: list[Entrant]) -> TournamentResult:
         c.gen_time_s if c.gen_time_s is not None else float("inf"),
     ))
     winner = next((c.entrant_label for c in cards if not c.disqualified), None)
-    return TournamentResult(scorecards=cards, winner_label=winner)
+    return TournamentResult(
+        scorecards=cards, winner_label=winner, clip_agreement=clip_agreement,
+    )

--- a/tests/test_tournament_consensus.py
+++ b/tests/test_tournament_consensus.py
@@ -1,0 +1,116 @@
+"""#65 — cross-config CONSENSUS judge (the no-ground-truth pseudo-reference).
+
+The other judges score each entrant in isolation, so they can't catch a fluent,
+well-formed, but DIVERGENT output (e.g. a unique mistranslation or a hallucinated
+end-card no other config produced). The consensus judge uses the agreement ACROSS
+entrants as a pseudo-reference: build a majority vocabulary, then score each
+entrant on precision (does it only say agreed things?) and recall (does it cover
+the agreed content?). It also reports a clip-level agreement score so a tournament
+on genuinely ambiguous audio can be auto-flagged for human review.
+
+No ground truth: consensus IS the reference. Robust to translation wording/timing
+variance — it compares content-word sets, not cue alignment.
+"""
+from __future__ import annotations
+
+
+def _t():
+    from subarr import tournament as t
+    return t
+
+
+# Three configs agree on the content; a fourth adds a unique hallucinated
+# end-card (the "amara.org" failure) on top of the agreed content.
+AGREE_A = (
+    "1\n00:00:00,000 --> 00:00:02,000\nThe storm will last seventy two hours.\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nCivil protection issued precautionary rules.\n"
+)
+AGREE_B = (
+    "1\n00:00:00,000 --> 00:00:02,000\nThe storm lasts seventy two hours.\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nCivil protection has issued precautionary rules.\n"
+)
+AGREE_C = (
+    "1\n00:00:00,000 --> 00:00:02,000\nThe storm will last seventy two hours total.\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nProtection issued some precautionary rules.\n"
+)
+HALLUC_ENDCARD = (
+    "1\n00:00:00,000 --> 00:00:02,000\nThe storm will last seventy two hours.\n\n"
+    "2\n00:00:02,000 --> 00:00:04,000\nCivil protection issued precautionary rules.\n\n"
+    "3\n00:00:04,000 --> 00:00:06,000\nSubtitles by the Amara dot org community forever.\n"
+)
+
+
+def test_consensus_report_present_per_entrant_and_clip():
+    t = _t()
+    res = t.run_tournament([
+        t.Entrant(label="a", srt_text=AGREE_A),
+        t.Entrant(label="b", srt_text=AGREE_B),
+        t.Entrant(label="c", srt_text=AGREE_C),
+    ])
+    for sc in res.scorecards:
+        assert sc.consensus is not None
+        assert 0.0 <= sc.consensus["precision"] <= 1.0
+        assert 0.0 <= sc.consensus["recall"] <= 1.0
+        assert 0.0 <= sc.consensus["f1"] <= 1.0
+    # clip-level agreement is exposed for the human-review flag
+    assert res.clip_agreement is not None
+    assert 0.0 <= res.clip_agreement <= 1.0
+
+
+def test_divergent_hallucination_scores_lower_consensus_precision():
+    """An entrant that adds content no other config agrees on (a hallucinated
+    end-card) must have LOWER consensus precision than the agreeing entrants."""
+    t = _t()
+    res = t.run_tournament([
+        t.Entrant(label="agree_a", srt_text=AGREE_A),
+        t.Entrant(label="agree_b", srt_text=AGREE_B),
+        t.Entrant(label="halluc", srt_text=HALLUC_ENDCARD),
+    ])
+    cards = {sc.entrant_label: sc for sc in res.scorecards}
+    assert cards["halluc"].consensus["precision"] < cards["agree_a"].consensus["precision"]
+    # ...and the agreeing entrant must outrank the diverging hallucination
+    assert res.winner_label in ("agree_a", "agree_b")
+    assert cards["halluc"].composite < cards["agree_a"].composite
+
+
+def test_dropout_scores_lower_consensus_recall():
+    """An entrant that drops most of the agreed content (looped/collapsed to a
+    couple of words) must have LOWER consensus recall than the full ones."""
+    t = _t()
+    dropout = "1\n00:00:00,000 --> 00:00:04,000\nstorm storm\n"
+    res = t.run_tournament([
+        t.Entrant(label="full_a", srt_text=AGREE_A),
+        t.Entrant(label="full_b", srt_text=AGREE_B),
+        t.Entrant(label="dropout", srt_text=dropout),
+    ])
+    cards = {sc.entrant_label: sc for sc in res.scorecards}
+    assert cards["dropout"].consensus["recall"] < cards["full_a"].consensus["recall"]
+
+
+def test_high_agreement_clip_flagged_higher_than_divergent_clip():
+    """The clip-level agreement score must be higher when entrants say the same
+    thing than when they wildly diverge (the human-review flag)."""
+    t = _t()
+    agree = t.run_tournament([
+        t.Entrant(label="a", srt_text=AGREE_A),
+        t.Entrant(label="b", srt_text=AGREE_B),
+        t.Entrant(label="c", srt_text=AGREE_C),
+    ])
+    diverge = t.run_tournament([
+        t.Entrant(label="x", srt_text="1\n00:00:00,000 --> 00:00:02,000\napple orchard harvest\n"),
+        t.Entrant(label="y", srt_text="1\n00:00:00,000 --> 00:00:02,000\nsubmarine periscope depth\n"),
+        t.Entrant(label="z", srt_text="1\n00:00:00,000 --> 00:00:02,000\nviolin concerto tempo\n"),
+    ])
+    assert agree.clip_agreement > diverge.clip_agreement
+
+
+def test_single_entrant_has_no_consensus_penalty():
+    """With one entrant there is no consensus to form — it must not be penalised,
+    and clip_agreement is undefined (None)."""
+    t = _t()
+    res = t.run_tournament([t.Entrant(label="only", srt_text=AGREE_A)])
+    sc = res.scorecards[0]
+    assert res.clip_agreement is None
+    # composite must equal the pre-consensus quality path (no consensus penalty);
+    # we assert it's not dragged down by a phantom consensus miss.
+    assert sc.composite > 50


### PR DESCRIPTION
**Stacked on #120** (base = `fix/tournament-readability-flooring`; retarget to `main` once #120 merges).

## What
Adds the cross-config **consensus judge** — the piece that turns agreement *across* entrants into a pseudo-reference, so the tournament can rank *faithfulness*, not just well-formedness.

## Why
The per-entrant judges (readability + silence/repeat/canned QE) score each output in isolation. They can't catch a fluent, well-formed but **divergent** output — a unique mistranslation, or a hallucinated end-card no other config produced. Tier-B validation (2026-06-04) hit this wall: with no ground truth we could rank well-formedness but not faithfulness, and n=3 showed per-clip winners flip within a language (well-formedness alone is noisy at the top).

## How
With ≥2 entrants on one clip, build a **majority content-word vocabulary**, then score each entrant:
- **precision** — its words that are agreed (low = divergence / hallucination)
- **recall** — agreed words it covers (low = dropout / loop-collapse)
- **f1** — composite; penalty subtracts `(1 − f1) × CONSENSUS_PENALTY` (40).
- **`clip_agreement`** (new `TournamentResult` field) — mean pairwise content-word Jaccard; low → configs disagree about what was said → **auto-flag the clip for human review**.

Bag-of-content-words, not cue alignment → robust to translation wording/timing variance. Needs no ground truth.

## Validated on real round-1 data
- `clip_agreement`: **0.88 / 0.85 / 0.86 / 0.94** (FR/DE/ES/EN, trustworthy) vs **0.33 on Korean** → correctly flags the clip where configs wildly disagree.
- Catches the ES **"Amara.org" hallucination** (precision 0.81 → tanked) and the KO `clean_film`/`terse` **loop-collapse** (recall 0.375 / 0.21 → tanked).
- On easy clips F1 ≈ 1.0 → small penalties, rankings preserved with confidence.

## Tests
5 new consensus tests (divergent-hallucination → lower precision; dropout → lower recall; clip-agreement flag; single-entrant no-penalty). **27 tournament tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)