### PR TITLE
feat(tournament): speech-coverage judge — penalise incomplete subs

### DIFF
--- a/src/subarr/tournament.py
+++ b/src/subarr/tournament.py
@@ -33,6 +33,7 @@ from .transcript_signals import (
     canned_phrase_hits,
     repeated_line_ratio,
     silence_text_ratio,
+    uncovered_speech_ratio,
 )
 
 # --- v1 proposed rubric (TUNABLE) ---------------------------------------
@@ -59,6 +60,10 @@ SILENCE_TEXT_PENALTY = 100.0   # × fraction of text over silence (hallucination
 REPEAT_PENALTY = 100.0         # × fraction of duplicate lines (looping)
 CANNED_PENALTY = 40.0          # × canned-phrase cues (capped)
 CANNED_CAP = 3
+# Base-camp completeness: speech with no subtitle (dropped dialogue). Weighted
+# below the catastrophic-failure tier (silence/repeat = 100) but high enough to
+# stop an incomplete sub from winning — an incomplete sub is a journey defect.
+COVERAGE_PENALTY = 50.0        # × fraction of speech left unsubtitled
 
 # CONSENSUS judge (#65) — the cross-config pseudo-reference. The per-entrant
 # judges above score each output in isolation, so they miss a fluent, well-formed
@@ -147,10 +152,17 @@ def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scor
     sil = silence_text_ratio(cues, entrant.speech_ranges)
     rep = repeated_line_ratio(cues)
     canned = canned_phrase_hits(cues)
+    # Base-camp COMPLETENESS (#65): speech left without a subtitle = dropped
+    # dialogue = an incomplete sub. The complement of silence_text_ratio, and
+    # the fix for the terseness artifact (Tier-B 2026-06-04: the judge rewarded
+    # short outputs that omit dialogue; chrF-vs-pro-reference showed those are
+    # LESS faithful). Only fires when VAD speech_ranges are supplied.
+    uncov = uncovered_speech_ratio(cues, entrant.speech_ranges)
     qe_penalty = (
         sil * SILENCE_TEXT_PENALTY
         + rep * REPEAT_PENALTY
         + min(canned, CANNED_CAP) * CANNED_PENALTY
+        + uncov * COVERAGE_PENALTY
     )
     readability_penalty = min(_readability_load(report) * READABILITY_K, READABILITY_CAP)
     quality = max(0.0, 100.0 - qe_penalty - readability_penalty)
@@ -158,6 +170,7 @@ def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scor
         "silence_text_ratio": round(sil, 4),
         "repeated_line_ratio": round(rep, 4),
         "canned_phrase_hits": canned,
+        "uncovered_speech_ratio": round(uncov, 4),
     }
 
     if entrant.gen_time_s and fastest_time_s and entrant.gen_time_s > 0:

--- a/src/subarr/transcript_signals.py
+++ b/src/subarr/transcript_signals.py
@@ -64,6 +64,33 @@ def silence_text_ratio(cues, speech_ranges) -> float:
     return outside / total if total > 0 else 0.0
 
 
+def uncovered_speech_ratio(cues, speech_ranges) -> float:
+    """Fraction of total SPEECH time that has NO cue overlapping it — i.e.
+    detected dialogue left WITHOUT a subtitle (an incomplete sub). The base-camp
+    complement of silence_text_ratio: that flags text over silence
+    (hallucination), this flags silence-of-text over speech (dropped dialogue).
+    A terse/truncated output that omits cues scores high here. 0.0 when there's
+    no speech data (don't penalize on missing VAD)."""
+    if not speech_ranges:
+        return 0.0
+    total = 0.0
+    covered = 0.0
+    spans = [(c.start_ms / 1000.0, c.end_ms / 1000.0) for c in cues]
+    for s, e in speech_ranges:
+        dur = e - s
+        if dur <= 0:
+            continue
+        total += dur
+        for cs, ce in spans:
+            lo = max(s, cs)
+            hi = min(e, ce)
+            if hi > lo:
+                covered += hi - lo
+    if total <= 0:
+        return 0.0
+    return max(0.0, (total - min(covered, total)) / total)
+
+
 def repeated_line_ratio(cues) -> float:
     """Fraction of cue lines that are duplicates of an earlier line. A stuck
     decoder repeats the same phrase; varied dialogue scores near 0."""

--- a/tests/test_tournament_validation.py
+++ b/tests/test_tournament_validation.py
@@ -121,3 +121,22 @@ def test_readability_is_secondary_to_qe():
         t.Entrant(label="fast_clean", srt_text=FAST_CLEAN, speech_ranges=FAST_RANGES),
     ])
     assert res.winner_label == "fast_clean"
+
+
+def test_incomplete_sub_penalised_for_uncovered_speech():
+    """Base-camp completeness (#65, Judd's 'cover the dialogue first'): a clean
+    but TRUNCATED sub that leaves most of the speech unsubtitled must score
+    lower than one that covers the whole clip. This is what kills the terseness
+    artifact — dropping dialogue is a defect even when what's written is clean.
+    Scored at the entrant level so consensus isn't involved."""
+    t = _t()
+    ranges = [(0.0, 6.0)]
+    complete = t.score_entrant(t.Entrant(label="complete", speech_ranges=ranges, srt_text=(
+        "1\n00:00:00,000 --> 00:00:02,000\nWhere are you going tonight?\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nI am meeting a friend downtown.\n\n"
+        "3\n00:00:04,000 --> 00:00:06,000\nWe will be back before midnight.\n")))
+    truncated = t.score_entrant(t.Entrant(label="truncated", speech_ranges=ranges, srt_text=(
+        "1\n00:00:00,000 --> 00:00:02,000\nWhere are you going tonight?\n")))
+    assert truncated.signals["uncovered_speech_ratio"] > 0.5
+    assert complete.signals["uncovered_speech_ratio"] < 0.1
+    assert complete.composite > truncated.composite

--- a/tests/test_transcript_signals.py
+++ b/tests/test_transcript_signals.py
@@ -38,6 +38,34 @@ def test_silence_text_ratio_one_when_text_over_silence():
     assert s.silence_text_ratio(cues, [(0.0, 2.0)]) == 1.0
 
 
+# --- uncovered_speech_ratio: speech that has NO subtitle (incomplete sub) ---
+# The base-camp complement of silence_text_ratio: a sub that drops dialogue
+# leaves speech unsubtitled. A terse/truncated output that captures fewer cues
+# scores high here (incomplete), even if everything it DID write is clean.
+
+def test_uncovered_speech_ratio_zero_when_speech_fully_subtitled():
+    s = _sig()
+    cues = _cues("1\n00:00:00,000 --> 00:00:06,000\nfull dialogue across the clip\n")
+    assert s.uncovered_speech_ratio(cues, [(0.0, 6.0)]) == 0.0
+
+
+def test_uncovered_speech_ratio_high_when_dialogue_dropped():
+    s = _sig()
+    # speech spans 0-6s but the sub only covers the first 2s → 4s of dialogue
+    # left with no subtitle (an incomplete sub) → ~0.67 uncovered.
+    cues = _cues("1\n00:00:00,000 --> 00:00:02,000\nonly the start\n")
+    r = s.uncovered_speech_ratio(cues, [(0.0, 6.0)])
+    assert 0.6 < r < 0.72
+
+
+def test_uncovered_speech_ratio_zero_without_speech_data():
+    s = _sig()
+    cues = _cues("1\n00:00:00,000 --> 00:00:02,000\nhi\n")
+    # no VAD → don't penalize (mirrors silence_text_ratio)
+    assert s.uncovered_speech_ratio(cues, None) == 0.0
+    assert s.uncovered_speech_ratio(cues, []) == 0.0
+
+
 def test_silence_text_ratio_partial_overlap():
     s = _sig()
     cues = _cues("1\n00:00:00,000 --> 00:00:04,000\nhalf over silence\n")


### PR DESCRIPTION
## What
Adds **`uncovered_speech_ratio`** — the symmetric complement of `silence_text_ratio`:
- `silence_text_ratio` → subtitle text where there's **no speech** (hallucination)
- `uncovered_speech_ratio` → **speech with no subtitle** (dropped dialogue / incomplete sub)

Wired into the composite as a QE penalty (`COVERAGE_PENALTY=50`, below the catastrophic-failure tier). Fires only when VAD `speech_ranges` are supplied.

## Why — the base-camp priority
The reference-based accuracy validation (chrF vs the films' **official embedded English subtitles**, DE/ES/ZH, 150 points) found the judge was crowning **`terse`** — but `terse` is short because it **drops dialogue**, and chrF ranked it near-bottom for faithfulness. The judge was *rewarding incomplete subs*. An incomplete sub is a structural defect regardless of translation accuracy, so this fixes it at the base-camp level (cover the dialogue first; perfect accuracy is the summit / a future QE model, #94).

## Re-validated against the chrF harness (DE/ES/ZH)
- **Spearman(composite, chrF): 0.333 → 0.456**
- **ES**: judge-best now == chrF-best (`base`)
- Terseness artifact reduced. DE (sparse German speech) + ZH (all configs chrF≈20, uniformly poor) remain hard — the real accuracy ceiling needs an adequacy/QE model; this PR is the base-camp completeness fix, not the summit.

## Tests (31 green, no regressions)
- 3 signal tests: full-coverage → 0; dropped-dialogue → high; no-VAD → 0 (don't penalize without VAD).
- 1 tournament test: a clean-but-truncated sub scores below a complete one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)