### PR TITLE
feat(backfill): throttled library-backfill selection core (#116) — core only, wiring pending

### DIFF
--- a/src/subarr/backfill.py
+++ b/src/subarr/backfill.py
@@ -1,0 +1,48 @@
+"""#116 — throttled library backfill (selection/throttle CORE).
+
+Borrowed from Sonarr_Backfiller: instead of dumping the whole subtitle-gap
+backlog into subgen at once (and flooding the GPU), trickle it — keep subgen's
+queue topped up to a target depth, adding a bounded batch each tick. On a big
+library this is the difference between a 500-job stampede and steadily closing
+gaps in the background.
+
+This module is the PURE decision math — given the eligible gap backlog, the
+current queue depth, and the config, decide what to enqueue NOW. It does no
+I/O, holds no state, and couples to nothing, so it's fully unit-tested.
+
+WIRING (the documented next step, NOT built here — needs care + live tests):
+  - eligibility: pull gaps from the coverage cache, filtered to probe-VERIFIED
+    gaps only (never raw Bazarr-wanted) and past the settle-window (#117);
+    order them (oldest? Tautulli-popularity? user-pickable).
+  - queue depth: read subgen's live queue length (SubgenClient.queue()).
+  - tick: call select_backfill_batch() on the scheduler cadence, enqueue the
+    returned gaps, surface progress ("backfilling: N gaps, M in flight").
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BackfillConfig:
+    # Default OFF — backfill never runs unless the user opts in. (Even when on,
+    # the caller must still only feed VERIFIED gaps; see module docstring.)
+    enabled: bool = False
+    # Hold subgen's queue at this depth — the throttle that prevents a stampede.
+    target_queue_depth: int = 3
+    # Max gaps to enqueue per tick when below target (smooths bursty draining).
+    batch: int = 5
+
+
+def select_backfill_batch(gaps, queue_depth: int, config: BackfillConfig) -> list:
+    """Return the slice of ``gaps`` to enqueue right now, bounded so the queue
+    never overfills past ``target_queue_depth`` and never grows by more than
+    ``batch`` in one tick. Pure: ``gaps`` is the caller's pre-filtered, ordered
+    eligible backlog; the return is its front slice."""
+    if not config.enabled:
+        return []
+    headroom = config.target_queue_depth - queue_depth
+    if headroom <= 0:
+        return []
+    n = min(headroom, config.batch, len(gaps))
+    return list(gaps[:n])

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,67 @@
+"""#116 — throttled library-backfill: the selection/throttle CORE.
+
+Borrowed from Sonarr_Backfiller's queue-depth throttle: drain the verified
+coverage-gap backlog gently, holding subgen's queue at a target depth instead
+of dumping the whole backlog at once.
+
+This pins the PURE decision math (which gaps to enqueue NOW). The integration
+— reading the live subgen queue depth, pulling the eligible (verified +
+settle-window-passed) gaps, and ticking on the scheduler — is the documented
+next step, deliberately NOT built here.
+"""
+from __future__ import annotations
+
+
+def _bf():
+    from subarr import backfill
+    return backfill
+
+
+def _cfg(**kw):
+    bf = _bf()
+    return bf.BackfillConfig(**{"enabled": True, "target_queue_depth": 3, "batch": 5, **kw})
+
+
+GAPS = [f"gap{i}" for i in range(10)]
+
+
+def test_disabled_selects_nothing():
+    bf = _bf()
+    assert bf.select_backfill_batch(GAPS, queue_depth=0, config=_cfg(enabled=False)) == []
+
+
+def test_queue_at_or_above_target_selects_nothing():
+    bf = _bf()
+    assert bf.select_backfill_batch(GAPS, queue_depth=3, config=_cfg(target_queue_depth=3)) == []
+    assert bf.select_backfill_batch(GAPS, queue_depth=5, config=_cfg(target_queue_depth=3)) == []
+
+
+def test_fills_headroom_up_to_target():
+    bf = _bf()
+    # target 3, queue 1 → headroom 2 → enqueue 2 (batch 5 not the limit)
+    out = bf.select_backfill_batch(GAPS, queue_depth=1, config=_cfg(target_queue_depth=3, batch=5))
+    assert out == ["gap0", "gap1"]
+
+
+def test_batch_caps_a_large_headroom():
+    bf = _bf()
+    # target 20, queue 0 → headroom 20, but batch 4 caps it
+    out = bf.select_backfill_batch(GAPS, queue_depth=0, config=_cfg(target_queue_depth=20, batch=4))
+    assert out == ["gap0", "gap1", "gap2", "gap3"]
+
+
+def test_never_exceeds_available_gaps():
+    bf = _bf()
+    out = bf.select_backfill_batch(["only0", "only1"], queue_depth=0, config=_cfg(target_queue_depth=10, batch=10))
+    assert out == ["only0", "only1"]
+
+
+def test_empty_backlog_selects_nothing():
+    bf = _bf()
+    assert bf.select_backfill_batch([], queue_depth=0, config=_cfg()) == []
+
+
+def test_config_defaults_are_safe_off():
+    bf = _bf()
+    # default config must be DISABLED — backfill never runs unless opted in
+    assert bf.BackfillConfig().enabled is False


### PR DESCRIPTION
Closes part of #116. The **pure selection/throttle core** of the throttled library-backfill (Sonarr_Backfiller borrow): `select_backfill_batch(gaps, queue_depth, config)` returns the bounded slice to enqueue now — never overfills past `target_queue_depth`, never exceeds `batch`, default DISABLED. 7 tests.

**Core only by design.** The integration (verified-gap eligibility + settle-window, live subgen queue-depth read, scheduler tick) touches the live queue path, so I left it for review rather than building it unattended. Module docstring spells out the wiring plan.

Built overnight on Judd's go-ahead. Marquee v1.1 borrow; the tested heart is here, the wiring is a reviewed follow-up.