### PR TITLE
feat(tournament): QE/adequacy judge — accuracy-grade summit (#123)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,14 @@ vad = [
     "onnxruntime>=1.16,<2.0",
     "numpy>=1.24,<3.0",
 ]
+# #123: QE/adequacy judge (the tournament summit). LaBSE cross-lingual
+# embeddings via sentence-transformers; validated rho=0.727 vs true accuracy.
+# DELIBERATELY NOT baked into the image (unlike [vad]) — sentence-transformers
+# pulls torch (~2GB). Pure opt-in for now; an onnx-lean LaBSE backend (drop the
+# torch weight, bakeable like silero) is the tracked follow-up optimization.
+qe = [
+    "sentence-transformers>=2.2,<6.0",
+]
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/src/subarr/qe.py
+++ b/src/subarr/qe.py
@@ -1,0 +1,82 @@
+"""#123 — reference-free QE / adequacy judge for the tournament.
+
+Validated in the Tier-B spike: LaBSE cross-lingual cosine(source_text,
+english_hypothesis) correlates **rho = 0.727** with true translation accuracy
+(chrF vs professional reference) — vs the structural judge's 0.41. This is the
+accuracy-grade signal that lets the tournament rank GOOD translations by
+faithfulness, not just catch structural defects (hallucination/looping/etc).
+
+Split mirrors vad.py:
+  - cosine_similarity / qe_adequacy: PURE scoring, fully unit-tested (embedder
+    injectable).
+  - the LaBSE embedder I/O sits behind qe_available(); opt-in dep, live-verified.
+
+Opt-in like the silero VAD extra. When the embedder is unavailable, qe_adequacy
+returns None and the tournament composite falls back to the structural judge
+(no penalty). The default backend is sentence-transformers/LaBSE; an onnx-lean
+packaging (drop the torch weight) is a tracked follow-up.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+# LaBSE model id; overridable for a pinned local copy / onnx swap.
+_MODEL_ENV = "SUBARR_QE_MODEL"
+QE_MODEL = "sentence-transformers/LaBSE"
+
+
+def cosine_similarity(a, b) -> float:
+    """Cosine of two equal-length vectors. 0.0 if either is a zero vector."""
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def qe_available() -> bool:
+    """True iff the QE embedder backend is importable. Never raises — callers
+    fall back to the structural judge when False."""
+    try:
+        import sentence_transformers  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+_embedder_cache = None
+
+
+def _default_embed(texts):
+    """Embed texts with LaBSE (sentence-transformers). Lazy + process-cached.
+    Live-verified I/O, not unit-tested (the model is the boundary)."""
+    global _embedder_cache
+    from sentence_transformers import SentenceTransformer
+    if _embedder_cache is None:
+        _embedder_cache = SentenceTransformer(os.environ.get(_MODEL_ENV, QE_MODEL))
+    return _embedder_cache.encode(list(texts), normalize_embeddings=True)
+
+
+def qe_adequacy(source: str, hyp: str, *, embedder=None) -> float | None:
+    """Reference-free adequacy: cosine(embed(source), embed(hypothesis)) — how
+    faithfully the English hypothesis conveys the source-language text.
+
+    Returns None (caller falls back to the structural judge) when either text
+    is empty, or the embedder is unavailable, or embedding fails. `embedder` is
+    injectable for tests (a callable: list[str] -> list[vector])."""
+    if not (source and source.strip()) or not (hyp and hyp.strip()):
+        return None
+    if embedder is None:
+        if not qe_available():
+            return None
+        embedder = _default_embed
+    try:
+        a, b = embedder([source, hyp])
+    except Exception:
+        log.warning("QE embed failed; falling back to structural judge", exc_info=True)
+        return None
+    return cosine_similarity(list(a), list(b))

--- a/src/subarr/tournament.py
+++ b/src/subarr/tournament.py
@@ -35,6 +35,7 @@ from .transcript_signals import (
     silence_text_ratio,
     uncovered_speech_ratio,
 )
+from . import qe as _qe
 
 # --- v1 proposed rubric (TUNABLE) ---------------------------------------
 CRITICAL_PENALTY = 2.0   # weight of a 'critical' readability issue
@@ -77,6 +78,16 @@ COVERAGE_PENALTY = 50.0        # × fraction of speech left unsubtitled
 # sets, not cue alignment).
 CONSENSUS_PENALTY = 40.0   # × (1 − consensus F1)
 
+# QE/ADEQUACY (#123, the summit) — reference-free LaBSE cosine(source, hyp).
+# Validated rho=0.727 vs true accuracy (vs the structural quality's ~0.41), so
+# when a source-language transcript is available it is the DOMINANT term: the
+# composite's quality becomes mostly the QE adequacy, with the structural
+# quality (which still gates hallucination/looping/dropout) as support.
+# Gated: only blends when Entrant.source_text is set AND the embedder is
+# available; otherwise composite is unchanged (structural-only). TUNABLE —
+# calibrate the blend against the chrF rig.
+QE_BLEND = 0.70   # weight of QE adequacy in quality_total when QE is present
+
 
 @dataclass
 class Entrant:
@@ -88,6 +99,9 @@ class Entrant:
     # entrants of one tournament (same source); enables the text-over-silence
     # hallucination judge. None → that judge is skipped (no penalty).
     speech_ranges: list[tuple[float, float]] | None = None
+    # #123: source-language transcript of the SAME audio (one extra subgen
+    # transcribe pass). Enables the QE/adequacy judge. None → QE skipped.
+    source_text: str | None = None
 
 
 @dataclass
@@ -101,6 +115,7 @@ class Scorecard:
     readability: dict[str, Any] | None   # the #92 report.to_dict()
     signals: dict[str, Any] | None = None  # QE signals (silence/repeat/canned)
     consensus: dict[str, Any] | None = None  # vs-majority precision/recall/f1
+    qe_adequacy: float | None = None       # #123: LaBSE cosine(source, hyp); None if unavailable
     notes: str = ""
 
 
@@ -166,23 +181,38 @@ def score_entrant(entrant: Entrant, fastest_time_s: float | None = None) -> Scor
     )
     readability_penalty = min(_readability_load(report) * READABILITY_K, READABILITY_CAP)
     quality = max(0.0, 100.0 - qe_penalty - readability_penalty)
+
+    # #123 QE/ADEQUACY (the summit): reference-free LaBSE cosine(source, hyp).
+    # When a source transcript is present (and the embedder is available), blend
+    # it in as the DOMINANT term — it's the validated accuracy signal (rho=0.727)
+    # the structural judge can't see. Structural quality stays as the failure-mode
+    # gate. None → composite is structural-only (unchanged behaviour).
+    qadq = None
+    if entrant.source_text:
+        hyp = " ".join(c.text for c in cues)
+        qadq = _qe.qe_adequacy(entrant.source_text, hyp)
+    quality_total = (
+        quality if qadq is None
+        else (qadq * 100.0) * QE_BLEND + quality * (1.0 - QE_BLEND)
+    )
     signals = {
         "silence_text_ratio": round(sil, 4),
         "repeated_line_ratio": round(rep, 4),
         "canned_phrase_hits": canned,
         "uncovered_speech_ratio": round(uncov, 4),
+        "qe_adequacy": round(qadq, 4) if qadq is not None else None,
     }
 
     if entrant.gen_time_s and fastest_time_s and entrant.gen_time_s > 0:
         speed_score = min(100.0, (fastest_time_s / entrant.gen_time_s) * 100.0)
-        composite = quality * QUALITY_WEIGHT + speed_score * SPEED_WEIGHT
+        composite = quality_total * QUALITY_WEIGHT + speed_score * SPEED_WEIGHT
     else:
-        composite = quality
+        composite = quality_total
     return Scorecard(
         entrant_label=entrant.label, disqualified=False,
         composite=round(composite, 2), readability_score=round(r_score, 2),
         cue_count=report.cue_count, gen_time_s=entrant.gen_time_s,
-        readability=report.to_dict(), signals=signals,
+        readability=report.to_dict(), signals=signals, qe_adequacy=qadq,
     )
 
 

--- a/src/subarr/tournament_harness.py
+++ b/src/subarr/tournament_harness.py
@@ -26,13 +26,18 @@ def judge_candidates(
     candidates: dict[str, str],
     speech_ranges: list[tuple[float, float]] | None = None,
     gen_times: dict[str, float] | None = None,
+    source_text: str | None = None,
 ) -> TournamentResult:
-    """Rank candidate SRTs (label → srt_text) with the validated judge."""
+    """Rank candidate SRTs (label → srt_text) with the validated judge.
+
+    `source_text` is the SHARED source-language transcript of the clip (same
+    audio for every entrant); when given, the QE/adequacy judge (#123) fires."""
     gen_times = gen_times or {}
     entrants = [
         Entrant(
             label=label, srt_text=srt,
             speech_ranges=speech_ranges, gen_time_s=gen_times.get(label),
+            source_text=source_text,
         )
         for label, srt in candidates.items()
     ]

--- a/tests/test_qe.py
+++ b/tests/test_qe.py
@@ -1,0 +1,61 @@
+"""#123 — reference-free QE/adequacy judge.
+
+Validated in the Tier-B spike: LaBSE cross-lingual cosine(source, hypothesis)
+correlates rho=0.727 with true translation accuracy (chrF vs pro reference) vs
+the structural judge's 0.41. This is the accuracy-grade signal.
+
+Split mirrors vad.py: the PURE scoring (cosine, adequacy with an injected
+embedder) is unit-tested here; the LaBSE model I/O sits behind an availability
+gate and is live-verified, not unit-tested.
+"""
+from __future__ import annotations
+
+
+def _qe():
+    from subarr import qe
+    return qe
+
+
+def test_cosine_identical_is_one():
+    qe = _qe()
+    assert abs(qe.cosine_similarity([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal_is_zero():
+    qe = _qe()
+    assert abs(qe.cosine_similarity([1.0, 0.0], [0.0, 1.0])) < 1e-9
+
+
+def test_cosine_handles_zero_vector():
+    qe = _qe()
+    assert qe.cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+def test_qe_adequacy_high_when_source_and_hyp_align():
+    qe = _qe()
+    # fake embedder: aligned strings → near-parallel vectors
+    vecs = {"src": [1.0, 0.0], "good": [0.99, 0.14], "bad": [0.0, 1.0]}
+    emb = lambda texts: [vecs[t] for t in texts]
+    hi = qe.qe_adequacy("src", "good", embedder=emb)
+    lo = qe.qe_adequacy("src", "bad", embedder=emb)
+    assert hi > 0.9 and lo < 0.2
+    assert hi > lo
+
+
+def test_qe_adequacy_none_when_unavailable(monkeypatch):
+    qe = _qe()
+    monkeypatch.setattr(qe, "qe_available", lambda: False)
+    # no embedder passed + backend unavailable → graceful None (caller falls back)
+    assert qe.qe_adequacy("source", "hyp") is None
+
+
+def test_qe_adequacy_none_on_empty_text():
+    qe = _qe()
+    emb = lambda texts: [[1.0, 0.0] for _ in texts]
+    assert qe.qe_adequacy("", "hyp", embedder=emb) is None
+    assert qe.qe_adequacy("source", "", embedder=emb) is None
+
+
+def test_qe_available_returns_bool_without_raising():
+    qe = _qe()
+    assert isinstance(qe.qe_available(), bool)

--- a/tests/test_tournament_qe.py
+++ b/tests/test_tournament_qe.py
@@ -1,0 +1,51 @@
+"""#123 — the QE/adequacy judge folded into the tournament composite.
+
+When a source transcript is present, the validated LaBSE adequacy signal
+dominates the composite (structural quality still gates failure modes). QE is
+monkeypatched here so the fold is tested deterministically without the model.
+"""
+from __future__ import annotations
+
+# two structurally-clean, single-cue outputs — equal on every structural judge,
+# so ONLY the QE adequacy can separate them.
+FAITHFUL = "1\n00:00:00,000 --> 00:00:03,000\nThe reactor is overheating.\n"
+OFF_TOPIC = "1\n00:00:00,000 --> 00:00:03,000\nThe weather is nice today.\n"
+SPEECH = [(0.0, 3.0)]
+
+
+def test_qe_adequacy_makes_the_faithful_translation_win(monkeypatch):
+    from subarr import qe, tournament as t
+
+    def fake_qe(source, hyp, **kw):
+        return 0.95 if "reactor" in hyp else 0.30
+
+    monkeypatch.setattr(qe, "qe_adequacy", fake_qe)
+    res = t.run_tournament([
+        t.Entrant(label="off", srt_text=OFF_TOPIC, source_text="SRC", speech_ranges=SPEECH),
+        t.Entrant(label="faithful", srt_text=FAITHFUL, source_text="SRC", speech_ranges=SPEECH),
+    ])
+    assert res.winner_label == "faithful"
+    fc = next(s for s in res.scorecards if s.entrant_label == "faithful")
+    assert fc.qe_adequacy == 0.95
+    assert fc.signals["qe_adequacy"] == 0.95
+
+
+def test_no_source_text_skips_qe(monkeypatch):
+    from subarr import qe, tournament as t
+    # would fire (high) if called — but no source_text means QE must be skipped
+    monkeypatch.setattr(qe, "qe_adequacy", lambda *a, **k: 0.99)
+    res = t.run_tournament([t.Entrant(label="x", srt_text=FAITHFUL, speech_ranges=SPEECH)])
+    sc = res.scorecards[0]
+    assert sc.qe_adequacy is None
+    assert sc.signals["qe_adequacy"] is None
+
+
+def test_qe_unavailable_is_graceful(monkeypatch):
+    from subarr import qe, tournament as t
+    # embedder unavailable → qe_adequacy returns None → structural-only composite
+    monkeypatch.setattr(qe, "qe_available", lambda: False)
+    res = t.run_tournament([
+        t.Entrant(label="a", srt_text=FAITHFUL, source_text="SRC", speech_ranges=SPEECH),
+    ])
+    assert res.scorecards[0].qe_adequacy is None
+    assert not res.scorecards[0].disqualified


### PR DESCRIPTION
The tournament summit. Adds the reference-free **QE/adequacy judge** validated in the Tier-B spike: **LaBSE cosine(source, hypothesis) → ρ=0.727 vs true accuracy** (chrF), nearly doubling the structural judge's 0.41.

- **`qe.py`** — pure `cosine_similarity` + `qe_adequacy` (embedder-injectable, 7 unit tests) + `qe_available()` gate + LaBSE sentence-transformers backend behind it. Mirrors the `vad.py` split (pure logic tested, model I/O is the boundary).
- **Tournament** — `Entrant.source_text` + `Scorecard.qe_adequacy`; `score_entrant` blends QE in as the **dominant** term (`QE_BLEND=0.70`) when source + embedder present, structural quality still gating hallucination/looping/dropout. Gated + graceful: no source/embedder → composite unchanged (all existing tests pass).
- **`[qe]` extra** = sentence-transformers. **Deliberately NOT baked into the image** (unlike `[vad]`) — it pulls torch ~2GB. Opt-in; an **onnx-lean LaBSE backend** (drop torch, bakeable like silero) is the tracked follow-up.

**Follow-ups:** (1) onnx-lean LaBSE packaging; (2) fold the source-transcribe pass into the live arena (needs #88); (3) calibrate `QE_BLEND` against the chrF rig; (4) surface `qe_adequacy` in the tournament UI. Closes the judging half of #123.

44 tests green.