### PR TITLE
feat(subgen): subarr-side per-request kwargs channel (#88)

### DIFF
--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -11,6 +11,7 @@ surfaces on the result. See SubgenCapabilities below.
 """
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -72,6 +73,12 @@ class SubgenCapabilities:
     # ground-truth funnel gates on this — without it the funnel falls
     # back to single-chunk detect_language (less reliable).
     robust_language_detection: bool = False
+    # v4.8 capability: POST /batch accepts a per-request `kwargs` JSON query
+    # param that overrides global + per-language SUBGEN_KWARGS for THIS scan
+    # only. The tuning-lab / arena gates on this — it lets one config sweep
+    # run variant-by-variant without a subgen restart per variant. Vanilla /
+    # ≤v4.7 → False (they silently ignore the unknown query param anyway).
+    per_request_kwargs: bool = False
     # v4.3+ patch revision string ('v4.3', 'v4.4', ...) when published by
     # subgen. Lets subarr feature-gate behaviour without sniffing each
     # capability individually.
@@ -88,6 +95,7 @@ class SubgenCapabilities:
             "audio_language_override": self.audio_language_override,
             "queue_cancel": self.queue_cancel,
             "robust_language_detection": self.robust_language_detection,
+            "per_request_kwargs": self.per_request_kwargs,
             "subarr_subgen_patch_rev": self.subarr_subgen_patch_rev,
         }
 
@@ -97,7 +105,8 @@ class SubgenCapabilities:
             reachable=False, version=None,
             has_queue=False, has_batch=False, is_subarr_subgen=False,
             audio_language_override=False, queue_cancel=False,
-            robust_language_detection=False, subarr_subgen_patch_rev=None,
+            robust_language_detection=False, per_request_kwargs=False,
+            subarr_subgen_patch_rev=None,
         )
 
 
@@ -219,6 +228,7 @@ class SubgenClient:
         audio_language_override = False
         queue_cancel = False
         robust_language_detection = False
+        per_request_kwargs = False
         patch_rev: str | None = None
         try:
             qr = await self._client.get("/queue")
@@ -242,6 +252,9 @@ class SubgenClient:
                             robust_language_detection = bool(
                                 caps_block.get("robust_language_detection")
                             )
+                            per_request_kwargs = bool(
+                                caps_block.get("per_request_kwargs")
+                            )
                 except ValueError:
                     pass
         except httpx.HTTPError:
@@ -261,6 +274,7 @@ class SubgenClient:
             audio_language_override=audio_language_override,
             queue_cancel=queue_cancel,
             robust_language_detection=robust_language_detection,
+            per_request_kwargs=per_request_kwargs,
             subarr_subgen_patch_rev=patch_rev,
         )
         log.info(
@@ -275,7 +289,8 @@ class SubgenClient:
 
     async def batch(self, directory: str, reverse: bool = False,
                     force_language: str | None = None,
-                    audio_language_override: str | None = None) -> tuple[int, dict[str, Any]]:
+                    audio_language_override: str | None = None,
+                    kwargs: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
         """POST /batch with subgen's V4.1 structured response.
 
         Returns (status_code, body). Caller distinguishes:
@@ -290,12 +305,21 @@ class SubgenClient:
           * subgen advertised audio_language_override=True via /queue, AND
           * subarr has a user verification for this file in audio_lang_store
         Vanilla / v4.2 subgens will silently ignore the unknown query param.
+
+        kwargs (v4.8+): per-request Whisper kwargs that override global +
+        per-language SUBGEN_KWARGS for THIS scan only — serialized to a JSON
+        query param. Used by the tuning-lab / arena to sweep configs without
+        a subgen restart per variant. Empty/None → omitted entirely (keeps
+        the request backward-compatible; ≤v4.7 silently ignore it). Gate on
+        capabilities.per_request_kwargs before relying on the override.
         """
         params: dict[str, Any] = {"directory": directory, "reverse": str(reverse).lower()}
         if force_language:
             params["forceLanguage"] = force_language
         if audio_language_override:
             params["audio_language_override"] = audio_language_override
+        if kwargs:
+            params["kwargs"] = json.dumps(kwargs)
         try:
             r = await self._client.post("/batch", params=params)
         except httpx.HTTPError as e:

--- a/tests/test_subgen_per_request_kwargs.py
+++ b/tests/test_subgen_per_request_kwargs.py
@@ -1,0 +1,118 @@
+"""#88 subarr-side — per-request kwargs channel.
+
+The v4.8 subgen patch lets POST /batch carry a per-request `kwargs` JSON
+query param that overrides global + per-language SUBGEN_KWARGS for THIS scan
+only (the tuning-lab / arena needs this so one config sweep doesn't require a
+container restart per variant). subarr must:
+
+  1. Detect the capability via /queue's capabilities.per_request_kwargs.
+  2. Forward batch(kwargs={...}) as ?kwargs=<json> — and omit it entirely
+     when not given (backward-compatible: vanilla/older subgen never sees it).
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from subarr.subgen_client import SubgenClient
+
+
+def _make_client(mock_transport: httpx.MockTransport) -> SubgenClient:
+    c = SubgenClient(base_url="http://fake-subgen:9000")
+    c._client = httpx.AsyncClient(
+        base_url="http://fake-subgen:9000", transport=mock_transport,
+    )
+    return c
+
+
+@pytest.mark.asyncio
+async def test_capability_detected_from_queue_block():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={
+                "version": "Subgen 2026.05.3, stable-ts 0.7.0 (docker)",
+            })
+        if request.url.path == "/queue":
+            return httpx.Response(200, json={
+                "queued": [], "processing": [],
+                "capabilities": {"per_request_kwargs": True},
+            })
+        return httpx.Response(404)
+
+    c = _make_client(httpx.MockTransport(handler))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+
+    assert caps.per_request_kwargs is True
+    assert caps.to_dict()["per_request_kwargs"] is True
+
+
+@pytest.mark.asyncio
+async def test_capability_absent_defaults_false():
+    """v4.7 and earlier: no per_request_kwargs flag → False, not crash."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={"version": "Subgen 2026.05.3 (docker)"})
+        if request.url.path == "/queue":
+            return httpx.Response(200, json={
+                "queued": [], "processing": [],
+                "capabilities": {"audio_language_override": True},
+            })
+        return httpx.Response(404)
+
+    c = _make_client(httpx.MockTransport(handler))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+
+    assert caps.per_request_kwargs is False
+
+
+@pytest.mark.asyncio
+async def test_batch_forwards_kwargs_as_json_query_param():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 1, "queued": 1})
+
+    c = _make_client(httpx.MockTransport(handler))
+    await c.batch("/media/x", kwargs={"vad_filter": True, "beam_size": 5})
+    await c.aclose()
+
+    assert "kwargs" in seen["params"]
+    assert json.loads(seen["params"]["kwargs"]) == {"vad_filter": True, "beam_size": 5}
+
+
+@pytest.mark.asyncio
+async def test_batch_omits_kwargs_when_not_given():
+    """Backward-compat: no kwargs arg → no kwargs query param at all."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 0})
+
+    c = _make_client(httpx.MockTransport(handler))
+    await c.batch("/media/x")
+    await c.aclose()
+
+    assert "kwargs" not in seen["params"]
+
+
+@pytest.mark.asyncio
+async def test_batch_omits_kwargs_when_empty_dict():
+    """Empty dict is a no-op override → don't send it (keeps the URL clean
+    and lets subgen's global/per-language kwargs apply unmodified)."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 0})
+
+    c = _make_client(httpx.MockTransport(handler))
+    await c.batch("/media/x", kwargs={})
+    await c.aclose()
+
+    assert "kwargs" not in seen["params"]


### PR DESCRIPTION
Closes the subarr side of #88. Pairs with the v4.8 subgen patch (already live on subgen-next) that lets `POST /batch` carry a per-request `kwargs` JSON query param overriding global + per-language `SUBGEN_KWARGS` for one scan only.

## What
- **`SubgenCapabilities.per_request_kwargs`** — parsed from `/queue`'s `capabilities` block; surfaced in `to_dict()` so `/api/integrations/health` exposes it for UI gating. Defaults `False` on vanilla / ≤v4.7 subgen.
- **`SubgenClient.batch(kwargs=...)`** — serializes per-request Whisper kwargs to `?kwargs=<json>`; omitted entirely when `None`/empty so the request stays backward-compatible (older subgen silently ignores unknown params anyway).

## Why
The foundation the tuning-lab / arena calls to sweep configs **without a subgen restart per variant** — the bottleneck that made Tier-B runs painful. Also unblocks folding source-transcribe into the live arena for the QE judge.

## Tests
TDD — 5 new tests in `tests/test_subgen_per_request_kwargs.py` (capability detect/default, forward/omit/empty-dict). Full suite **432 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)