### PR TITLE
feat(arena): tuning-lab orchestrator + per-request subgen channels (#131)

### DIFF
--- a/src/subarr/arena.py
+++ b/src/subarr/arena.py
@@ -1,0 +1,140 @@
+"""#131 — tuning-lab arena orchestrator.
+
+Drives a config sweep against the LIVE subgen model and ranks the outputs
+with the validated tournament judge (`tournament_harness.judge_candidates`).
+
+The flow, per run:
+  1. Capability gate — needs subarr-subgen ≥v4.9 (per-request `kwargs` AND
+     per-request `task` on POST /batch). Otherwise we can't isolate configs
+     or transcribe-vs-translate per call, so we refuse loudly.
+  2. Source transcript ONCE — stage the clip into an isolated scratch dir,
+     `batch(task="transcribe")`, read the produced `.srt`, extract plain
+     text. This is the shared source the QE/adequacy judge (#123) scores
+     each candidate translation against.
+  3. Candidates — for each config variant, stage the clip into its OWN
+     scratch dir (so outputs never clobber each other or the real library
+     sub), `batch(task="translate", kwargs=variant)`, read the `.srt`.
+  4. Judge — feed `{label → srt}` + the source text + VAD speech ranges to
+     `judge_candidates` → a ranked `TournamentResult`.
+
+Everything subgen-facing is behind two injected seams so the orchestration
+logic is unit-testable without a real subgen or filesystem:
+  - `subgen`     — a SubgenClient (or anything with probe_capabilities/batch).
+  - `workspace`  — an `ArenaWorkspace`: stages a clip into an isolated dir and
+                   waits for the produced subtitle. The concrete filesystem +
+                   path-mapping + queue-polling implementation lives there
+                   (and is the part that needs live verification).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .subtitle_readability import parse_srt
+from .tournament import TournamentResult
+from .tournament_harness import judge_candidates
+
+# Label used for the shared source-transcribe staging dir. Underscored so it
+# can't collide with a user-supplied variant label.
+SOURCE_LABEL = "__source__"
+
+
+class ArenaUnsupported(RuntimeError):
+    """The connected subgen can't run the arena (missing v4.9 capabilities)."""
+
+
+@dataclass
+class ConfigVariant:
+    """One candidate Whisper config to trial. `kwargs` is the per-request
+    SUBGEN_KWARGS override sent to /batch for this variant only."""
+    label: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StagedClip:
+    """A clip copied into an isolated scratch dir. `subgen_dir` is the
+    directory path in SUBGEN's filesystem view (what we pass to /batch)."""
+    label: str
+    subgen_dir: str
+
+
+@dataclass
+class VariantOutcome:
+    label: str
+    srt_text: str | None
+    error: str | None = None
+
+
+@dataclass
+class ArenaResult:
+    source_text: str | None
+    outcomes: list[VariantOutcome]
+    tournament: TournamentResult
+
+
+class ArenaWorkspace(Protocol):
+    """Isolation seam. Implementations stage a clip into a per-label scratch
+    dir subgen can read+write and subarr can read, then wait for the produced
+    subtitle to land."""
+    async def stage(self, media_path: str, label: str) -> StagedClip: ...
+    async def await_subtitle(self, clip: StagedClip, *, timeout_s: float = 600) -> str | None: ...
+    async def cleanup(self) -> None: ...
+
+
+def _srt_to_text(srt_text: str) -> str:
+    """Join cue text the same way the tournament derives its QE hypothesis,
+    so the source transcript and the candidate hyps are extracted identically."""
+    return " ".join(c.text for c in parse_srt(srt_text))
+
+
+async def run_arena(
+    media_path: str,
+    variants: list[ConfigVariant],
+    *,
+    subgen,
+    workspace: ArenaWorkspace,
+    capabilities=None,
+    speech_ranges: list[tuple[float, float]] | None = None,
+    source_language: str | None = None,
+    judge=judge_candidates,
+) -> ArenaResult:
+    """Run one config sweep and return the ranked result. See module docstring."""
+    if not variants:
+        raise ValueError("run_arena needs at least one config variant")
+
+    caps = capabilities if capabilities is not None else await subgen.probe_capabilities()
+    if not (caps.has_batch and caps.per_request_kwargs and caps.per_request_task):
+        raise ArenaUnsupported(
+            "tuning-lab arena needs subarr-subgen >=v4.9 — POST /batch must "
+            "advertise both per_request_kwargs and per_request_task "
+            f"(saw kwargs={caps.per_request_kwargs}, task={caps.per_request_task}, "
+            f"batch={caps.has_batch})"
+        )
+
+    # 1. Source transcript (once) — task=transcribe, default config.
+    source_text: str | None = None
+    src_clip = await workspace.stage(media_path, SOURCE_LABEL)
+    await subgen.batch(src_clip.subgen_dir, task="transcribe", force_language=source_language)
+    src_srt = await workspace.await_subtitle(src_clip)
+    if src_srt:
+        source_text = _srt_to_text(src_srt)
+
+    # 2. Candidates — one isolated scratch dir + one kwargs variant each.
+    outcomes: list[VariantOutcome] = []
+    candidates: dict[str, str] = {}
+    for v in variants:
+        try:
+            clip = await workspace.stage(media_path, v.label)
+            await subgen.batch(clip.subgen_dir, task="translate", kwargs=v.kwargs)
+            srt = await workspace.await_subtitle(clip)
+        except Exception as e:  # one bad variant must not sink the whole sweep
+            outcomes.append(VariantOutcome(v.label, None, error=str(e)))
+            continue
+        outcomes.append(VariantOutcome(v.label, srt, None if srt else "no subtitle produced"))
+        if srt:
+            candidates[v.label] = srt
+
+    # 3. Judge.
+    result = judge(candidates, speech_ranges=speech_ranges, source_text=source_text)
+    return ArenaResult(source_text=source_text, outcomes=outcomes, tournament=result)

--- a/src/subarr/arena.py
+++ b/src/subarr/arena.py
@@ -4,59 +4,45 @@ Drives a config sweep against the LIVE subgen model and ranks the outputs
 with the validated tournament judge (`tournament_harness.judge_candidates`).
 
 The flow, per run:
-  1. Capability gate — needs subarr-subgen ≥v4.9 (per-request `kwargs` AND
-     per-request `task` on POST /batch). Otherwise we can't isolate configs
-     or transcribe-vs-translate per call, so we refuse loudly.
-  2. Source transcript ONCE — stage the clip into an isolated scratch dir,
-     `batch(task="transcribe")`, read the produced `.srt`, extract plain
-     text. This is the shared source the QE/adequacy judge (#123) scores
-     each candidate translation against.
-  3. Candidates — for each config variant, stage the clip into its OWN
-     scratch dir (so outputs never clobber each other or the real library
-     sub), `batch(task="translate", kwargs=variant)`, read the `.srt`.
-  4. Judge — feed `{label → srt}` + the source text + VAD speech ranges to
+  1. Preflight — the runner checks the connected subgen can actually do this.
+  2. Source transcript ONCE (`task="transcribe"`) → extract plain text. This
+     is the shared source the QE/adequacy judge (#123) scores each candidate
+     translation against.
+  3. Candidates — for each config variant, run `task="translate"` with that
+     variant's per-request `kwargs`.
+  4. Judge — feed `{label → srt}` + source text + VAD speech ranges to
      `judge_candidates` → a ranked `TournamentResult`.
 
-Everything subgen-facing is behind two injected seams so the orchestration
-logic is unit-testable without a real subgen or filesystem:
-  - `subgen`     — a SubgenClient (or anything with probe_capabilities/batch).
-  - `workspace`  — an `ArenaWorkspace`: stages a clip into an isolated dir and
-                   waits for the produced subtitle. The concrete filesystem +
-                   path-mapping + queue-polling implementation lives there
-                   (and is the part that needs live verification).
+Everything subgen-facing is behind ONE injected seam, `CandidateRunner`, so
+the orchestration logic is unit-testable without a real subgen.
+
+The production runner is `AsrRunner` — it drives subgen's v4.10 `/asr` path-
+input channel: subgen reads the media off the shared mount (no upload) and
+returns the subtitle over HTTP (no shared writable scratch, no library
+pollution, no output-isolation problem). That's why there's no scratch-dir /
+filesystem machinery here at all.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from .paths import canonical_to_subgen_batch
 from .subtitle_readability import parse_srt
 from .tournament import TournamentResult
 from .tournament_harness import judge_candidates
 
-# Label used for the shared source-transcribe staging dir. Underscored so it
-# can't collide with a user-supplied variant label.
-SOURCE_LABEL = "__source__"
-
 
 class ArenaUnsupported(RuntimeError):
-    """The connected subgen can't run the arena (missing v4.9 capabilities)."""
+    """The connected subgen can't run the arena (missing the v4.10 /asr channel)."""
 
 
 @dataclass
 class ConfigVariant:
     """One candidate Whisper config to trial. `kwargs` is the per-request
-    SUBGEN_KWARGS override sent to /batch for this variant only."""
+    SUBGEN_KWARGS override sent for this variant only."""
     label: str
     kwargs: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class StagedClip:
-    """A clip copied into an isolated scratch dir. `subgen_dir` is the
-    directory path in SUBGEN's filesystem view (what we pass to /batch)."""
-    label: str
-    subgen_dir: str
 
 
 @dataclass
@@ -73,13 +59,41 @@ class ArenaResult:
     tournament: TournamentResult
 
 
-class ArenaWorkspace(Protocol):
-    """Isolation seam. Implementations stage a clip into a per-label scratch
-    dir subgen can read+write and subarr can read, then wait for the produced
-    subtitle to land."""
-    async def stage(self, media_path: str, label: str) -> StagedClip: ...
-    async def await_subtitle(self, clip: StagedClip, *, timeout_s: float = 600) -> str | None: ...
-    async def cleanup(self) -> None: ...
+class CandidateRunner(Protocol):
+    """Seam: produce a subtitle for `media_path` under a given task + kwargs.
+    Returns the raw SRT text, or None if the model produced nothing."""
+    async def preflight(self) -> None: ...
+    async def run(self, media_path: str, *, task: str, kwargs: dict[str, Any]) -> str | None: ...
+
+
+class AsrRunner:
+    """Production runner over subgen's v4.10 `/asr` path-input channel.
+
+    No upload (subgen reads the shared media mount), no shared scratch (the
+    sub returns over HTTP). Gate is enforced in `preflight()`.
+    """
+    def __init__(self, subgen, *, capabilities=None, source_language: str | None = None,
+                 to_subgen_path=canonical_to_subgen_batch):
+        self._subgen = subgen
+        self._caps = capabilities
+        self._source_language = source_language
+        self._to_subgen_path = to_subgen_path
+
+    async def preflight(self) -> None:
+        caps = self._caps if self._caps is not None else await self._subgen.probe_capabilities()
+        if not getattr(caps, "asr_arena", False):
+            raise ArenaUnsupported(
+                "tuning-lab arena needs subarr-subgen >=v4.10 — /asr must "
+                "advertise capabilities.asr_arena (path-input + per-request "
+                "kwargs + HTTP return)"
+            )
+
+    async def run(self, media_path: str, *, task: str, kwargs: dict[str, Any]) -> str | None:
+        subgen_path = self._to_subgen_path(media_path)
+        srt = await self._subgen.asr(
+            subgen_path, task=task, language=self._source_language, kwargs=kwargs or None,
+        )
+        return srt or None
 
 
 def _srt_to_text(srt_text: str) -> str:
@@ -92,42 +106,26 @@ async def run_arena(
     media_path: str,
     variants: list[ConfigVariant],
     *,
-    subgen,
-    workspace: ArenaWorkspace,
-    capabilities=None,
+    runner: CandidateRunner,
     speech_ranges: list[tuple[float, float]] | None = None,
-    source_language: str | None = None,
     judge=judge_candidates,
 ) -> ArenaResult:
     """Run one config sweep and return the ranked result. See module docstring."""
     if not variants:
         raise ValueError("run_arena needs at least one config variant")
 
-    caps = capabilities if capabilities is not None else await subgen.probe_capabilities()
-    if not (caps.has_batch and caps.per_request_kwargs and caps.per_request_task):
-        raise ArenaUnsupported(
-            "tuning-lab arena needs subarr-subgen >=v4.9 — POST /batch must "
-            "advertise both per_request_kwargs and per_request_task "
-            f"(saw kwargs={caps.per_request_kwargs}, task={caps.per_request_task}, "
-            f"batch={caps.has_batch})"
-        )
+    await runner.preflight()
 
     # 1. Source transcript (once) — task=transcribe, default config.
-    source_text: str | None = None
-    src_clip = await workspace.stage(media_path, SOURCE_LABEL)
-    await subgen.batch(src_clip.subgen_dir, task="transcribe", force_language=source_language)
-    src_srt = await workspace.await_subtitle(src_clip)
-    if src_srt:
-        source_text = _srt_to_text(src_srt)
+    source_srt = await runner.run(media_path, task="transcribe", kwargs={})
+    source_text = _srt_to_text(source_srt) if source_srt else None
 
-    # 2. Candidates — one isolated scratch dir + one kwargs variant each.
+    # 2. Candidates — one translate per variant with its own kwargs.
     outcomes: list[VariantOutcome] = []
     candidates: dict[str, str] = {}
     for v in variants:
         try:
-            clip = await workspace.stage(media_path, v.label)
-            await subgen.batch(clip.subgen_dir, task="translate", kwargs=v.kwargs)
-            srt = await workspace.await_subtitle(clip)
+            srt = await runner.run(media_path, task="translate", kwargs=v.kwargs)
         except Exception as e:  # one bad variant must not sink the whole sweep
             outcomes.append(VariantOutcome(v.label, None, error=str(e)))
             continue

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -79,6 +79,11 @@ class SubgenCapabilities:
     # run variant-by-variant without a subgen restart per variant. Vanilla /
     # ≤v4.7 → False (they silently ignore the unknown query param anyway).
     per_request_kwargs: bool = False
+    # v4.9 capability: POST /batch accepts a per-request `task` (transcribe|
+    # translate) query param that overrides the global TRANSCRIBE_OR_TRANSLATE
+    # for that batch only. The tuning-lab arena gates on this to drive a
+    # source-transcribe AND candidate-translate through one path-based channel.
+    per_request_task: bool = False
     # v4.3+ patch revision string ('v4.3', 'v4.4', ...) when published by
     # subgen. Lets subarr feature-gate behaviour without sniffing each
     # capability individually.
@@ -96,6 +101,7 @@ class SubgenCapabilities:
             "queue_cancel": self.queue_cancel,
             "robust_language_detection": self.robust_language_detection,
             "per_request_kwargs": self.per_request_kwargs,
+            "per_request_task": self.per_request_task,
             "subarr_subgen_patch_rev": self.subarr_subgen_patch_rev,
         }
 
@@ -106,7 +112,7 @@ class SubgenCapabilities:
             has_queue=False, has_batch=False, is_subarr_subgen=False,
             audio_language_override=False, queue_cancel=False,
             robust_language_detection=False, per_request_kwargs=False,
-            subarr_subgen_patch_rev=None,
+            per_request_task=False, subarr_subgen_patch_rev=None,
         )
 
 
@@ -229,6 +235,7 @@ class SubgenClient:
         queue_cancel = False
         robust_language_detection = False
         per_request_kwargs = False
+        per_request_task = False
         patch_rev: str | None = None
         try:
             qr = await self._client.get("/queue")
@@ -255,6 +262,9 @@ class SubgenClient:
                             per_request_kwargs = bool(
                                 caps_block.get("per_request_kwargs")
                             )
+                            per_request_task = bool(
+                                caps_block.get("per_request_task")
+                            )
                 except ValueError:
                     pass
         except httpx.HTTPError:
@@ -275,6 +285,7 @@ class SubgenClient:
             queue_cancel=queue_cancel,
             robust_language_detection=robust_language_detection,
             per_request_kwargs=per_request_kwargs,
+            per_request_task=per_request_task,
             subarr_subgen_patch_rev=patch_rev,
         )
         log.info(
@@ -290,7 +301,8 @@ class SubgenClient:
     async def batch(self, directory: str, reverse: bool = False,
                     force_language: str | None = None,
                     audio_language_override: str | None = None,
-                    kwargs: dict[str, Any] | None = None) -> tuple[int, dict[str, Any]]:
+                    kwargs: dict[str, Any] | None = None,
+                    task: str | None = None) -> tuple[int, dict[str, Any]]:
         """POST /batch with subgen's V4.1 structured response.
 
         Returns (status_code, body). Caller distinguishes:
@@ -312,7 +324,16 @@ class SubgenClient:
         a subgen restart per variant. Empty/None → omitted entirely (keeps
         the request backward-compatible; ≤v4.7 silently ignore it). Gate on
         capabilities.per_request_kwargs before relying on the override.
+
+        task (v4.9+): per-request 'transcribe' or 'translate' that overrides
+        the global TRANSCRIBE_OR_TRANSLATE for THIS scan only. Lets the arena
+        drive a source-transcribe and a candidate-translate over one channel.
+        None → omitted (subgen keeps its global). Gate on
+        capabilities.per_request_task before relying on it. Raises ValueError
+        on any other value (fail loud rather than silently send junk).
         """
+        if task is not None and task not in ("transcribe", "translate"):
+            raise ValueError(f"task must be 'transcribe' or 'translate', got {task!r}")
         params: dict[str, Any] = {"directory": directory, "reverse": str(reverse).lower()}
         if force_language:
             params["forceLanguage"] = force_language
@@ -320,6 +341,8 @@ class SubgenClient:
             params["audio_language_override"] = audio_language_override
         if kwargs:
             params["kwargs"] = json.dumps(kwargs)
+        if task:
+            params["task"] = task
         try:
             r = await self._client.post("/batch", params=params)
         except httpx.HTTPError as e:

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -84,6 +84,11 @@ class SubgenCapabilities:
     # for that batch only. The tuning-lab arena gates on this to drive a
     # source-transcribe AND candidate-translate through one path-based channel.
     per_request_task: bool = False
+    # v4.10 capability: POST /asr accepts ?path= (read audio from a subgen-
+    # visible path — no upload) + ?kwargs= (per-request override, folded into
+    # the dedup hash) and returns the sub over HTTP. The tuning-lab arena gates
+    # on this — it's the no-shared-scratch channel (vs /batch's disk output).
+    asr_arena: bool = False
     # v4.3+ patch revision string ('v4.3', 'v4.4', ...) when published by
     # subgen. Lets subarr feature-gate behaviour without sniffing each
     # capability individually.
@@ -102,6 +107,7 @@ class SubgenCapabilities:
             "robust_language_detection": self.robust_language_detection,
             "per_request_kwargs": self.per_request_kwargs,
             "per_request_task": self.per_request_task,
+            "asr_arena": self.asr_arena,
             "subarr_subgen_patch_rev": self.subarr_subgen_patch_rev,
         }
 
@@ -112,7 +118,7 @@ class SubgenCapabilities:
             has_queue=False, has_batch=False, is_subarr_subgen=False,
             audio_language_override=False, queue_cancel=False,
             robust_language_detection=False, per_request_kwargs=False,
-            per_request_task=False, subarr_subgen_patch_rev=None,
+            per_request_task=False, asr_arena=False, subarr_subgen_patch_rev=None,
         )
 
 
@@ -236,6 +242,7 @@ class SubgenClient:
         robust_language_detection = False
         per_request_kwargs = False
         per_request_task = False
+        asr_arena = False
         patch_rev: str | None = None
         try:
             qr = await self._client.get("/queue")
@@ -265,6 +272,7 @@ class SubgenClient:
                             per_request_task = bool(
                                 caps_block.get("per_request_task")
                             )
+                            asr_arena = bool(caps_block.get("asr_arena"))
                 except ValueError:
                     pass
         except httpx.HTTPError:
@@ -286,6 +294,7 @@ class SubgenClient:
             robust_language_detection=robust_language_detection,
             per_request_kwargs=per_request_kwargs,
             per_request_task=per_request_task,
+            asr_arena=asr_arena,
             subarr_subgen_patch_rev=patch_rev,
         )
         log.info(
@@ -352,3 +361,43 @@ class SubgenClient:
         except ValueError:
             body = {"_raw": r.text[:500]}
         return r.status_code, body
+
+    async def asr(self, path: str, *, task: str = "transcribe",
+                  language: str | None = None, kwargs: dict[str, Any] | None = None,
+                  initial_prompt: str | None = None,
+                  timeout_s: float = 900.0) -> str:
+        """v4.10+ arena channel: path-input ASR that BLOCKS until done and
+        returns the subtitle TEXT over HTTP — no upload, no shared scratch.
+
+        `path` is a subgen-visible path (the file subgen can already read off
+        the shared media mount). `task` is transcribe|translate; `kwargs` is a
+        per-request Whisper override (folded into subgen's dedup hash so two
+        configs don't collide). Gate on capabilities.asr_arena before calling.
+
+        Returns the raw subtitle text (SRT by default; '' if the model produced
+        nothing). Raises SubgenUnavailable on transport failure or a structured
+        error payload, ValueError on a bad task.
+        """
+        if task not in ("transcribe", "translate"):
+            raise ValueError(f"task must be 'transcribe' or 'translate', got {task!r}")
+        params: dict[str, Any] = {"task": task, "path": path}
+        if language:
+            params["language"] = language
+        if initial_prompt:
+            params["initial_prompt"] = initial_prompt
+        if kwargs:
+            params["kwargs"] = json.dumps(kwargs)
+        # /asr blocks for the whole transcription — needs a wide read timeout.
+        asr_timeout = httpx.Timeout(connect=3.0, read=timeout_s, write=10.0, pool=3.0)
+        try:
+            r = await self._client.post("/asr", params=params, timeout=asr_timeout)
+        except httpx.HTTPError as e:
+            raise SubgenUnavailable(f"subgen /asr failed: {e}") from e
+        # Success streams text/plain (the subtitle); errors return a JSON dict.
+        if "application/json" in r.headers.get("content-type", ""):
+            try:
+                body = r.json()
+            except ValueError:
+                body = {"message": r.text[:200]}
+            raise SubgenUnavailable(f"subgen /asr error: {body.get('message', body)}")
+        return r.text

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -2,144 +2,161 @@
 
 The arena drives a config sweep against the LIVE subgen model and ranks the
 outputs with the validated tournament judge. These tests prove the
-ORCHESTRATION logic (capability gating, source-transcribe-once,
-per-variant translate with isolated scratch dirs, judging) against a fake
-workspace + a recording subgen client — no real subgen / filesystem.
+ORCHESTRATION logic (preflight gate, source-transcribe once, per-variant
+translate, judging, bad-variant survival) against a fake runner — plus the
+real `AsrRunner` against a mocked subgen transport.
 """
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from subarr.arena import (
     ArenaUnsupported,
+    AsrRunner,
     ConfigVariant,
     run_arena,
 )
-from subarr.subgen_client import SubgenCapabilities
-
-
-def _caps(*, kwargs=True, task=True, batch=True) -> SubgenCapabilities:
-    return SubgenCapabilities(
-        reachable=True, version="2026.05.3",
-        has_queue=True, has_batch=batch, is_subarr_subgen=True,
-        per_request_kwargs=kwargs, per_request_task=task,
-    )
+from subarr.subgen_client import SubgenCapabilities, SubgenClient
 
 
 def _srt(line: str) -> str:
     return f"1\n00:00:00,000 --> 00:00:03,000\n{line}\n"
 
 
-class RecordingSubgen:
-    """Fake SubgenClient: records every batch() call, returns a queued count."""
-    def __init__(self, caps: SubgenCapabilities):
-        self._caps = caps
-        self.calls: list[dict] = []
+class FakeRunner:
+    """Records run() calls; returns a preset SRT per task/label sequence.
 
-    async def probe_capabilities(self) -> SubgenCapabilities:
-        return self._caps
-
-    async def batch(self, directory, *, task=None, kwargs=None,
-                    force_language=None, **rest):
-        self.calls.append({"directory": directory, "task": task,
-                           "kwargs": kwargs, "force_language": force_language})
-        return 200, {"walked": 1, "queued": 1}
-
-
-class FakeWorkspace:
-    """Stages clips into labelled dirs; returns a preset SRT per label.
-
-    `subtitles` maps label → srt text (or None to simulate 'no output').
-    Missing label → falls back to `default_srt`.
+    `outputs` is consumed in call order: first call is the source transcribe,
+    then one per variant. A value of None simulates 'no subtitle produced'.
     """
-    def __init__(self, subtitles: dict[str, str | None], default_srt: str | None = None):
-        self._subs = subtitles
-        self._default = default_srt
-        self.staged: list[str] = []
-        self.cleaned = False
+    def __init__(self, outputs: list[str | None], supported: bool = True):
+        self._outputs = list(outputs)
+        self._supported = supported
+        self.calls: list[dict] = []
+        self.preflighted = False
 
-    async def stage(self, media_path, label):
-        self.staged.append(label)
-        from subarr.arena import StagedClip
-        return StagedClip(label=label, subgen_dir=f"/scratch/{label}")
+    async def preflight(self):
+        self.preflighted = True
+        if not self._supported:
+            raise ArenaUnsupported("nope")
 
-    async def await_subtitle(self, clip, *, timeout_s: float = 600):
-        return self._subs.get(clip.label, self._default)
-
-    async def cleanup(self):
-        self.cleaned = True
+    async def run(self, media_path, *, task, kwargs):
+        self.calls.append({"media_path": media_path, "task": task, "kwargs": kwargs})
+        return self._outputs.pop(0) if self._outputs else None
 
 
 @pytest.mark.asyncio
-async def test_arena_unsupported_when_task_capability_missing():
-    sg = RecordingSubgen(_caps(task=False))
-    ws = FakeWorkspace({})
+async def test_preflight_gate_blocks_unsupported_subgen():
+    runner = FakeRunner([], supported=False)
     with pytest.raises(ArenaUnsupported):
-        await run_arena("/media/clip.mkv", [ConfigVariant("a", {})],
-                        subgen=sg, workspace=ws)
-
-
-@pytest.mark.asyncio
-async def test_arena_unsupported_when_kwargs_capability_missing():
-    sg = RecordingSubgen(_caps(kwargs=False))
-    ws = FakeWorkspace({})
-    with pytest.raises(ArenaUnsupported):
-        await run_arena("/media/clip.mkv", [ConfigVariant("a", {})],
-                        subgen=sg, workspace=ws)
+        await run_arena("/x.mkv", [ConfigVariant("a", {})], runner=runner)
+    assert runner.preflighted
 
 
 @pytest.mark.asyncio
 async def test_source_transcribed_once_then_each_variant_translated():
-    sg = RecordingSubgen(_caps())
-    ws = FakeWorkspace({
-        "__source__": _srt("the reactor is overheating"),
-        "noisy": _srt("reactor overheating now"),
-        "clean": _srt("the weather is fine"),
-    })
+    runner = FakeRunner([
+        _srt("the reactor is overheating"),   # source transcribe
+        _srt("reactor overheating now"),       # variant noisy
+        _srt("the weather is fine"),           # variant clean
+    ])
     variants = [ConfigVariant("noisy", {"vad_filter": True}),
                 ConfigVariant("clean", {"beam_size": 5})]
 
-    res = await run_arena("/media/clip.mkv", variants, subgen=sg,
-                          workspace=ws, source_language="ko")
+    res = await run_arena("/media/clip.mkv", variants, runner=runner)
 
-    # one transcribe (source) + two translate (variants)
-    tasks = [c["task"] for c in sg.calls]
+    tasks = [c["task"] for c in runner.calls]
     assert tasks == ["transcribe", "translate", "translate"]
-    # source call seeded the source language
-    assert sg.calls[0]["force_language"] == "ko"
-    # each variant forwarded its own kwargs
-    assert sg.calls[1]["kwargs"] == {"vad_filter": True}
-    assert sg.calls[2]["kwargs"] == {"beam_size": 5}
+    # source call carries no per-request kwargs; variants carry their own
+    assert runner.calls[0]["kwargs"] == {}
+    assert runner.calls[1]["kwargs"] == {"vad_filter": True}
+    assert runner.calls[2]["kwargs"] == {"beam_size": 5}
     # source transcript extracted to plain text for QE
     assert res.source_text == "the reactor is overheating"
-    # judged both candidates
     assert {o.label for o in res.outcomes} == {"noisy", "clean"}
     assert res.tournament is not None
 
 
 @pytest.mark.asyncio
 async def test_variant_with_no_subtitle_is_dropped_from_judging():
-    sg = RecordingSubgen(_caps())
-    ws = FakeWorkspace({
-        "__source__": _srt("source line"),
-        "good": _srt("a translated line"),
-        "broken": None,           # produced no subtitle
-    })
+    runner = FakeRunner([
+        _srt("source line"),     # source
+        _srt("a translated line"),  # good
+        None,                    # broken → no sub
+    ])
     variants = [ConfigVariant("good", {}), ConfigVariant("broken", {})]
 
-    res = await run_arena("/media/clip.mkv", variants, subgen=sg, workspace=ws)
+    res = await run_arena("/media/clip.mkv", variants, runner=runner)
 
     broken = next(o for o in res.outcomes if o.label == "broken")
-    assert broken.srt_text is None
-    assert broken.error is not None
-    # the broken variant must not have reached the judge
+    assert broken.srt_text is None and broken.error is not None
     judged = {sc.entrant_label for sc in res.tournament.scorecards}
-    assert "broken" not in judged
-    assert "good" in judged
+    assert "broken" not in judged and "good" in judged
+
+
+@pytest.mark.asyncio
+async def test_one_variant_raising_does_not_sink_the_sweep():
+    class FlakyRunner(FakeRunner):
+        async def run(self, media_path, *, task, kwargs):
+            if kwargs.get("boom"):
+                raise RuntimeError("subgen exploded")
+            return await super().run(media_path, task=task, kwargs=kwargs)
+
+    runner = FlakyRunner([_srt("src"), _srt("ok line")])
+    variants = [ConfigVariant("boom", {"boom": True}), ConfigVariant("ok", {})]
+    res = await run_arena("/x.mkv", variants, runner=runner)
+
+    boom = next(o for o in res.outcomes if o.label == "boom")
+    assert "subgen exploded" in boom.error
+    assert {sc.entrant_label for sc in res.tournament.scorecards} == {"ok"}
 
 
 @pytest.mark.asyncio
 async def test_empty_variants_rejected():
-    sg = RecordingSubgen(_caps())
     with pytest.raises(ValueError):
-        await run_arena("/media/clip.mkv", [], subgen=sg, workspace=FakeWorkspace({}))
+        await run_arena("/x.mkv", [], runner=FakeRunner([]))
+
+
+# ── AsrRunner over a real mocked transport ─────────────────────────────────
+
+def _client(handler) -> SubgenClient:
+    c = SubgenClient(base_url="http://fake:9000")
+    c._client = httpx.AsyncClient(base_url="http://fake:9000", transport=httpx.MockTransport(handler))
+    return c
+
+
+@pytest.mark.asyncio
+async def test_asr_runner_preflight_requires_asr_arena():
+    caps = SubgenCapabilities(reachable=True, version="x", has_queue=True,
+                              has_batch=True, is_subarr_subgen=True, asr_arena=False)
+    runner = AsrRunner(_client(lambda r: httpx.Response(200)), capabilities=caps)
+    with pytest.raises(ArenaUnsupported):
+        await runner.preflight()
+
+
+@pytest.mark.asyncio
+async def test_asr_runner_maps_path_and_forwards_task_kwargs():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, text=_srt("translated"),
+                              headers={"content-type": "text/plain"})
+
+    caps = SubgenCapabilities(reachable=True, version="x", has_queue=True,
+                              has_batch=True, is_subarr_subgen=True, asr_arena=True)
+    runner = AsrRunner(_client(handler), capabilities=caps, source_language="ko",
+                       to_subgen_path=lambda p: "/media/" + p.strip("/"))
+
+    await runner.preflight()
+    out = await runner.run("TV/Show/ep.mkv", task="translate", kwargs={"beam_size": 5})
+
+    assert out == _srt("translated")
+    assert seen["path"] == "/asr"
+    assert seen["params"]["task"] == "translate"
+    assert seen["params"]["path"] == "/media/TV/Show/ep.mkv"
+    assert seen["params"]["language"] == "ko"
+    import json
+    assert json.loads(seen["params"]["kwargs"]) == {"beam_size": 5}

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -1,0 +1,145 @@
+"""#131 — tuning-lab arena orchestrator.
+
+The arena drives a config sweep against the LIVE subgen model and ranks the
+outputs with the validated tournament judge. These tests prove the
+ORCHESTRATION logic (capability gating, source-transcribe-once,
+per-variant translate with isolated scratch dirs, judging) against a fake
+workspace + a recording subgen client — no real subgen / filesystem.
+"""
+from __future__ import annotations
+
+import pytest
+
+from subarr.arena import (
+    ArenaUnsupported,
+    ConfigVariant,
+    run_arena,
+)
+from subarr.subgen_client import SubgenCapabilities
+
+
+def _caps(*, kwargs=True, task=True, batch=True) -> SubgenCapabilities:
+    return SubgenCapabilities(
+        reachable=True, version="2026.05.3",
+        has_queue=True, has_batch=batch, is_subarr_subgen=True,
+        per_request_kwargs=kwargs, per_request_task=task,
+    )
+
+
+def _srt(line: str) -> str:
+    return f"1\n00:00:00,000 --> 00:00:03,000\n{line}\n"
+
+
+class RecordingSubgen:
+    """Fake SubgenClient: records every batch() call, returns a queued count."""
+    def __init__(self, caps: SubgenCapabilities):
+        self._caps = caps
+        self.calls: list[dict] = []
+
+    async def probe_capabilities(self) -> SubgenCapabilities:
+        return self._caps
+
+    async def batch(self, directory, *, task=None, kwargs=None,
+                    force_language=None, **rest):
+        self.calls.append({"directory": directory, "task": task,
+                           "kwargs": kwargs, "force_language": force_language})
+        return 200, {"walked": 1, "queued": 1}
+
+
+class FakeWorkspace:
+    """Stages clips into labelled dirs; returns a preset SRT per label.
+
+    `subtitles` maps label → srt text (or None to simulate 'no output').
+    Missing label → falls back to `default_srt`.
+    """
+    def __init__(self, subtitles: dict[str, str | None], default_srt: str | None = None):
+        self._subs = subtitles
+        self._default = default_srt
+        self.staged: list[str] = []
+        self.cleaned = False
+
+    async def stage(self, media_path, label):
+        self.staged.append(label)
+        from subarr.arena import StagedClip
+        return StagedClip(label=label, subgen_dir=f"/scratch/{label}")
+
+    async def await_subtitle(self, clip, *, timeout_s: float = 600):
+        return self._subs.get(clip.label, self._default)
+
+    async def cleanup(self):
+        self.cleaned = True
+
+
+@pytest.mark.asyncio
+async def test_arena_unsupported_when_task_capability_missing():
+    sg = RecordingSubgen(_caps(task=False))
+    ws = FakeWorkspace({})
+    with pytest.raises(ArenaUnsupported):
+        await run_arena("/media/clip.mkv", [ConfigVariant("a", {})],
+                        subgen=sg, workspace=ws)
+
+
+@pytest.mark.asyncio
+async def test_arena_unsupported_when_kwargs_capability_missing():
+    sg = RecordingSubgen(_caps(kwargs=False))
+    ws = FakeWorkspace({})
+    with pytest.raises(ArenaUnsupported):
+        await run_arena("/media/clip.mkv", [ConfigVariant("a", {})],
+                        subgen=sg, workspace=ws)
+
+
+@pytest.mark.asyncio
+async def test_source_transcribed_once_then_each_variant_translated():
+    sg = RecordingSubgen(_caps())
+    ws = FakeWorkspace({
+        "__source__": _srt("the reactor is overheating"),
+        "noisy": _srt("reactor overheating now"),
+        "clean": _srt("the weather is fine"),
+    })
+    variants = [ConfigVariant("noisy", {"vad_filter": True}),
+                ConfigVariant("clean", {"beam_size": 5})]
+
+    res = await run_arena("/media/clip.mkv", variants, subgen=sg,
+                          workspace=ws, source_language="ko")
+
+    # one transcribe (source) + two translate (variants)
+    tasks = [c["task"] for c in sg.calls]
+    assert tasks == ["transcribe", "translate", "translate"]
+    # source call seeded the source language
+    assert sg.calls[0]["force_language"] == "ko"
+    # each variant forwarded its own kwargs
+    assert sg.calls[1]["kwargs"] == {"vad_filter": True}
+    assert sg.calls[2]["kwargs"] == {"beam_size": 5}
+    # source transcript extracted to plain text for QE
+    assert res.source_text == "the reactor is overheating"
+    # judged both candidates
+    assert {o.label for o in res.outcomes} == {"noisy", "clean"}
+    assert res.tournament is not None
+
+
+@pytest.mark.asyncio
+async def test_variant_with_no_subtitle_is_dropped_from_judging():
+    sg = RecordingSubgen(_caps())
+    ws = FakeWorkspace({
+        "__source__": _srt("source line"),
+        "good": _srt("a translated line"),
+        "broken": None,           # produced no subtitle
+    })
+    variants = [ConfigVariant("good", {}), ConfigVariant("broken", {})]
+
+    res = await run_arena("/media/clip.mkv", variants, subgen=sg, workspace=ws)
+
+    broken = next(o for o in res.outcomes if o.label == "broken")
+    assert broken.srt_text is None
+    assert broken.error is not None
+    # the broken variant must not have reached the judge
+    judged = {sc.entrant_label for sc in res.tournament.scorecards}
+    assert "broken" not in judged
+    assert "good" in judged
+
+
+@pytest.mark.asyncio
+async def test_empty_variants_rejected():
+    sg = RecordingSubgen(_caps())
+    with pytest.raises(ValueError):
+        await run_arena("/media/clip.mkv", [], subgen=sg, workspace=FakeWorkspace({}))

--- a/tests/test_subgen_per_request_task.py
+++ b/tests/test_subgen_per_request_task.py
@@ -1,0 +1,106 @@
+"""#131 subarr-side — per-request task channel.
+
+The v4.9 subgen patch lets POST /batch carry a `task=transcribe|translate`
+query param that overrides the global TRANSCRIBE_OR_TRANSLATE for one batch
+(the tuning-lab arena drives a source-transcribe AND candidate-translate
+through the same path-based channel). subarr must:
+
+  1. Detect the capability via /queue's capabilities.per_request_task.
+  2. Forward batch(task="transcribe"|"translate") as ?task= — omitting it
+     entirely (and rejecting unknown values) so older subgen keeps its
+     env-locked behaviour.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from subarr.subgen_client import SubgenClient
+
+
+def _make_client(mock_transport: httpx.MockTransport) -> SubgenClient:
+    c = SubgenClient(base_url="http://fake-subgen:9000")
+    c._client = httpx.AsyncClient(
+        base_url="http://fake-subgen:9000", transport=mock_transport,
+    )
+    return c
+
+
+@pytest.mark.asyncio
+async def test_capability_detected_from_queue_block():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={"version": "Subgen 2026.05.3 (docker)"})
+        if request.url.path == "/queue":
+            return httpx.Response(200, json={
+                "queued": [], "processing": [],
+                "capabilities": {"per_request_task": True},
+            })
+        return httpx.Response(404)
+
+    c = _make_client(httpx.MockTransport(handler))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+
+    assert caps.per_request_task is True
+    assert caps.to_dict()["per_request_task"] is True
+
+
+@pytest.mark.asyncio
+async def test_capability_absent_defaults_false():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={"version": "Subgen 2026.05.3 (docker)"})
+        if request.url.path == "/queue":
+            return httpx.Response(200, json={
+                "queued": [], "processing": [],
+                "capabilities": {"per_request_kwargs": True},
+            })
+        return httpx.Response(404)
+
+    c = _make_client(httpx.MockTransport(handler))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+
+    assert caps.per_request_task is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task", ["transcribe", "translate"])
+async def test_batch_forwards_valid_task(task):
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 1, "queued": 1})
+
+    c = _make_client(httpx.MockTransport(handler))
+    await c.batch("/media/x", task=task)
+    await c.aclose()
+
+    assert seen["params"].get("task") == task
+
+
+@pytest.mark.asyncio
+async def test_batch_omits_task_when_not_given():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 0})
+
+    c = _make_client(httpx.MockTransport(handler))
+    await c.batch("/media/x")
+    await c.aclose()
+
+    assert "task" not in seen["params"]
+
+
+@pytest.mark.asyncio
+async def test_batch_rejects_unknown_task():
+    """Defensive: an unknown task value is dropped, not forwarded (subgen
+    would ignore it, but we keep the request clean + fail loud in code)."""
+    c = _make_client(httpx.MockTransport(lambda r: httpx.Response(200, json={"walked": 0})))
+    with pytest.raises(ValueError):
+        await c.batch("/media/x", task="summarize")
+    await c.aclose()

--- a/tests/test_subgen_per_request_task.py
+++ b/tests/test_subgen_per_request_task.py
@@ -66,6 +66,26 @@ async def test_capability_absent_defaults_false():
 
 
 @pytest.mark.asyncio
+async def test_asr_arena_capability_detected_from_queue_block():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={"version": "Subgen 2026.05.3 (docker)"})
+        if request.url.path == "/queue":
+            return httpx.Response(200, json={
+                "queued": [], "processing": [],
+                "capabilities": {"asr_arena": True},
+            })
+        return httpx.Response(404)
+
+    c = _make_client(httpx.MockTransport(handler))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+
+    assert caps.asr_arena is True
+    assert caps.to_dict()["asr_arena"] is True
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("task", ["transcribe", "translate"])
 async def test_batch_forwards_valid_task(task):
     seen: dict = {}


### PR DESCRIPTION
The backend core for the tuning lab (#131): drive a config sweep against the live subgen model and rank the outputs with the validated tournament judge — **no env edits, no restarts, and no shared writable mount**.

## Architecture (revised after RTFM + a deployment-cost review)
Originally scoped on `/batch` + a shared scratch dir; pivoted to subgen's **`/asr` path-input channel** to kill the shared-mount requirement:
- subgen reads the media off the mount both containers **already share** (no upload),
- transcribes/translates and **returns the sub over HTTP** (no shared writable scratch, no library pollution, no output-isolation problem).

## What
- **Per-request subgen channels** (still useful for CLI / Tier-B / federated sweeps):
  - `SubgenClient.batch(task=…)` + `capabilities.per_request_task` (v4.9).
  - `SubgenClient.batch(kwargs=…)` + `capabilities.per_request_kwargs` (v4.8, from #130).
- **`SubgenClient.asr(path, task, language, kwargs)`** — path-input ASR, returns the sub text; `capabilities.asr_arena` (v4.10).
- **`arena.run_arena()`** — preflight-gate → source-transcribe **once** (`task=transcribe`, plain text for the QE judge #123) → per-variant **translate** (`task=translate`, `kwargs=variant`) → `judge_candidates(source_text, speech_ranges)` → ranked `TournamentResult`. One bad variant is recorded and skipped, not fatal.
- subgen sits behind a single `CandidateRunner` seam; **`AsrRunner`** is the production impl. No filesystem/scratch machinery.

## Pairs with
Published **`ghcr.io/coaxk/subarr-subgen:2026.05.3-r4`** (patch rev v4.10): adds `/asr` `path` + `kwargs` + folds kwargs into the dedup hash (latent-collision fix). Live-verified end-to-end (path-input transcribe returned a real SRT, zero upload).

## Deliberately NOT in this PR (follow-ups on #131)
- `POST /api/arena/run` + push state.
- Tuning-lab UI tab + adopt-winner → config persistence (reuse #112).

## Tests
TDD — runner-seam orchestration + `AsrRunner` over a mocked transport + per-request channel/capability tests. Full suite **446 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)