### PR TITLE
feat(arena): tuning-lab run API — service + routes + SSE (#131)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -37,7 +37,7 @@ from .probe_walker import ProbeWalker
 from .provenance import ProvenanceStore
 from .onboarding import OnboardingStore
 from .routers import (
-    admin, arbiter as r_arbiter, arr_mediainfo as r_arr_mediainfo,
+    admin, arbiter as r_arbiter, arena as r_arena, arr_mediainfo as r_arr_mediainfo,
     audio_lang as r_audio_lang,
     bazarr_sync, blacklist as r_blacklist, browse, coverage, coverage_actions,
     discovery as r_discovery, household as r_household,
@@ -47,6 +47,8 @@ from .routers import (
     queue, scan, schedule as r_schedule, sidecar as r_sidecar,
     telemetry as r_telemetry, updates as r_updates, vad as r_vad,
 )
+from .arena import AsrRunner
+from .arena_service import ArenaService
 from .scan_runner import ScanRunner
 from .scan_store import ScanStore
 from .error_store import ErrorStore
@@ -98,6 +100,16 @@ async def lifespan(app_: FastAPI):
         subgen_provider=lambda: app_.state.subgen,
         # Best-effort anonymous error-class recording for telemetry.
         error_recorder=lambda cls: app_.state.errors.record(cls),
+    )
+    # #131 tuning-lab arena. build_runner resolves subgen + caps LIVE (closure
+    # over app_.state) so an onboarding client-swap or a subgen upgrade picked
+    # up by the watchdog is reflected on the next run without a restart.
+    app_.state.arena = ArenaService(
+        build_runner=lambda run: AsrRunner(
+            app_.state.subgen,
+            capabilities=getattr(app_.state, "subgen_caps", None),
+            source_language=run.source_language,
+        ),
     )
     app_.state.docker = DockerOps()
     app_.state.integrations = IntegrationBundle()
@@ -382,6 +394,7 @@ app.include_router(r_home.router)
 app.include_router(r_onboarding.router)
 app.include_router(r_sidecar.router)
 app.include_router(r_vad.router)
+app.include_router(r_arena.router)
 
 
 @app.get("/api/health")

--- a/src/subarr/arena.py
+++ b/src/subarr/arena.py
@@ -109,8 +109,15 @@ async def run_arena(
     runner: CandidateRunner,
     speech_ranges: list[tuple[float, float]] | None = None,
     judge=judge_candidates,
+    on_source=None,
+    on_variant=None,
 ) -> ArenaResult:
-    """Run one config sweep and return the ranked result. See module docstring."""
+    """Run one config sweep and return the ranked result. See module docstring.
+
+    `on_source(text)` fires once the source transcript is ready; `on_variant(
+    outcome)` fires after each variant completes. Both are optional sync hooks
+    the run service uses to push live SSE progress without blocking the sweep.
+    """
     if not variants:
         raise ValueError("run_arena needs at least one config variant")
 
@@ -119,6 +126,8 @@ async def run_arena(
     # 1. Source transcript (once) — task=transcribe, default config.
     source_srt = await runner.run(media_path, task="transcribe", kwargs={})
     source_text = _srt_to_text(source_srt) if source_srt else None
+    if on_source is not None:
+        on_source(source_text)
 
     # 2. Candidates — one translate per variant with its own kwargs.
     outcomes: list[VariantOutcome] = []
@@ -126,12 +135,14 @@ async def run_arena(
     for v in variants:
         try:
             srt = await runner.run(media_path, task="translate", kwargs=v.kwargs)
+            outcome = VariantOutcome(v.label, srt, None if srt else "no subtitle produced")
         except Exception as e:  # one bad variant must not sink the whole sweep
-            outcomes.append(VariantOutcome(v.label, None, error=str(e)))
-            continue
-        outcomes.append(VariantOutcome(v.label, srt, None if srt else "no subtitle produced"))
-        if srt:
-            candidates[v.label] = srt
+            outcome = VariantOutcome(v.label, None, error=str(e))
+        outcomes.append(outcome)
+        if outcome.srt_text:
+            candidates[v.label] = outcome.srt_text
+        if on_variant is not None:
+            on_variant(outcome)
 
     # 3. Judge.
     result = judge(candidates, speech_ranges=speech_ranges, source_text=source_text)

--- a/src/subarr/arena_service.py
+++ b/src/subarr/arena_service.py
@@ -1,0 +1,127 @@
+"""#131 — ArenaService: background lifecycle + SSE event stream for a sweep.
+
+Mirrors ScanRunner: `create()` makes a pending run, `start()` schedules an
+asyncio task that drives `run_arena`, and `subscribe()` is an async generator
+the SSE endpoint streams. Runs are in-memory (an arena run is a transient
+experiment — it doesn't need to survive a restart like an audited scan does).
+
+The run state stays light on purpose: live `outcomes` carry label/ok/error
+(not the full SRT), and `result` is the serialized `TournamentResult`. The
+raw candidate subtitles are not stored — the ranking + signals are what the
+tuning lab needs; surfacing the winning SRT text is a later UI nicety.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, AsyncIterator, Callable
+
+from .arena import CandidateRunner, ConfigVariant, run_arena
+
+
+@dataclass
+class ArenaRun:
+    id: str
+    media_path: str
+    variants: list[dict[str, Any]]          # [{label, kwargs}]
+    source_language: str | None = None
+    status: str = "pending"                  # pending | running | done | error
+    source_text: str | None = None
+    outcomes: list[dict[str, Any]] = field(default_factory=list)
+    result: dict[str, Any] | None = None     # serialized TournamentResult
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class ArenaService:
+    def __init__(self, build_runner: Callable[[ArenaRun], CandidateRunner]):
+        self._build_runner = build_runner
+        self._runs: dict[str, ArenaRun] = {}
+        self._subscribers: dict[str, set[asyncio.Queue]] = {}
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    # ── store ──────────────────────────────────────────────────────────────
+    def create(self, media_path: str, variants: list[ConfigVariant],
+               source_language: str | None = None) -> ArenaRun:
+        run = ArenaRun(
+            id=uuid.uuid4().hex[:12],
+            media_path=media_path,
+            variants=[{"label": v.label, "kwargs": v.kwargs} for v in variants],
+            source_language=source_language,
+        )
+        self._runs[run.id] = run
+        return run
+
+    def get(self, run_id: str) -> ArenaRun | None:
+        return self._runs.get(run_id)
+
+    def list(self) -> list[ArenaRun]:
+        return list(self._runs.values())
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def start(self, run: ArenaRun) -> None:
+        self._tasks[run.id] = asyncio.create_task(self._run(run.id), name=f"arena-{run.id}")
+
+    async def aclose(self) -> None:
+        for t in list(self._tasks.values()):
+            t.cancel()
+
+    # ── SSE ────────────────────────────────────────────────────────────────
+    def _emit(self, run_id: str, evt: dict) -> None:
+        for q in list(self._subscribers.get(run_id, ())):
+            try:
+                q.put_nowait(evt)
+            except asyncio.QueueFull:
+                pass  # a slow consumer drops events; it can re-GET the state
+
+    async def subscribe(self, run_id: str) -> AsyncIterator[dict]:
+        q: asyncio.Queue = asyncio.Queue(maxsize=256)
+        self._subscribers.setdefault(run_id, set()).add(q)
+        try:
+            while True:
+                evt = await q.get()
+                yield evt
+                if evt.get("event") in ("done", "error"):
+                    return
+        finally:
+            subs = self._subscribers.get(run_id)
+            if subs:
+                subs.discard(q)
+                if not subs:
+                    self._subscribers.pop(run_id, None)
+
+    async def _run(self, run_id: str) -> None:
+        run = self._runs[run_id]
+        run.status = "running"
+        self._emit(run_id, {"event": "start",
+                            "data": {"id": run.id, "variants": [v["label"] for v in run.variants]}})
+        try:
+            runner = self._build_runner(run)
+            variants = [ConfigVariant(v["label"], v["kwargs"]) for v in run.variants]
+
+            def on_source(text: str | None) -> None:
+                run.source_text = text
+                self._emit(run_id, {"event": "source", "data": {"has_text": bool(text)}})
+
+            def on_variant(outcome) -> None:
+                d = {"label": outcome.label, "ok": outcome.srt_text is not None,
+                     "error": outcome.error}
+                run.outcomes.append(d)
+                self._emit(run_id, {"event": "variant", "data": d})
+
+            result = await run_arena(run.media_path, variants, runner=runner,
+                                     on_source=on_source, on_variant=on_variant)
+            run.result = asdict(result.tournament)
+            run.status = "done"
+            self._emit(run_id, {"event": "done", "data": run.to_dict()})
+        except asyncio.CancelledError:
+            run.status = "error"
+            run.error = "cancelled"
+            raise
+        except Exception as e:
+            run.status = "error"
+            run.error = str(e)
+            self._emit(run_id, {"event": "error", "data": {"error": str(e)}})

--- a/src/subarr/routers/arena.py
+++ b/src/subarr/routers/arena.py
@@ -1,0 +1,105 @@
+"""#131 — tuning-lab arena API.
+
+POST /api/arena/run         start a config sweep (background; returns the run)
+GET  /api/arena/runs        list runs
+GET  /api/arena/{id}        run state (poll while running, or just read once)
+GET  /api/arena/{id}/events SSE stream of live progress
+
+The sweep runs against the live subgen model over the v4.10 /asr path-input
+channel (no upload, no shared scratch). Gated on capabilities.asr_arena so
+older/vanilla subgen gets a clear "needs subarr-subgen >=v4.10" instead of a
+confusing failure.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from ..arena import ConfigVariant
+from ..paths import PathOutsideRootError, canonical_to_fs
+
+router = APIRouter(prefix="/api/arena", tags=["arena"])
+
+
+class VariantSpec(BaseModel):
+    label: str = Field(..., min_length=1)
+    kwargs: dict = Field(default_factory=dict)
+
+
+class ArenaRunRequest(BaseModel):
+    media_path: str = Field(..., min_length=1)
+    variants: list[VariantSpec] = Field(..., min_length=1)
+    source_language: str | None = None
+
+
+@router.post("/run", status_code=202)
+async def create_arena_run(req: ArenaRunRequest, request: Request) -> dict:
+    p = req.media_path.strip().strip("/")
+    if not p:
+        raise HTTPException(400, detail="empty media_path")
+    try:
+        target = canonical_to_fs(p)
+    except PathOutsideRootError:
+        raise HTTPException(400, detail=f"path escapes media root: {req.media_path!r}")
+    if not target.is_file():
+        raise HTTPException(404, detail=f"not a file: {req.media_path!r}")
+
+    labels = [v.label for v in req.variants]
+    if len(set(labels)) != len(labels):
+        raise HTTPException(400, detail="variant labels must be unique")
+
+    # Capability gate upfront: a clear 503 beats kicking off a run that will
+    # fail at preflight. asr_arena = subarr-subgen >=v4.10 (/asr path+kwargs).
+    caps = getattr(request.app.state, "subgen_caps", None)
+    if not getattr(caps, "asr_arena", False):
+        raise HTTPException(
+            503,
+            detail={
+                "error": "unsupported",
+                "reason": "the tuning lab needs subarr-subgen >=v4.10 — its /asr "
+                          "endpoint must advertise the arena channel (path-input + "
+                          "per-request kwargs).",
+                "remedy": "Upgrade your subgen image to "
+                          "ghcr.io/coaxk/subarr-subgen:latest (>=2026.05.3-r4).",
+            },
+        )
+
+    svc = request.app.state.arena
+    variants = [ConfigVariant(v.label, v.kwargs) for v in req.variants]
+    run = svc.create(p, variants, source_language=req.source_language)
+    svc.start(run)
+    return run.to_dict()
+
+
+@router.get("/runs")
+async def list_arena_runs(request: Request) -> dict:
+    return {"runs": [r.to_dict() for r in request.app.state.arena.list()]}
+
+
+@router.get("/{run_id}")
+async def get_arena_run(run_id: str, request: Request) -> dict:
+    run = request.app.state.arena.get(run_id)
+    if run is None:
+        raise HTTPException(404, detail="arena run not found")
+    return run.to_dict()
+
+
+@router.get("/{run_id}/events")
+async def arena_events(run_id: str, request: Request) -> StreamingResponse:
+    svc = request.app.state.arena
+    if svc.get(run_id) is None:
+        raise HTTPException(404, detail="arena run not found")
+
+    async def gen():
+        try:
+            async for evt in svc.subscribe(run_id):
+                payload = json.dumps(evt.get("data"))
+                yield f"event: {evt['event']}\ndata: {payload}\n\n"
+        except asyncio.CancelledError:
+            return
+
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/tests/test_arena_router.py
+++ b/tests/test_arena_router.py
@@ -1,0 +1,71 @@
+"""#131 — arena API routes.
+
+Route-level behaviour (capability gate, validation, create/list/get) against
+the TestClient stub. The run *completion* path is proven at the service layer
+(test_arena_service.py) — here we keep things deterministic and don't wait on
+the background task to finish through the sync TestClient.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+def _arena_stub(req: httpx.Request) -> httpx.Response:
+    if req.url.path == "/status":
+        return httpx.Response(200, json={"version": "Subgen 2026.05.3 (test)"})
+    if req.url.path == "/queue":
+        return httpx.Response(200, json={
+            "queued": [], "processing": [],
+            "capabilities": {"asr_arena": True},
+        })
+    if req.url.path == "/asr":
+        return httpx.Response(200, text="1\n00:00:00,000 --> 00:00:02,000\nhi\n",
+                              headers={"content-type": "text/plain"})
+    return httpx.Response(404, json={"detail": "stub: unhandled"})
+
+
+def _body(label="a", kwargs=None, path="TV/Show/ep.mkv"):
+    return {"media_path": path, "variants": [{"label": label, "kwargs": kwargs or {}}]}
+
+
+def test_run_blocked_when_subgen_lacks_asr_arena(app_with_stub):
+    # default stub /queue advertises no asr_arena → 503 with a clear reason
+    r = app_with_stub.post("/api/arena/run", json=_body())
+    assert r.status_code == 503
+    assert r.json()["detail"]["error"] == "unsupported"
+    assert "v4.10" in r.json()["detail"]["reason"]
+
+
+@pytest.mark.subgen(handler=_arena_stub)
+def test_run_created_and_listed(app_with_stub):
+    r = app_with_stub.post("/api/arena/run", json=_body(kwargs={"beam_size": 5}))
+    assert r.status_code == 202
+    run = r.json()
+    assert run["status"] in ("pending", "running", "done")
+    assert run["variants"] == [{"label": "a", "kwargs": {"beam_size": 5}}]
+    rid = run["id"]
+
+    got = app_with_stub.get(f"/api/arena/{rid}")
+    assert got.status_code == 200 and got.json()["id"] == rid
+
+    listed = app_with_stub.get("/api/arena/runs").json()["runs"]
+    assert any(x["id"] == rid for x in listed)
+
+
+@pytest.mark.subgen(handler=_arena_stub)
+def test_duplicate_variant_labels_rejected(app_with_stub):
+    body = {"media_path": "TV/Show/ep.mkv",
+            "variants": [{"label": "a", "kwargs": {}}, {"label": "a", "kwargs": {"x": 1}}]}
+    r = app_with_stub.post("/api/arena/run", json=body)
+    assert r.status_code == 400
+
+
+@pytest.mark.subgen(handler=_arena_stub)
+def test_unknown_path_404(app_with_stub):
+    r = app_with_stub.post("/api/arena/run", json=_body(path="TV/Nope/missing.mkv"))
+    assert r.status_code == 404
+
+
+def test_get_unknown_run_404(app_with_stub):
+    assert app_with_stub.get("/api/arena/deadbeef").status_code == 404

--- a/tests/test_arena_service.py
+++ b/tests/test_arena_service.py
@@ -1,0 +1,97 @@
+"""#131 — ArenaService: background run lifecycle + SSE event stream.
+
+Mirrors ScanRunner's shape (create → start → _run task → subscribe()). Driven
+here by a fake CandidateRunner so the lifecycle is tested without subgen.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from subarr.arena import ArenaUnsupported, ConfigVariant
+from subarr.arena_service import ArenaRun, ArenaService
+
+
+def _srt(line: str) -> str:
+    return f"1\n00:00:00,000 --> 00:00:03,000\n{line}\n"
+
+
+class FakeRunner:
+    def __init__(self, outputs, supported=True):
+        self._outputs = list(outputs)
+        self._supported = supported
+
+    async def preflight(self):
+        if not self._supported:
+            raise ArenaUnsupported("needs v4.10")
+
+    async def run(self, media_path, *, task, kwargs):
+        return self._outputs.pop(0) if self._outputs else None
+
+
+def _service(outputs, supported=True) -> ArenaService:
+    return ArenaService(build_runner=lambda run: FakeRunner(outputs, supported))
+
+
+def test_create_returns_pending_run():
+    svc = _service([])
+    run = svc.create("/media/clip.mkv",
+                     [ConfigVariant("a", {"beam_size": 5})], source_language="ko")
+    assert run.status == "pending"
+    assert run.id and svc.get(run.id) is run
+    d = run.to_dict()
+    assert d["media_path"] == "/media/clip.mkv"
+    assert d["variants"] == [{"label": "a", "kwargs": {"beam_size": 5}}]
+    assert d["source_language"] == "ko"
+
+
+@pytest.mark.asyncio
+async def test_run_completes_and_records_result():
+    svc = _service([_srt("source line"), _srt("cand a"), _srt("cand b")])
+    run = svc.create("/m.mkv", [ConfigVariant("a", {}), ConfigVariant("b", {})])
+    svc.start(run)
+    await svc._tasks[run.id]
+
+    assert run.status == "done"
+    assert run.source_text == "source line"
+    assert [o["label"] for o in run.outcomes] == ["a", "b"]
+    assert all(o["ok"] for o in run.outcomes)
+    assert run.result is not None
+    assert "scorecards" in run.result and "winner_label" in run.result
+
+
+@pytest.mark.asyncio
+async def test_preflight_failure_marks_error():
+    svc = _service([], supported=False)
+    run = svc.create("/m.mkv", [ConfigVariant("a", {})])
+    svc.start(run)
+    await svc._tasks[run.id]
+
+    assert run.status == "error"
+    assert "v4.10" in run.error
+    assert run.result is None
+
+
+@pytest.mark.asyncio
+async def test_events_streamed_to_subscriber():
+    svc = _service([_srt("src"), _srt("a"), None])
+    run = svc.create("/m.mkv", [ConfigVariant("a", {}), ConfigVariant("b", {})])
+
+    events: list[dict] = []
+
+    async def collect():
+        async for evt in svc.subscribe(run.id):
+            events.append(evt)
+
+    consumer = asyncio.create_task(collect())
+    await asyncio.sleep(0)      # let the subscriber register before the run emits
+    svc.start(run)
+    await svc._tasks[run.id]
+    await asyncio.wait_for(consumer, timeout=2)
+
+    kinds = [e["event"] for e in events]
+    assert kinds[0] == "start"
+    assert "source" in kinds
+    assert kinds.count("variant") == 2
+    assert kinds[-1] == "done"


### PR DESCRIPTION
Wraps the arena orchestrator (#132) in a background-run lifecycle + HTTP surface, mirroring the `ScanRunner` / scan-router pattern subarr already uses.

## What
- **`ArenaService`** — `create()` → pending run, `start()` → asyncio task driving `run_arena`, `subscribe()` async-gen for SSE. In-memory (a sweep is a transient experiment, not an audited scan). Run state stays light: live `outcomes` carry label/ok/error; `result` is the serialized `TournamentResult`.
- **`run_arena` hooks** — optional `on_source` / `on_variant` so the service pushes live progress without blocking the sweep.
- **`routers/arena.py`**:
  - `POST /api/arena/run` — validates the media path + unique labels, **gates on `capabilities.asr_arena`** with a clear 503 ("needs subarr-subgen ≥v4.10") so older subgen fails legibly.
  - `GET /api/arena/runs`, `GET /api/arena/{id}`, `GET /api/arena/{id}/events` (SSE, `text/event-stream`).
- **app wiring** — `app.state.arena = ArenaService(build_runner=AsrRunner …)` resolving the **live** subgen client + caps per run (picks up onboarding client-swaps / subgen upgrades without a restart).

## Why poll/SSE, not a new push system
Subarr is store-backed + `usePoller` throughout, with SSE already used by the scan router. An arena run is a **user-initiated, infrequent, long-lived job**, so it fits that exact pattern — SSE for live progress + a state endpoint to read once. No new infra.

## Tests
TDD — `ArenaService` lifecycle + event stream, route gate/validation/create/list/404. Full suite **455 passed**.

## Remaining on #131
- Tuning-lab UI tab.
- Adopt-winner → per-language config persistence (reuse #112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)