### PR TITLE
fix(telemetry): gate ollama-configured on real reachability (#119)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -128,6 +128,11 @@ async def lifespan(app_: FastAPI):
     app_.state.watcher.start()
     app_.state.schedule = ScheduleStore(settings.db_path)
     app_.state.ollama = OllamaClient()
+    # #119: last-known ollama reachability, populated by the integrations-
+    # health probe (GET /api/integrations/health). None until first probe;
+    # telemetry gates "ollama configured" on this real signal instead of
+    # the defaulted OLLAMA_URL (non-empty on every install).
+    app_.state.ollama_probe_result = None
     # v1.1-O Layer 4: user audio-language verifications (manual review queue).
     from .audio_lang_store import AudioLangStore
     app_.state.audio_lang = AudioLangStore(settings.db_path)

--- a/src/subarr/routers/integrations.py
+++ b/src/subarr/routers/integrations.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -16,6 +17,16 @@ from ..integrations import IntegrationError
 
 router = APIRouter(prefix="/api", tags=["integrations"])
 log = logging.getLogger(__name__)
+
+
+@dataclass
+class OllamaProbeResult:
+    """Last-known ollama reachability, cached on app.state by the
+    integrations-health endpoint. Mirrors the subgen_caps `.reachable`
+    pattern so telemetry can report ollama on a REAL signal (was
+    /api/tags reachable?) rather than the defaulted OLLAMA_URL, which is
+    non-empty on every install (#119)."""
+    reachable: bool
 
 
 async def _probe(name: str, client, summary_kind: str = "version") -> dict[str, Any]:
@@ -90,6 +101,14 @@ async def integrations_health(request: Request) -> dict[str, Any]:
     if ollama is not None:
         probes_coros.append(_probe("ollama", ollama, "ollama_models"))
     probes = await asyncio.gather(*probes_coros)
+    # #119: cache ollama reachability on app.state so telemetry reports it
+    # on a real signal (was /api/tags up?) instead of the defaulted URL.
+    # The ollama probe, when present, is always the last entry appended.
+    if ollama is not None:
+        ollama_probe = next((p for p in probes if p.get("name") == "ollama"), None)
+        request.app.state.ollama_probe_result = OllamaProbeResult(
+            reachable=bool(ollama_probe and ollama_probe.get("online"))
+        )
     # Subgen capabilities probed once at boot, cached on app.state.
     # Surfaced here so the UI can show "compat mode" badges + gate
     # scan-submit on has_batch.

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -412,14 +412,27 @@ def make_default_stats_provider(app_state) -> Any:
         except Exception:
             pass
 
-        # Integrations — configured = api key is non-empty
+        # Integrations — configured = api key is non-empty. Every keyed
+        # integration defaults to an empty key, so bool() is only True
+        # when the user actually wired it up.
+        #
+        # #119: ollama has NO key — only a URL that defaults to
+        # http://ollama:11434 on every install, so bool(settings.ollama_url)
+        # reported "configured" 100% of the time (a measurement artifact,
+        # not real adoption). Gate instead on the cached reachability from
+        # the integrations-health probe (/api/tags), mirroring how
+        # subgen_caps.reachable is cached on app.state. If the probe hasn't
+        # run yet (None), treat as not-configured rather than trusting the
+        # defaulted URL.
+        ollama_probe = getattr(app_state, "ollama_probe_result", None)
+        ollama_reachable = bool(ollama_probe and getattr(ollama_probe, "reachable", False))
         integrations = {
             "bazarr":   bool(settings.bazarr_api_key),
             "sonarr":   bool(settings.sonarr_api_key),
             "radarr":   bool(settings.radarr_api_key),
             "tautulli": bool(settings.tautulli_api_key),
             "plex":     bool(settings.plex_token),
-            "ollama":   bool(settings.ollama_url),
+            "ollama":   ollama_reachable,
         }
 
         # Docker tier inferred from config presence

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -258,3 +258,66 @@ async def test_last_payload_parses_back_to_dict(db_path: Path):
     st = c.state()
     assert isinstance(st.last_payload, dict)
     assert st.last_payload["install_id"] == st.install_id
+
+
+# ─── make_default_stats_provider: ollama configured signal (#119) ───
+#
+# Regression: ollama was reported "configured" for EVERY install because it
+# gated on bool(settings.ollama_url), which defaults to http://ollama:11434.
+# It must instead reflect REAL reachability from the cached integrations-
+# health probe (app.state.ollama_probe_result.reachable), mirroring the
+# subgen_caps pattern.
+
+
+from types import SimpleNamespace
+
+from subarr.telemetry import make_default_stats_provider
+
+
+def _fake_app_state(db_path: Path, ollama_probe_result) -> SimpleNamespace:
+    """Minimal app.state stand-in for make_default_stats_provider.
+
+    Only the attributes the provider touches are wired; everything that
+    can raise is left absent so the provider's try/except fallbacks fire
+    and we isolate the ollama-reachability assertion."""
+    from subarr.probe_store import ProbeStore
+    from subarr.scan_store import ScanStore
+    from subarr.error_store import ErrorStore
+    from subarr.schedule_store import ScheduleStore
+
+    return SimpleNamespace(
+        probe_store=ProbeStore(db_path),
+        scans=ScanStore(db_path),
+        errors=ErrorStore(db_path),
+        schedule=ScheduleStore(db_path),
+        ollama_probe_result=ollama_probe_result,
+    )
+
+
+def test_ollama_configured_true_when_probe_reachable(db_path: Path):
+    """Cached probe says ollama is reachable → reported configured."""
+    state = _fake_app_state(db_path, SimpleNamespace(reachable=True))
+    provider = make_default_stats_provider(state)
+    out = provider()
+    assert out["integrations"]["ollama"] is True
+
+
+def test_ollama_not_configured_when_defaulted_url_but_unreachable(db_path: Path):
+    """Defaulted OLLAMA_URL but nothing listening → cached probe is
+    unreachable → NOT reported configured (the #119 fix). bool(ollama_url)
+    would have been True here on every install."""
+    from subarr.config import settings
+    assert settings.ollama_url  # the default string is non-empty (pre-fix bug)
+    state = _fake_app_state(db_path, SimpleNamespace(reachable=False))
+    provider = make_default_stats_provider(state)
+    out = provider()
+    assert out["integrations"]["ollama"] is False
+
+
+def test_ollama_not_configured_when_probe_never_ran(db_path: Path):
+    """No cached probe yet (app.state.ollama_probe_result is None) →
+    treat as not-configured rather than falling back to the URL default."""
+    state = _fake_app_state(db_path, None)
+    provider = make_default_stats_provider(state)
+    out = provider()
+    assert out["integrations"]["ollama"] is False


### PR DESCRIPTION
Closes #119.

Telemetry reported the ollama integration "configured" on ~100% of installs because it gated on `bool(settings.ollama_url)`, which defaults to `http://ollama:11434` (always non-empty). Now gates on real reachability, mirroring the existing `subgen_caps.reachable` pattern.

## Changes
- `routers/integrations.py`: `OllamaProbeResult(reachable)` cached on `app.state.ollama_probe_result` after the health fan-out (reuses the existing `/api/tags` probe — `online=True` means reachable).
- `app.py`: one-line `app_.state.ollama_probe_result = None` init.
- `telemetry.py`: `"ollama"` now reads the cached probe; None → not-configured.
- `tests/test_telemetry.py`: +3 tests (reachable→configured, defaulted-URL-but-unreachable→NOT, never-probed→NOT). TDD red→green.

`PYTHONPATH=src python -m pytest tests/test_telemetry.py` → 17 passed. Confirmed plex/bazarr/sonarr/radarr/tautulli are genuinely key-gated; ollama was the only inflated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)