### PR TITLE
feat(queue): consume subgen WEBHOOK_URL_COMPLETED push (#87)

### DIFF
--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -173,20 +173,50 @@ class CompletionWatcher:
             subgen_path = canonical_to_subgen_batch(entry.canonical_path)
             if subgen_path in in_flight:
                 continue
-            self._provenance.mark_completed(entry.id)
-            log.info("completion: %s (ledger #%d)", entry.canonical_path, entry.id)
-            # v1.1-G: try direct multipart upload first (closes the loop
-            # tightly + no race vs. Bazarr's filesystem scan). Falls back
-            # to scan-disk task if upload fails or we lack episode_id.
-            uploaded = await self._try_upload_to_bazarr(entry)
-            if not uploaded and entry.series_id is not None:
-                await self._trigger_bazarr_scan(entry.id, entry.series_id)
-            # v1.1.1: fire Plex partial-scan against the file's directory
-            # so the freshly-written sidecar appears in Plex (and on Apple
-            # TV) without waiting for Plex's periodic scan. Best-effort —
-            # failure here doesn't unwind anything; Plex will pick it up
-            # on the next periodic scan anyway.
-            await self._maybe_plex_partial_scan(entry.canonical_path)
+            await self.complete_entry(entry)
+
+    async def complete_entry(self, entry) -> None:
+        """Run the full completion flow for one ledger entry: mark it
+        completed, write the .srt back to Bazarr (direct upload, falling
+        back to a scan-disk trigger), and fire a Plex partial-scan.
+
+        This is the single battle-tested completion path. It is invoked
+        both by the polling pass (_pass_pending) and by the push-based
+        webhook receiver (#87). Idempotent enough for either driver — a
+        second call merely re-stamps completed_at and re-fires harmless
+        best-effort write-backs.
+        """
+        self._provenance.mark_completed(entry.id)
+        log.info("completion: %s (ledger #%d)", entry.canonical_path, entry.id)
+        # v1.1-G: try direct multipart upload first (closes the loop
+        # tightly + no race vs. Bazarr's filesystem scan). Falls back
+        # to scan-disk task if upload fails or we lack episode_id.
+        uploaded = await self._try_upload_to_bazarr(entry)
+        if not uploaded and entry.series_id is not None:
+            await self._trigger_bazarr_scan(entry.id, entry.series_id)
+        # v1.1.1: fire Plex partial-scan against the file's directory
+        # so the freshly-written sidecar appears in Plex (and on Apple
+        # TV) without waiting for Plex's periodic scan. Best-effort —
+        # failure here doesn't unwind anything; Plex will pick it up
+        # on the next periodic scan anyway.
+        await self._maybe_plex_partial_scan(entry.canonical_path)
+
+    async def complete_by_canonical(self, canonical_path: str) -> int:
+        """Push entrypoint (#87): given a canonical path that subgen just
+        reported finished via WEBHOOK_URL_COMPLETED, run the completion
+        flow for every matching still-pending ledger entry.
+
+        Returns the number of entries completed. Zero is normal and benign
+        — it just means the polling pass already handled this path, or the
+        path was never tracked by subarr (e.g. a subgen Plex/Tautulli
+        auto-transcribe rather than a subarr-submitted job)."""
+        matches = [
+            e for e in self._provenance.query_by_path(canonical_path)
+            if e.completed_at is None
+        ]
+        for entry in matches:
+            await self.complete_entry(entry)
+        return len(matches)
 
     async def _pass_retry_bazarr_notify(self) -> None:
         """Find ledger entries that completed but never successfully fired

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -78,6 +78,13 @@ class Settings:
     # set PLEX_PARTIAL_SCAN_ENABLED=0 to fall back to whatever scan cadence
     # Plex's own scheduler runs at.
     plex_partial_scan_enabled: bool
+    # #87: accept subgen's WEBHOOK_URL_COMPLETED push at
+    # POST /api/subgen/webhook/completed. Push beats polling — lower
+    # queue-UI latency, fewer requests. Default on; the polling watcher
+    # stays running as the fallback for vanilla subgen (operators who
+    # haven't pointed WEBHOOK_URL_COMPLETED at subarr). Set
+    # SUBARR_SUBGEN_WEBHOOK_ENABLED=0 to reject pushes and rely on polling.
+    subgen_webhook_enabled: bool
     # v1.1.1 #219 closer: PUT user-verified audio language back to Sonarr's
     # episodeFile so Bazarr's next sync sees the correct foreign-language
     # audio and unblinds itself. Writes to Sonarr's DB, so OPT-IN. Default
@@ -181,6 +188,9 @@ def load() -> Settings:
         plex_partial_scan_enabled=_env_or(
             "PLEX_PARTIAL_SCAN_ENABLED", "1"
         ).strip().lower() not in ("0", "false", "no", "off"),
+        subgen_webhook_enabled=_env_or(
+            "SUBARR_SUBGEN_WEBHOOK_ENABLED", "1"
+        ).strip().lower() not in ("0", "false", "no", "off"),
         sonarr_propagate_audio_lang=os.environ.get(
             "SONARR_PROPAGATE_AUDIO_LANG", "0"
         ).strip().lower() in ("1", "true", "yes", "on"),
@@ -258,6 +268,7 @@ FIELD_ENV_VARS: dict[str, str] = {
     "plex_audio_hints": "PLEX_AUDIO_HINTS",
     "sonarr_propagate_audio_lang": "SONARR_PROPAGATE_AUDIO_LANG",
     "plex_partial_scan_enabled": "PLEX_PARTIAL_SCAN_ENABLED",
+    "subgen_webhook_enabled": "SUBARR_SUBGEN_WEBHOOK_ENABLED",
 }
 
 
@@ -287,6 +298,7 @@ _FIELD_COERCE = {
     "plex_audio_hints": _coerce_bool,
     "sonarr_propagate_audio_lang": _coerce_bool,
     "plex_partial_scan_enabled": _coerce_bool,
+    "subgen_webhook_enabled": _coerce_bool,
     "ollama_model": str,
     "ollama_url": str,
     "ollama_vision_model": str,

--- a/src/subarr/paths.py
+++ b/src/subarr/paths.py
@@ -68,3 +68,26 @@ def canonical_to_subgen_batch(canonical: str) -> str:
     if rel:
         return f"{prefix}/{rel}"
     return prefix + "/"
+
+
+def subgen_to_canonical(subgen_path: str) -> str:
+    """Inverse of canonical_to_subgen_batch: map a subgen-space absolute
+    path (e.g. `/media/TV/Show/file.mkv`) back to subarr's canonical form
+    (`TV/Show/file.mkv`).
+
+    Used by the WEBHOOK_URL_COMPLETED receiver (#87): subgen's completion
+    webhook reports the source file at its OWN mount path, which is the
+    `subgen_media_prefix` prefix. We strip that prefix to get the canonical
+    key the provenance ledger is indexed by.
+
+    If the path doesn't start with the configured prefix, it's returned
+    stripped of leading slashes as a best-effort canonical — the caller
+    will simply find no matching ledger entry, which is benign.
+    """
+    p = (subgen_path or "").strip()
+    prefix = settings.subgen_media_prefix.rstrip("/")
+    if prefix and p.startswith(prefix + "/"):
+        return p[len(prefix) + 1:].strip("/")
+    if prefix and p == prefix:
+        return ""
+    return p.strip("/")

--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -250,6 +250,78 @@ async def get_queue(request: Request, history_window_s: int = _DEFAULT_HISTORY_W
     }
 
 
+# ─── subgen push completion (#87) ────────────────────────────────────────
+
+class SubgenCompletedWebhook(BaseModel):
+    """Payload subgen POSTs to WEBHOOK_URL_COMPLETED on task finish.
+
+    Verified against subgen_patched.send_completion_webhook (2026-06):
+      { "event": "transcribed"|"translated"|...,
+        "file":     "/media/TV/Show/file.mkv",   # subgen-space abs path
+        "subtitle": "/media/TV/Show/file.en.srt",
+        "language": "en" }
+
+    `file` is the only field we strictly need (it keys the provenance
+    ledger after prefix-stripping). Everything else is accepted + logged
+    so a future subgen field never 422s the hook. extra="allow" keeps
+    unknown keys visible for logging without breaking validation.
+    """
+    model_config = {"extra": "allow"}
+
+    file: str | None = None
+    subtitle: str | None = None
+    event: str | None = None
+    language: str | None = None
+
+
+@router.post("/subgen/webhook/completed")
+async def subgen_webhook_completed(
+    payload: SubgenCompletedWebhook, request: Request,
+) -> dict:
+    """Push-based completion receiver (#87) — the low-latency alternative
+    to polling subgen's /queue. Operators point subgen's
+    WEBHOOK_URL_COMPLETED at this endpoint; subgen POSTs here the instant a
+    transcribe/translate finishes, and we run the SAME completion flow the
+    polling watcher uses (mark provenance completed → Bazarr write-back →
+    Plex partial-scan). Polling stays running as the fallback for vanilla
+    subgen setups that haven't configured the webhook.
+
+    Reuses CompletionWatcher.complete_by_canonical so the battle-tested
+    Bazarr/Plex logic lives in exactly one place. Idempotent: if polling
+    already completed the entry, this is a benign no-op (matched=0).
+    """
+    from ..config import settings as _settings
+    if not _settings.subgen_webhook_enabled:
+        # Operator opted out of push; tell subgen we received it so it
+        # doesn't log a delivery failure, but do nothing (polling drives).
+        return {"accepted": False, "reason": "webhook disabled", "matched": 0}
+
+    if not payload.file:
+        raise HTTPException(400, detail="payload missing 'file'")
+
+    # Log any fields beyond the documented shape so a subgen change is
+    # discoverable rather than silently dropped.
+    known = {"file", "subtitle", "event", "language"}
+    extra = {k: v for k, v in payload.model_dump().items() if k not in known}
+    if extra:
+        log.info("subgen completion webhook carried unknown fields: %s", extra)
+
+    from ..paths import subgen_to_canonical
+    canonical = subgen_to_canonical(payload.file)
+    watcher = request.app.state.watcher
+    matched = await watcher.complete_by_canonical(canonical)
+    log.info(
+        "subgen completion webhook: event=%s file=%s canonical=%s matched=%d",
+        payload.event, payload.file, canonical, matched,
+    )
+    return {
+        "accepted": True,
+        "canonical_path": canonical,
+        "event": payload.event,
+        "matched": matched,
+    }
+
+
 # ─── Per-row actions ─────────────────────────────────────────────────────
 
 class RequeueRequest(BaseModel):

--- a/tests/test_subgen_webhook.py
+++ b/tests/test_subgen_webhook.py
@@ -1,0 +1,120 @@
+"""Tests for the push-based subgen completion webhook (#87).
+
+POST /api/subgen/webhook/completed consumes subgen's WEBHOOK_URL_COMPLETED
+POSTs and runs the SAME completion flow the polling watcher uses (mark
+provenance completed → Bazarr write-back → Plex partial-scan). Polling
+stays as the fallback; this is the low-latency push alternative.
+
+Payload shape (verified against subgen_patched.send_completion_webhook):
+  { "event": "transcribed", "file": "/media/TV/Show/file.mkv",
+    "subtitle": "/media/TV/Show/file.en.srt", "language": "en" }
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+def _bazarr_tasks_handler(req: httpx.Request) -> httpx.Response:
+    """Bazarr stub that exposes the scan-disk task + records triggers."""
+    path = req.url.path
+    if path == "/api/system/tasks" and req.method == "GET":
+        return httpx.Response(200, json={"data": [
+            {"job_id": "series_full_scan_subtitles",
+             "name": "Index All Existing Episodes Subtitles"},
+        ]})
+    if path == "/api/system/tasks" and req.method == "POST":
+        # trigger_task — record the taskid so the test can assert it fired.
+        _bazarr_tasks_handler.triggered.append(req.url.params.get("taskid"))
+        return httpx.Response(204)
+    return httpx.Response(404, json={"detail": "stub: unhandled"})
+
+
+_bazarr_tasks_handler.triggered = []  # type: ignore[attr-defined]
+
+
+@pytest.mark.integrations_stub(bazarr_handler=_bazarr_tasks_handler)
+def test_webhook_marks_completed_and_triggers_flow(app_with_stub):
+    """A completed-webhook POST marks the matching provenance entry
+    completed AND fires the Bazarr scan-disk task (the shared completion
+    flow), proving the push path reuses the watcher logic."""
+    _bazarr_tasks_handler.triggered.clear()
+    app = app_with_stub.app
+
+    # Seed a pending provenance entry (as a scan submission would).
+    canonical = "TV/Foreign Drama/Season 1/Foreign.S01E03.mkv"
+    led_id = app.state.provenance.record(
+        canonical_path=canonical, scan_id="scan-1", series_id=42,
+    )
+    pending = app.state.provenance.query_by_path(canonical)
+    assert pending and pending[0].completed_at is None
+
+    # subgen reports completion at ITS mount path (/media prefix).
+    r = app_with_stub.post("/api/subgen/webhook/completed", json={
+        "event": "transcribed",
+        "file": "/media/TV/Foreign Drama/Season 1/Foreign.S01E03.mkv",
+        "subtitle": "/media/TV/Foreign Drama/Season 1/Foreign.S01E03.en.srt",
+        "language": "en",
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["accepted"] is True
+    assert body["matched"] == 1
+    assert body["canonical_path"] == canonical
+
+    # Provenance entry is now completed.
+    after = app.state.provenance.query_by_path(canonical)
+    assert after[0].id == led_id
+    assert after[0].completed_at is not None
+
+    # The shared completion flow fired Bazarr's scan-disk task (no .srt
+    # sidecar on disk → upload path falls through to scan-disk trigger).
+    assert "series_full_scan_subtitles" in _bazarr_tasks_handler.triggered
+
+
+def test_webhook_unknown_path_is_benign_noop(app_with_stub):
+    """A completion for a path subarr never tracked (e.g. a subgen Plex
+    auto-transcribe) returns matched=0 without error — not every subgen
+    job originated from subarr."""
+    r = app_with_stub.post("/api/subgen/webhook/completed", json={
+        "event": "transcribed",
+        "file": "/media/TV/Untracked/random.mkv",
+        "subtitle": "/media/TV/Untracked/random.en.srt",
+        "language": "en",
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["matched"] == 0
+
+
+def test_webhook_missing_file_is_400(app_with_stub):
+    r = app_with_stub.post("/api/subgen/webhook/completed", json={
+        "event": "transcribed", "language": "en",
+    })
+    assert r.status_code == 400
+
+
+def test_webhook_disabled_rejects_push(subarr_env, monkeypatch):
+    """When SUBARR_SUBGEN_WEBHOOK_ENABLED=0 the receiver accepts the POST
+    (so subgen doesn't log a delivery failure) but does nothing — polling
+    is the operator's chosen driver."""
+    monkeypatch.setenv("SUBARR_SUBGEN_WEBHOOK_ENABLED", "0")
+    # Rebuild settings so the env change takes effect for this test.
+    from subarr import config
+    monkeypatch.setattr(config, "settings", config.load())
+
+    from fastapi.testclient import TestClient
+    from subarr.app import app
+    with TestClient(app) as c:
+        canonical = "TV/Foreign Drama/Season 1/Foreign.S01E03.mkv"
+        c.app.state.provenance.record(
+            canonical_path=canonical, scan_id="scan-x", series_id=42,
+        )
+        r = c.post("/api/subgen/webhook/completed", json={
+            "event": "transcribed",
+            "file": "/media/" + canonical,
+        })
+        assert r.status_code == 200
+        assert r.json()["accepted"] is False
+        # Entry stays pending — push was ignored.
+        after = c.app.state.provenance.query_by_path(canonical)
+        assert after[0].completed_at is None


### PR DESCRIPTION
Closes #87.

Adds a push-based completion path from subgen (`WEBHOOK_URL_COMPLETED`) as an alternative to polling `/queue`. Polling stays on as the fallback.

## Payload
`{"event":"transcribed","file":"/media/TV/Show/file.mkv","subtitle":".../file.en.srt","language":"en"}` — `file` (subgen-space absolute path) is the only required field; it keys the provenance ledger after prefix-stripping.

## Changes (151 insertions, no app.py edit)
- `completion_watcher.py`: extracted per-entry flow into `complete_entry(entry)` (polling pass reuses it) + `complete_by_canonical(path)` push entrypoint. Bazarr/Plex write-back unchanged, now single-sourced.
- `paths.py`: `subgen_to_canonical()` (inverse of `canonical_to_subgen_batch`).
- `config.py`: `subgen_webhook_enabled` (`SUBARR_SUBGEN_WEBHOOK_ENABLED`, default ON) wired into `FIELD_ENV_VARS` + `_FIELD_COERCE`.
- `routers/queue.py`: `POST /api/subgen/webhook/completed` — pydantic `extra="allow"`, 400 on missing `file`, benign `matched=0` for untracked paths, idempotent vs polling.
- `tests/test_subgen_webhook.py`: new (completed→provenance+Bazarr scan; unknown-path no-op; missing-file 400; disabled-flag rejects).

`PYTHONPATH=src python -m pytest` → 78 passing (4 new + watcher/queue/paths/config/onboarding all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)