### PR TITLE
feat(coverage): inherit series audio-language intent to new episodes (#69)

### DIFF
--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -775,6 +775,90 @@ def _classify_audio_label(item: CoverageItem,
         item.audio_source = "ffprobe"
 
 
+class _SeriesIntentLookup(dict):
+    """A {canonical_path: value} map that, on a miss, falls back to the
+    longest series-intent prefix that the looked-up path starts with.
+
+    #69: the coverage build loads verifications in BULK (get_all_as_lookup),
+    which deliberately does NOT flatten series intents into one synthetic row
+    per episode — that would be O(declared series x episodes) and would go
+    stale the instant a new episode is added. Instead we keep the per-file
+    rows as the fast exact-match layer and resolve series-intent inheritance
+    lazily here. The net effect: a NEW episode under a declared-language
+    series auto-resolves as verified during the coverage build, without any
+    per-file re-verification — which is exactly the issue's intent.
+
+    Per-file rows always win because dict exact-match short-circuits before
+    the prefix fallback ever runs.
+    """
+
+    __slots__ = ("_intents",)
+
+    def __init__(self, base: dict, intents: list[tuple[str, str]]):
+        super().__init__(base)
+        # Longest prefix first so the most specific declaration wins.
+        self._intents = sorted(intents, key=lambda t: len(t[0]), reverse=True)
+
+    def __bool__(self) -> bool:
+        # Truthy if EITHER per-file rows OR series intents exist — callers
+        # guard with `if user_verifications and ...`, and an intents-only
+        # store (no per-file rows yet) must still be consulted (#69).
+        return bool(len(self) or self._intents)
+
+    def _match_intent(self, key) -> str | None:
+        if not isinstance(key, str):
+            return None
+        for prefix, value in self._intents:
+            if key.startswith(prefix):
+                return value
+        return None
+
+    def __contains__(self, key) -> bool:  # type: ignore[override]
+        if super().__contains__(key):
+            return True
+        return self._match_intent(key) is not None
+
+    def __missing__(self, key):
+        value = self._match_intent(key)
+        if value is None:
+            raise KeyError(key)
+        return value
+
+    def get(self, key, default=None):  # type: ignore[override]
+        if super().__contains__(key):
+            return super().__getitem__(key)
+        value = self._match_intent(key)
+        return value if value is not None else default
+
+
+def _build_verification_lookup(audio_lang_store: Any):
+    """Build the (user_verifications, verification_sources) pair the coverage
+    build feeds to _classify_audio_label / _refine_audio_sources.
+
+    Per-file verifications are the exact-match fast path; declared series
+    intents are layered underneath via longest-prefix fallback (#69) so new
+    episodes of a declared series inherit the language automatically.
+    """
+    if audio_lang_store is None:
+        return {}, {}
+    base_langs = audio_lang_store.get_all_as_lookup()
+    base_sources = audio_lang_store.get_all_sources_as_lookup()
+    intents = audio_lang_store.list_series_intents()
+    lang_intents: list[tuple[str, str]] = [
+        (i["series_prefix"], i["lang_code"]) for i in intents
+    ]
+    # Source string mirrors the per-path get() inheritance label so the UI
+    # badge (via _refine_audio_sources -> "user") and any source-aware
+    # consumer treats inherited rows as user-sourced.
+    source_intents: list[tuple[str, str]] = [
+        (i["series_prefix"], f"series_intent:{i.get('source', 'user')}")
+        for i in intents
+    ]
+    user_verifications = _SeriesIntentLookup(base_langs, lang_intents)
+    verification_sources = _SeriesIntentLookup(base_sources, source_intents)
+    return user_verifications, verification_sources
+
+
 def _refine_audio_sources(items: list, verification_sources: dict) -> None:
     """Post-pass: _classify set audio_source='user' for any store-verified hit;
     refine it to the ACTUAL verification source so the UI badge distinguishes
@@ -988,13 +1072,15 @@ async def build_coverage(
 
     # v1.1-O Layer 4: load user verifications. These OVERRIDE all
     # auto-detected signals — user has ground truth.
-    user_verifications: dict[str, str] = (
-        audio_lang_store.get_all_as_lookup() if audio_lang_store else {}
-    )
-    # Per-file verification SOURCE (user / whisper-robust / auto-high-conf),
-    # used by the post-pass to refine audio_source for the UI confidence badge.
-    verification_sources: dict[str, str] = (
-        audio_lang_store.get_all_sources_as_lookup() if audio_lang_store else {}
+    #
+    # #69: the lookups are intent-aware — per-file verifications are the
+    # exact-match fast path, and declared series-level intents are layered
+    # underneath via longest-prefix fallback so NEW episodes of a declared
+    # series auto-resolve as verified during this build (no per-file
+    # re-verification needed). verification_sources mirrors the inheritance
+    # so the UI confidence badge attributes inherited rows to the user.
+    user_verifications, verification_sources = _build_verification_lookup(
+        audio_lang_store
     )
 
     items: list[CoverageItem] = []

--- a/tests/test_coverage_series_intent.py
+++ b/tests/test_coverage_series_intent.py
@@ -1,0 +1,97 @@
+"""#69: series-level audio-language intent expands to NEW episodes during a
+coverage build.
+
+The store already inherits intent on a per-path get() (#226), but the coverage
+build loads verifications in BULK via get_all_as_lookup(), which deliberately
+does NOT flatten series intents (would be O(series x episodes)). So a declared
+series whose new episode has no per-file verification row was NOT auto-applied
+during classification. This wires the intent-aware lookup into build_coverage's
+user_verifications so a matching new episode resolves as user-verified.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.audio_lang_store import AudioLangStore
+    db = tmp_path / "audio_lang.db"
+    run_migrations(db)
+    yield AudioLangStore(db)
+
+
+def _ep(canonical, file_canonical):
+    from subarr.coverage_engine import CoverageItem
+    return CoverageItem(
+        media_type="episode", title="Cheers", canonical_path=canonical,
+        episode_number="1x9", file_canonical_path=file_canonical,
+        audio_langs=["und"], original_language="english",
+    )
+
+
+def test_intent_lookup_resolves_new_episode_under_declared_series(store):
+    """A series intent declared on the parent prefix makes a NEW episode
+    (no per-file verification) resolve via the bulk lookup used by the
+    coverage build."""
+    from subarr.coverage_engine import _build_verification_lookup
+
+    store.set_series_intent(series_prefix="TV/Cheers/", lang_code="eng")
+    user_verifications, verification_sources = _build_verification_lookup(store)
+
+    new_ep = "TV/Cheers/Season 1/Cheers.S01E09.mkv"
+    # The new episode has no per-file row, yet membership + value resolve via
+    # longest-prefix series-intent inheritance.
+    assert new_ep in user_verifications
+    assert user_verifications[new_ep] == "eng"
+    assert verification_sources.get(new_ep).startswith("series_intent")
+
+
+def test_classify_marks_new_episode_verified_from_series_intent(store):
+    """End-to-end through the classifier: a declared series turns an
+    un-tagged (und) new episode into an audio-verified row."""
+    from subarr.coverage_engine import (
+        _build_verification_lookup, _classify_audio_label,
+    )
+
+    store.set_series_intent(series_prefix="TV/Cheers/", lang_code="eng")
+    user_verifications, _ = _build_verification_lookup(store)
+
+    item = _ep("TV/Cheers", "TV/Cheers/Season 1/Cheers.S01E09.mkv")
+    assert item.audio_verified is False  # default before classify
+
+    _classify_audio_label(item, user_verifications=user_verifications)
+
+    assert item.audio_verified is True
+    assert item.audio_langs == ["eng"]
+    assert item.audio_label_unknown is False
+
+
+def test_per_file_verification_still_wins_over_intent(store):
+    """A real per-file verification must beat the inherited series intent."""
+    from subarr.coverage_engine import _build_verification_lookup
+
+    store.set_series_intent(series_prefix="TV/Cheers/", lang_code="eng")
+    store.upsert(canonical_path="TV/Cheers/Season 1/Cheers.S01E05.mkv",
+                 lang_code="fre")
+    user_verifications, _ = _build_verification_lookup(store)
+
+    assert user_verifications["TV/Cheers/Season 1/Cheers.S01E05.mkv"] == "fre"
+
+
+def test_unrelated_path_not_matched(store):
+    """A path outside any declared series prefix is NOT a member."""
+    from subarr.coverage_engine import _build_verification_lookup
+
+    store.set_series_intent(series_prefix="TV/Cheers/", lang_code="eng")
+    user_verifications, _ = _build_verification_lookup(store)
+
+    assert "TV/Frasier/Season 1/Frasier.S01E01.mkv" not in user_verifications
+
+
+def test_no_store_yields_empty_lookups():
+    from subarr.coverage_engine import _build_verification_lookup
+    uv, vs = _build_verification_lookup(None)
+    assert uv == {}
+    assert vs == {}


### PR DESCRIPTION
Closes #69.

`audio_lang_store` already had `series_lang_intent` + per-path inheritance in `AudioLangStore.get()`, but `build_coverage()` loads verifications in **bulk** via `get_all_as_lookup()` / `get_all_sources_as_lookup()`, which don't flatten series intents — and `_classify_audio_label` only does exact-match `file_path in user_verifications`. So new episodes of a declared series never inherited the language during a coverage build.

## Changes (only `coverage_engine.py` + new test)
- `_SeriesIntentLookup(dict)`: on a miss, falls back to the **longest series-intent prefix** the path starts with. Per-file rows always win (exact match short-circuits). Overrides `__contains__`/`__missing__`/`.get()`/`__bool__` (the last is essential — the classifier guards `if user_verifications and ...`, and an intents-only store has a falsy base dict).
- `_build_verification_lookup(audio_lang_store)`: layers `list_series_intents()` under per-file rows for both `user_verifications` (lang) and `verification_sources` (labelled `series_intent:<src>`, so `_refine_audio_sources` attributes inherited rows to "user").
- `build_coverage()`: the two raw `get_all_*` assignments → one `_build_verification_lookup()` call.
- `tests/test_coverage_series_intent.py`: 5 tests (inherited new episode resolves verified end-to-end; per-file-wins; unrelated-path miss; no-store).

`PYTHONPATH=src python -m pytest` → **460 passed**.

> ⚠️ **Integration note:** `feat/131-arena-ui` reworks the same `build_coverage()` verification-loading block (the #90 whisper/user loader-split). When that branch rebases onto main, reconcile the two: build `user_verifications` via this PR's `_build_verification_lookup` (series-intent fallback) **and** keep #90's `_is_machine` split for `whisper_verifications`. They're complementary (intents are user-sourced, never whisper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)