### PR TITLE
fix(coverage): debounce/coalesce refresh + parallelize per-series rglobs (#104)

### DIFF
--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -104,6 +104,14 @@ class Settings:
     # the model from onboarding. Set SUBARR_VAD_ENABLED=0 to hard-disable.
     vad_enabled: bool
 
+    # #104: minimum seconds between coverage-cache rebuilds triggered by
+    # event kicks (completion / audio-lang verify / manual refresh). A
+    # burst of events coalesces into a single rebuild, and rebuilds are
+    # spaced at least this far apart so we don't hammer the NAS + thread
+    # pool. The fixed background loop (DEFAULT_INTERVAL_S) is the floor
+    # cadence; this knob debounces the on-demand kicks on top of it.
+    coverage_refresh_min_interval_s: float
+
     # v1.1 Coverage dashboard integrations. Empty url disables the upstream.
     bazarr_url: str
     bazarr_api_key: str
@@ -199,6 +207,11 @@ def load() -> Settings:
         ).strip().lower() in ("1", "true", "yes", "on"),
         vad_enabled=_env_or("SUBARR_VAD_ENABLED", "1").strip().lower()
         not in ("0", "false", "no", "off"),
+        # #104: default 120s. Min-clamped at 0 (a 0/negative value disables
+        # debounce — every kick rebuilds, the pre-#104 behaviour).
+        coverage_refresh_min_interval_s=max(
+            0.0, float(_env_or("SUBARR_COVERAGE_REFRESH_MIN_INTERVAL_S", "120"))
+        ),
         # Integration URLs use _env_or so a blank line in .env still gets the
         # sane in-cluster default. Disabling an integration is signalled by
         # the empty api_key, not by clearing the URL.

--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -129,6 +129,111 @@ class CoverageCache:
         # is currently being rebuilt.
         self._refresh_lock = asyncio.Lock()
         self._refreshing = False
+        # #104 debounce/coalesce state. `request_refresh` is the single
+        # entry point for all event-driven kicks (completion / audio-lang
+        # verify / manual refresh / queue change). It collapses a burst of
+        # kicks into at most one in-flight build + one queued follow-up,
+        # and spaces builds at least `_min_interval_s` apart.
+        from . import config
+        try:
+            self._min_interval_s: float = config.load().coverage_refresh_min_interval_s
+        except Exception:
+            self._min_interval_s = 120.0
+        self._last_refresh_done: float = 0.0  # monotonic clock
+        self._pending_again: bool = False     # coalesced follow-up flag
+        self._pending_args: tuple | None = None  # args for the follow-up
+        self._refresh_task: asyncio.Task | None = None
+        self._debounce_handle: asyncio.TimerHandle | None = None
+
+    # ─── #104: debounce / coalesce ──────────────────────────────────
+    @property
+    def min_interval_s(self) -> float:
+        return self._min_interval_s
+
+    def set_min_interval_s(self, v: float) -> None:
+        self._min_interval_s = max(0.0, float(v))
+
+    def has_pending_refresh(self) -> bool:
+        """True when a coalesced follow-up build is queued or a debounce
+        timer is armed — i.e. work is still pending beyond the current
+        in-flight build."""
+        return self._pending_again or self._debounce_handle is not None
+
+    def request_refresh(self, bundle, probe_store, audio_lang_store,
+                        *, use_tautulli: bool = True, probe_walker=None) -> None:
+        """Single coalescing entry point for event-driven refresh kicks.
+
+        Behaviour:
+        - If a build is in flight: set a flag so exactly ONE follow-up
+          build runs after it completes (N kicks → 1 follow-up, not N).
+        - Else if we're inside the min-interval debounce window since the
+          last build: arm (or keep) a single timer to run one build when
+          the window elapses. Repeated kicks during the window collapse
+          into that one timer.
+        - Else: start a build immediately.
+
+        Non-blocking / fire-and-forget. The expensive build always runs
+        under `refresh()`'s asyncio.Lock, so even racing callers can't
+        double-build."""
+        args = (bundle, probe_store, audio_lang_store, use_tautulli, probe_walker)
+        self._pending_args = args
+
+        if self._refreshing:
+            # A build is running — mark "run once more when done".
+            self._pending_again = True
+            return
+
+        if self._debounce_handle is not None:
+            # A debounce timer is already armed; latest args win (set
+            # above), nothing else to do.
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no loop (shouldn't happen in app context)
+
+        wait = self._time_until_allowed(loop)
+        if wait <= 0:
+            self._start_refresh_task(args)
+        else:
+            self._debounce_handle = loop.call_later(
+                wait, self._fire_debounced
+            )
+
+    def _time_until_allowed(self, loop) -> float:
+        if self._min_interval_s <= 0 or self._last_refresh_done == 0.0:
+            return 0.0
+        elapsed = loop.time() - self._last_refresh_done
+        return max(0.0, self._min_interval_s - elapsed)
+
+    def _fire_debounced(self) -> None:
+        self._debounce_handle = None
+        if self._refreshing:
+            self._pending_again = True
+            return
+        if self._pending_args is not None:
+            self._start_refresh_task(self._pending_args)
+
+    def _start_refresh_task(self, args: tuple) -> None:
+        bundle, probe_store, audio_lang_store, use_tautulli, probe_walker = args
+
+        async def _run():
+            try:
+                await self.refresh(
+                    bundle, probe_store, audio_lang_store,
+                    use_tautulli=use_tautulli, probe_walker=probe_walker,
+                )
+            except Exception as e:  # pragma: no cover - logged, non-fatal
+                log.warning("coverage refresh (coalesced) failed: %s", e)
+            finally:
+                # If kicks arrived while we built, run exactly one more.
+                if self._pending_again:
+                    self._pending_again = False
+                    if self._pending_args is not None:
+                        self._start_refresh_task(self._pending_args)
+
+        self._refresh_task = asyncio.ensure_future(_run())
 
     def load(self) -> None:
         """Warm the in-memory mirror from the persisted snapshot so the
@@ -235,6 +340,11 @@ class CoverageCache:
                 return snap
             finally:
                 self._refreshing = False
+                # #104: record completion time for the debounce window.
+                try:
+                    self._last_refresh_done = asyncio.get_running_loop().time()
+                except RuntimeError:  # pragma: no cover
+                    pass
 
     async def _kick_eager_probe(self, probe_walker, items: list[dict[str, Any]]) -> None:
         """Queue a targeted probe of the build's unprobed rows. Never lets a

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -269,6 +269,43 @@ def _scan_for_srt_recursive(canonical_dir: str) -> list[str]:
         return []
 
 
+# #104: the per-series rglob is the dominant cost of a coverage build —
+# ~668 foreign series each walked one-at-a-time blocked the build for
+# minutes. We now fan the rglobs out across a bounded thread pool. The
+# cap matters: an UNBOUNDED fan-out would have hundreds of concurrent
+# rglobs hammering the NAS at once, which chokes it worse than serial.
+# 8-wide is a sane default (matches typical NAS spindle/SMB concurrency
+# without thrashing); tune via the call site if needed.
+_SRT_SCAN_CONCURRENCY = 8
+
+
+async def _build_srt_index_parallel(
+    canonical_dirs, cap: int = _SRT_SCAN_CONCURRENCY,
+) -> dict[str, list[str]]:
+    """Recursively scan each (unique, non-empty) series canonical dir for
+    .srt files, with bounded concurrency. Returns {canonical_dir: [rel
+    srt paths]}. Each dir is scanned exactly once (deduped here), so the
+    build's two pass-loops can read straight from the result dict instead
+    of awaiting an rglob inline.
+
+    Concurrency is capped via a semaphore so we parallelise the I/O wait
+    without unbounded fan-out onto the NAS. Each individual scan still
+    runs in a worker thread (rglob is blocking) so the event loop stays
+    free."""
+    unique = [d for d in dict.fromkeys(canonical_dirs) if d]
+    if not unique:
+        return {}
+    sem = asyncio.Semaphore(max(1, cap))
+
+    async def _one(d: str) -> tuple[str, list[str]]:
+        async with sem:
+            paths = await asyncio.to_thread(_scan_for_srt_recursive, d)
+        return d, paths
+
+    pairs = await asyncio.gather(*[_one(d) for d in unique])
+    return dict(pairs)
+
+
 def _match_episode_srt_pattern(srt_paths: list[str], episode_number: str | None) -> tuple[bool, list[str]]:
     """Given a list of relative .srt paths under a series dir and an
     episode_number ('1x3'), return (any_match, matching_paths).
@@ -1089,6 +1126,17 @@ async def build_coverage(
     # filesystem once.
     series_srt_index: dict[str, list[str]] = {}
 
+    # #104: pre-scan all wanted-episode series dirs in parallel (bounded)
+    # up front, instead of awaiting an rglob inline one series at a time
+    # inside the loop below. On a large foreign library the serialised
+    # rglobs were the dominant cost of the build (minutes). The loop then
+    # just reads from this index.
+    _ep_canonical_dirs = [
+        _strip_arr_prefix(sonarr_by_id.get(w.get("sonarrSeriesId"), {}).get("path"))
+        for w in bz_eps
+    ]
+    series_srt_index.update(await _build_srt_index_parallel(_ep_canonical_dirs))
+
     # Authoritative file-path resolution via Sonarr (one episode + episodefile
     # call per series with wanted eps). Replaces fragile S<NN>E<NN> filename
     # pattern matching — catches releases that use Part.N / Episode_NN / other
@@ -1125,10 +1173,10 @@ async def build_coverage(
         s = sonarr_by_id.get(sonarr_id, {})
         canonical = _strip_arr_prefix(s.get("path"))
         if canonical and canonical not in series_srt_index:
-            # #228: rglob blocks the event loop. On a real-size library this
-            # is the difference between the app feeling responsive during a
-            # walk vs. timeouts on /api/health. Offload to a thread per call;
-            # we already dedupe per-series via series_srt_index above.
+            # #104: normally pre-populated by the parallel pre-scan above.
+            # This inline fallback only fires for a dir that wasn't in the
+            # pre-scan set (defensive); still offloaded so it never blocks
+            # the event loop (#228).
             series_srt_index[canonical] = await asyncio.to_thread(
                 _scan_for_srt_recursive, canonical
             )
@@ -1353,12 +1401,22 @@ async def _add_bazarr_blind_synthetic_rows(
     for _eid, _ep in sonarr_eps_by_id.items():
         eps_by_series_id.setdefault(_ep.get("seriesId"), []).append((_eid, _ep))
 
+    # #104: pre-scan all foreign-series dirs not already in the index, in
+    # parallel (bounded), before the loop. This is the ~668-series fan-out
+    # that previously ran strictly one-at-a-time.
+    _foreign_dirs = [
+        c for c in (_strip_arr_prefix(s.get("path")) for s in foreign_series)
+        if c and c not in series_srt_index
+    ]
+    series_srt_index.update(await _build_srt_index_parallel(_foreign_dirs))
+
     synthetic_added = 0
     for s in foreign_series:
         sid = s.get("id")
         series_canonical = _strip_arr_prefix(s.get("path"))
         if series_canonical and series_canonical not in series_srt_index:
-            # #228: same offload as the main loop above.
+            # #104: defensive inline fallback (pre-scan above normally
+            # covers this). Offloaded so it never blocks the loop (#228).
             series_srt_index[series_canonical] = await asyncio.to_thread(
                 _scan_for_srt_recursive, series_canonical
             )

--- a/src/subarr/routers/audio_lang.py
+++ b/src/subarr/routers/audio_lang.py
@@ -70,18 +70,13 @@ async def upsert_verification(req: VerifyRequest, request: Request) -> dict[str,
 
     # v1.1 ARCH fix #197: kick a background coverage refresh so the
     # corresponding row's chip turns green within a few seconds, not 30.
-    import asyncio as _asyncio
+    # #104: route through the coalescing entry point so a burst of
+    # verifications collapses into a single debounced rebuild.
     cov_cache = getattr(request.app.state, "coverage_cache", None)
-    if cov_cache is not None and not cov_cache.is_refreshing():
+    if cov_cache is not None:
         bundle = request.app.state.integrations
         probe_store = request.app.state.probe_store
-
-        async def _refresh():
-            try:
-                await cov_cache.refresh(bundle, probe_store, store)
-            except Exception as e:
-                log.warning("post-verify refresh failed: %s", e)
-        _asyncio.create_task(_refresh())
+        cov_cache.request_refresh(bundle, probe_store, store)
     return {"verified": True, "canonical_path": req.canonical_path,
             "lang_code": req.lang_code.lower(),
             "sonarr_propagation": propagation}

--- a/src/subarr/routers/coverage.py
+++ b/src/subarr/routers/coverage.py
@@ -35,29 +35,25 @@ async def refresh_coverage(request: Request) -> dict[str, Any]:
     Frontend calls this after user actions that invalidate the cache
     (e.g. audio-lang verification, manual Bazarr sync). UI polls until
     `refreshing` flips back to False."""
-    import asyncio as _asyncio
     cov_cache = getattr(request.app.state, "coverage_cache", None)
     if cov_cache is None:
         return {"refreshed": False, "reason": "cache not configured"}
-    if cov_cache.is_refreshing():
-        return {"refreshed": False, "reason": "refresh already in flight"}
     bundle = request.app.state.integrations
     probe_store = request.app.state.probe_store
     audio_lang_store = getattr(request.app.state, "audio_lang", None)
-
     probe_walker = getattr(request.app.state, "probe_walker", None)
 
-    async def _do():
-        try:
-            await cov_cache.refresh(bundle, probe_store, audio_lang_store,
-                                    probe_walker=probe_walker)
-        except Exception as e:
-            log.warning("manual coverage refresh failed: %s", e)
-
-    _asyncio.create_task(_do())
+    # #104: route through the coalescing entry point. A burst of UI/event
+    # kicks collapses into at most one in-flight build + one follow-up,
+    # debounced to settings.coverage_refresh_min_interval_s. We no longer
+    # reject when a build is in flight — the request is coalesced instead.
+    cov_cache.request_refresh(
+        bundle, probe_store, audio_lang_store, probe_walker=probe_walker,
+    )
     snap = cov_cache.get_cached()
     return {
         "refreshed": True,
+        "coalesced": cov_cache.is_refreshing() or cov_cache.has_pending_refresh(),
         "previous_generated_at": snap.generated_at if snap else None,
         "previous_item_count": snap.item_count if snap else 0,
     }

--- a/tests/test_coverage_refresh_perf.py
+++ b/tests/test_coverage_refresh_perf.py
@@ -1,0 +1,152 @@
+"""Tests for #104: coverage-refresh debounce/coalesce + parallel rglob.
+
+Two concerns under test:
+
+1. Debounce / coalesce of the event-driven refresh kicks. A burst of
+   `request_refresh()` calls must collapse into at most one in-flight
+   build + at most one queued follow-up, and must respect a minimum
+   interval between builds (the config knob). We never want N events to
+   trigger N full 60-90s builds.
+
+2. The per-series .srt rglob fan-out must run with bounded concurrency
+   (parallel, but capped) rather than strictly one-at-a-time.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from subarr import coverage_cache
+from subarr.coverage_cache import CoverageCache
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return CoverageCache(tmp_path / "cov.db")
+
+
+def _patch_build(monkeypatch, *, calls: list, delay: float = 0.05):
+    """Patch build_coverage so refresh() does a cheap fake build that
+    records each invocation and sleeps `delay` to simulate work."""
+    async def _fake_build(bundle, **kwargs):
+        calls.append(time.monotonic())
+        await asyncio.sleep(delay)
+
+        class _Report:
+            def to_dict(self):
+                return {"items": [], "totals": {}, "sources": {}}
+        return _Report()
+
+    import subarr.coverage_engine as ce
+    monkeypatch.setattr(ce, "build_coverage", _fake_build)
+
+
+# ─── Debounce / coalesce ────────────────────────────────────────────
+
+
+def test_burst_of_triggers_coalesces_to_at_most_two_builds(cache, monkeypatch):
+    """N rapid triggers while a build is in flight collapse to one
+    in-flight build + one queued follow-up (so exactly 2 builds, not N)."""
+    calls: list = []
+    _patch_build(monkeypatch, calls=calls, delay=0.1)
+
+    async def _run():
+        # Fire 10 triggers in a tight burst. The first starts a build;
+        # the rest arrive while it runs and must coalesce into a single
+        # follow-up.
+        for _ in range(10):
+            cache.request_refresh(None, None, None)
+            await asyncio.sleep(0)  # let the scheduler pick up each call
+        # Wait for everything to drain.
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            if not cache.is_refreshing() and not cache.has_pending_refresh():
+                break
+        await asyncio.sleep(0.05)
+
+    asyncio.run(_run())
+    assert len(calls) <= 2, f"expected ≤2 builds from a burst, got {len(calls)}"
+    assert len(calls) >= 1, "a refresh must still happen"
+
+
+def test_request_refresh_respects_min_interval(cache, monkeypatch):
+    """A second request shortly after a completed build is debounced —
+    it does not immediately fire another full build."""
+    calls: list = []
+    _patch_build(monkeypatch, calls=calls, delay=0.01)
+    cache.set_min_interval_s(0.5)
+
+    async def _run():
+        cache.request_refresh(None, None, None)
+        # Wait for the first build to finish.
+        for _ in range(50):
+            await asyncio.sleep(0.02)
+            if calls and not cache.is_refreshing():
+                break
+        assert len(calls) == 1
+        # Immediately request again — inside the 0.5s window. Must NOT
+        # produce a second immediate build.
+        cache.request_refresh(None, None, None)
+        await asyncio.sleep(0.1)
+        assert len(calls) == 1, "second request inside window should be debounced"
+
+    asyncio.run(_run())
+
+
+def test_min_interval_default_from_config(monkeypatch, tmp_path):
+    """The debounce window defaults from settings.coverage_refresh_min_interval_s."""
+    from subarr import config
+    c = CoverageCache(tmp_path / "c.db")
+    # Default knob present and applied.
+    assert c.min_interval_s == config.load().coverage_refresh_min_interval_s
+
+
+# ─── Parallel rglob ─────────────────────────────────────────────────
+
+
+def test_srt_index_scan_runs_concurrently(monkeypatch):
+    """_build_srt_index_parallel must run scans with >1 in flight at once
+    (parallel) but never exceed the concurrency cap."""
+    import subarr.coverage_engine as ce
+
+    in_flight = 0
+    max_in_flight = 0
+
+    def _slow_scan(canonical: str):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(0.05)
+        in_flight -= 1
+        return [f"{canonical}/sub.srt"]
+
+    monkeypatch.setattr(ce, "_scan_for_srt_recursive", _slow_scan)
+
+    dirs = [f"series{i}" for i in range(12)]
+    cap = 4
+    result = asyncio.run(ce._build_srt_index_parallel(dirs, cap=cap))
+
+    assert max_in_flight > 1, "scans must run concurrently, not serially"
+    assert max_in_flight <= cap, f"concurrency must be capped at {cap}, saw {max_in_flight}"
+    assert set(result.keys()) == set(dirs)
+    assert result["series0"] == ["series0/sub.srt"]
+
+
+def test_srt_index_handles_empty_and_dedupes(monkeypatch):
+    import subarr.coverage_engine as ce
+
+    seen: list = []
+
+    def _scan(canonical: str):
+        seen.append(canonical)
+        return []
+
+    monkeypatch.setattr(ce, "_scan_for_srt_recursive", _scan)
+    # Duplicate + empty dirs must be deduped and skipped.
+    result = asyncio.run(
+        ce._build_srt_index_parallel(["a", "a", "", "b"], cap=4)
+    )
+    assert set(result.keys()) == {"a", "b"}
+    assert sorted(seen) == ["a", "b"]


### PR DESCRIPTION
Closes #104 (the perf follow-up to #93/#103).

Coverage refresh was ~60-90s and fired on a 5-min loop PLUS every completion/partial-scan/queue event. This coalesces the on-demand kicks and parallelizes the rglob scan. (Full incremental refresh is deferred to a separate PR — noted below.)

## 1. Debounce / coalesce
Single entry point `CoverageCache.request_refresh(...)` that all event-driven kicks call instead of each `create_task`-ing a full build.
- In flight → a `_pending_again` flag runs exactly one follow-up (N kicks → ≤2 builds, never N).
- Within the window → one `loop.call_later` timer, repeated kicks collapse into it (latest args win).
- Window = `coverage_refresh_min_interval_s` config knob (`SUBARR_COVERAGE_REFRESH_MIN_INTERVAL_S`, **default 120s**; `0` = pre-#104 behaviour). The fixed 5-min `background_refresh_loop` stays as the floor cadence. The refresh endpoint now reports `coalesced` instead of rejecting "already in flight".

## 2. Parallel rglob
`_build_srt_index_parallel(canonical_dirs, cap=8)` — `asyncio.gather` over a `Semaphore`, each scan `to_thread`-offloaded. Both build loops pre-scan dirs in parallel, then read from the index. **Concurrency cap = 8** (deliberate — unbounded fan-out would choke the NAS). Dedupes + skips empty dirs; defensive per-dir fallback retained.

## Files
`coverage_cache.py`, `coverage_engine.py`, `config.py`, `routers/coverage.py`, `routers/audio_lang.py`, `tests/test_coverage_refresh_perf.py` (5 new TDD tests).

`PYTHONPATH=src python -m pytest` → **472 passed**.

> Deferred (separate PR): full incremental refresh (single completion updates only the changed file vs rebuilding the 600+ snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)