### PR TITLE
fix(queue): infer 'sub_exists' for any subtitle sidecar, not just .srt (#89)

### DIFF
--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -47,6 +47,15 @@ log = logging.getLogger(__name__)
 # 24h captures a full day's submissions without dragging in noise.
 _DEFAULT_HISTORY_WINDOW_S = 24 * 3600
 
+# Subtitle sidecar extensions subgen treats as an already-existing subtitle.
+# Mirrors has_external_subtitle_in_language() in subgen_patched.py — a file
+# subgen skipped because ANY of these sits next to it (not only .srt) was
+# previously mislabeled 'unknown' (#89). Kept in sync with subgen's set.
+_SUBTITLE_SIDECAR_EXTS = (
+    ".srt", ".vtt", ".sub", ".ass", ".ssa",
+    ".idx", ".sbv", ".pgs", ".ttml", ".lrc",
+)
+
 
 def match_progress(processing_path: str, progress_map: dict[str, dict]) -> dict | None:
     """Find a progress entry whose bracket-name is a prefix of the
@@ -72,9 +81,23 @@ def _infer_skip_reason(canonical_path: str) -> str:
     internal sub language match, lrc exists, etc.). The per-file reason
     only appears in subgen's logs. Until subgen emits a per-reason
     breakdown (subgen-side patch — out of scope here), we infer the most
-    common case heuristically: if an .srt sits next to the video file the
-    user submitted, classify as 'sub_exists'. Otherwise 'unknown' (most
-    often audio_lang, but other branches are possible).
+    common case heuristically: if a recognized subtitle sidecar sits next
+    to the video file the user submitted, classify as 'sub_exists'.
+    Otherwise 'unknown' (most often audio_lang, but other branches are
+    possible).
+
+    The sidecar match covers every extension subgen's
+    has_external_subtitle_in_language() recognizes (see
+    _SUBTITLE_SIDECAR_EXTS), not just .srt — a skip caused by an existing
+    .ass/.vtt/etc. sidecar is just as much "sub already exists" and should
+    not land in the noisy 'unknown' bucket (#89).
+
+    NOTE: subgen ALSO skips on EMBEDDED (internal) subtitles and on
+    SKIP_IF_AUDIO_LANGUAGES. Detecting either requires opening/probing the
+    media container — a signal this function does not have (the scan_store
+    PathResult it's derived from carries only path/status/error, no
+    audio_langs or embedded-sub flags). Those remain 'unknown' here; see
+    the follow-up note in the PR for wiring probe data through.
 
     Returns 'sub_exists' | 'audio_lang' | 'unknown'. 'audio_lang' is
     reserved for a future subgen-side patch; today this helper never
@@ -98,8 +121,10 @@ def _infer_skip_reason(canonical_path: str) -> str:
             if not sibling.is_file():
                 continue
             name = sibling.name
-            # Match `<stem>.srt`, `<stem>.<lang>.srt`, `<stem>.<lang>.<flag>.srt`
-            if name.startswith(stem + ".") and name.lower().endswith(".srt"):
+            # Match `<stem>.<ext>`, `<stem>.<lang>.<ext>`,
+            # `<stem>.<lang>.<flag>.<ext>` for any subtitle sidecar ext.
+            if name.startswith(stem + ".") and \
+                    name.lower().endswith(_SUBTITLE_SIDECAR_EXTS):
                 return "sub_exists"
     except OSError:
         return "unknown"

--- a/tests/test_infer_skip_reason.py
+++ b/tests/test_infer_skip_reason.py
@@ -1,0 +1,104 @@
+"""Unit tests for queue._infer_skip_reason (#89 slice).
+
+subgen returns a single 'skipped' counter regardless of which should_skip_file
+branch fired. subarr's _infer_skip_reason re-derives the most common reason
+from locally-inspectable on-disk data so the "Issues — silent fails" bucket
+isn't a wall of unexplained 'unknown' chips.
+
+Before this slice the helper only matched an external `.srt` sidecar. subgen
+(has_external_subtitle_in_language) actually treats a wider extension set as an
+existing subtitle: {.srt, .vtt, .sub, .ass, .ssa, .idx, .sbv, .pgs, .ttml,
+.lrc}. So a file subgen skipped because an `.ass`/`.vtt`/etc. sidecar already
+exists was mislabeled 'unknown'. These tests pin the broadened sidecar match
+while keeping the directory / no-sidecar / wrong-stem cases as 'unknown'.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from subarr import paths
+from subarr.routers.queue import _infer_skip_reason
+
+
+@pytest.fixture
+def media_tree(tmp_path, monkeypatch):
+    """Point the media root at a tmp tree with one episode file.
+
+    settings is a frozen dataclass, so instead of mutating it we swap the
+    `settings` reference that paths.canonical_to_fs resolves against for a
+    lightweight stub exposing only `.media_root`.
+
+    Returns (root, show_dir). Tests drop sidecars next to ep.mkv and assert
+    the inferred skip reason for canonical path 'TV/Show/ep.mkv'.
+    """
+    root = tmp_path / "media"
+    show = root / "TV" / "Show"
+    show.mkdir(parents=True)
+    (show / "ep.mkv").write_bytes(b"")
+    monkeypatch.setattr(paths, "settings", types.SimpleNamespace(media_root=root))
+    return root, show
+
+
+CANON = "TV/Show/ep.mkv"
+
+
+def test_external_srt_sidecar_classified_sub_exists(media_tree):
+    """Existing behavior: a matching .srt next to the file → 'sub_exists'."""
+    _root, show = media_tree
+    (show / "ep.en.srt").write_text("1\n")
+    assert _infer_skip_reason(CANON) == "sub_exists"
+
+
+def test_plain_srt_sidecar_classified_sub_exists(media_tree):
+    """`<stem>.srt` (no lang tag) also counts as an existing sub."""
+    _root, show = media_tree
+    (show / "ep.srt").write_text("1\n")
+    assert _infer_skip_reason(CANON) == "sub_exists"
+
+
+@pytest.mark.parametrize("ext", [".ass", ".ssa", ".vtt", ".sub", ".idx",
+                                 ".sbv", ".pgs", ".ttml", ".lrc"])
+def test_non_srt_subtitle_sidecar_classified_sub_exists(media_tree, ext):
+    """NEW (#89): subgen skips on any subtitle extension it recognizes, not
+    just .srt. A matching `.ass`/`.vtt`/etc. sidecar must classify as
+    'sub_exists', not 'unknown'."""
+    _root, show = media_tree
+    (show / f"ep.en{ext}").write_text("x\n")
+    assert _infer_skip_reason(CANON) == "sub_exists"
+
+
+def test_no_sidecar_is_unknown(media_tree):
+    """Genuinely unexplained skip (e.g. audio-language match — not locally
+    inspectable here) still falls through to 'unknown'."""
+    _root, _show = media_tree
+    assert _infer_skip_reason(CANON) == "unknown"
+
+
+def test_unrelated_subtitle_does_not_false_positive(media_tree):
+    """A subtitle for a DIFFERENT file in the same folder must not be
+    attributed to this file — stem must match."""
+    _root, show = media_tree
+    (show / "other-episode.en.srt").write_text("1\n")
+    assert _infer_skip_reason(CANON) == "unknown"
+
+
+def test_directory_path_is_unknown(media_tree):
+    """A canonical path pointing at a folder (season dir) can't be pinned to
+    THE file subgen tripped on → 'unknown' (unchanged)."""
+    assert _infer_skip_reason("TV/Show") == "unknown"
+
+
+def test_path_outside_root_is_unknown(media_tree):
+    """Traversal / outside-root path resolves to 'unknown' rather than
+    raising."""
+    assert _infer_skip_reason("../../etc/passwd") == "unknown"
+
+
+def test_non_subtitle_sibling_is_not_matched(media_tree):
+    """A same-stem non-subtitle file (e.g. a .nfo) must not be mistaken for
+    an existing subtitle."""
+    _root, show = media_tree
+    (show / "ep.nfo").write_text("meta\n")
+    assert _infer_skip_reason(CANON) == "unknown"


### PR DESCRIPTION
Partial #89 (the safe, self-contained slice).

`_infer_skip_reason` (routers/queue.py) classifies WHY subgen skipped a queued item, but only checked for an external **`.srt`** sidecar — so a skip caused by an existing `.ass`/`.vtt`/`.sub`/`.idx`/etc. sidecar was mislabeled `unknown` and cluttered the "silent fails subgen swallowed" bucket.

## Change (routers/queue.py only)
- Match every extension subgen's `has_external_subtitle_in_language()` recognizes (`_SUBTITLE_SIDECAR_EXTS`), kept in sync with subgen's set — `<stem>.<ext>` / `<stem>.<lang>.<ext>` / `<stem>.<lang>.<flag>.<ext>`.
- `tests/test_infer_skip_reason.py`: new (non-.srt sidecar → `sub_exists`; lang/flag variants; genuinely-unexplained still `unknown`).

## Deliberately deferred (follow-up)
subgen ALSO skips on **embedded/internal** subs and **`SKIP_IF_AUDIO_LANGUAGES`**. Detecting either needs probe data (audio_langs / embedded-sub flags) that this function doesn't have — the `scan_store` PathResult it derives from carries only path/status/error. Wiring probe data through is the next slice; it touches coverage/probe plumbing (currently under heavy rework on `feat/131-arena-ui`), so it's intentionally left out here to avoid a merge landmine.

`PYTHONPATH=src python -m pytest tests/test_infer_skip_reason.py tests/test_queue.py` → 21 passed. Scope: `routers/queue.py` + its test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)