### PR TITLE
ci(security): hash-pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,15 +28,15 @@ jobs:
       matrix:
         language: [python, javascript-typescript]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           language: ${{ matrix.language }}
           queries: security-extended
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -27,9 +27,9 @@ jobs:
     name: bundle drift check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: 'pip'
       - run: pip install -e .[dev]
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
       - run: npm ci || npm install
@@ -36,18 +36,18 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -58,7 +58,7 @@ jobs:
             type=sha,format=short
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,8 +39,8 @@ jobs:
     name: bandit (Python static analysis)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with: { python-version: "3.11" }
       - run: pip install bandit[sarif]
       - name: bandit -r src/
@@ -61,7 +61,7 @@ jobs:
       # so this is best-effort only.
       - if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: bandit.sarif
           category: bandit
@@ -70,8 +70,8 @@ jobs:
     name: pip-audit (dep CVEs)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with: { python-version: "3.11" }
       - run: pip install pip-audit
       - name: pip-audit on declared deps
@@ -93,7 +93,7 @@ jobs:
     container:
       image: semgrep/semgrep:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: semgrep ci
         env:
           SEMGREP_RULES: >-
@@ -104,7 +104,7 @@ jobs:
         run: semgrep ci --sarif --output=semgrep.sarif || true
       - if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep
@@ -114,10 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: build image (no push)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true
@@ -134,7 +134,7 @@ jobs:
       # Split: table step is the gate (filters apply correctly here),
       # SARIF step is exit-code 0 (best-effort artifact producer).
       - name: trivy scan (gate)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: subarr:scan
           format: table
@@ -147,7 +147,7 @@ jobs:
         # Action tags use the "v" prefix on this publisher's repo.
         # exit-code 0 here — the gate above already decided pass/fail.
         if: always()
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: subarr:scan
           format: sarif
@@ -157,7 +157,7 @@ jobs:
           ignore-unfixed: true
       - if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy.sarif
           category: trivy

--- a/.github/workflows/tone-gate.yml
+++ b/.github/workflows/tone-gate.yml
@@ -32,7 +32,7 @@ jobs:
     name: scan for tone tripwires
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: scan
         run: |
           set -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to subarr are documented here. The format follows
 [Semantic Versioning](https://semver.org/) — major bumps signal
 breaking config changes.
 
+## [Unreleased]
+
+### Fixed
+- **Bazarr error paths raised `NameError` instead of `IntegrationError`** —
+  `bazarr.py` raised `IntegrationError` in 14 paths without importing it. Any
+  Bazarr failure (HTTP error, not-configured) would have thrown the wrong
+  exception.
+- **Per-episode Bazarr history lookup threw `TypeError` at runtime** — a
+  duplicate `episodes_history`/`movies_history` definition shadowed the general
+  one, so `provenance.py`'s `episodes_history(sonarr_episode_id=…)` call failed.
+  Both now covered by regression tests.
+
+### Changed
+- **Repo quality hardening.** Enforced `ruff check` + `ruff format` as a CI gate
+  and pre-commit hook (previously configured but never run); added a pytest gate
+  on pull requests; hash-pinned all GitHub Actions to commit SHAs (dependabot
+  keeps them current). Both bugs above were surfaced by enabling the lint gate.
+
+### Thanks
+- **u/MrSlaw** (r/bazarr) for a thorough, accurate review of the repo's lint
+  state and CI/supply-chain hardening — directly prompted the changes above,
+  including catching the duplicate-method bug.
+
 ## [1.3.0] - 2026-06-08
 
 ### Added


### PR DESCRIPTION
Second half of the r/bazarr feedback (after #172): hash-pin every GitHub Action to a full commit SHA instead of a mutable tag.

## Why
Mutable tags (`@v6`, `@v0.36.0`) can be repointed by a repo compromise — the tag-poisoning attack class that hit `tj-actions/changed-files` in 2025, and the reason the reviewer specifically flagged `aquasecurity/trivy-action@v0.36.0`.

## What
- All actions across `codeql / frontend / release / security / tone-gate` pinned to `@<sha> # vX`. (`ci.yml` from #172 was already pinned.)
- **Annotated tags dereferenced to their commit SHA** — `trivy-action@v0.36.0` and `codeql-action@v4` are annotated; pinning the tag-object SHA would not resolve. Verified via the commits endpoint.
- `dependabot.yml` already has the `github-actions` ecosystem, so the pinned SHAs get bumped automatically — pinning + dependabot together is the complete pattern.
- Credited u/MrSlaw in CHANGELOG.

## Deliberately out of scope (tracked separately)
Ran `zizmor` (the reviewer also suggested it): 28 findings beyond pinning — `semgrep/semgrep:latest` unpinned container image (HIGH), missing `permissions:` blocks, `persist-credentials: false`. Getting to zero + adding a **blocking** zizmor gate is its own pass — filed as an issue rather than shipping a `continue-on-error` gate that would pass without checking anything.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>