### PR TITLE
ci(security): clear all zizmor findings + add a blocking zizmor gate (#174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
-# Lint + test gate. Fills two gaps: ruff was configured but never enforced in
-# CI, and pytest only ran in release.yml (on push/tags), not on PRs.
-#   - lint:  ruff check + ruff format --check on every push + PR
-#   - test:  full pytest suite on PRs (pushes to main are covered by release.yml
-#            before publish, so we don't double-run the suite there)
+# Lint + test + workflow-security gate.
+#   - lint:    ruff check + ruff format --check on every push + PR
+#   - test:    full pytest suite on PRs (pushes to main run it in release.yml
+#              before publish, so we don't double-run the suite there)
+#   - zizmor:  GitHub Actions security audit (pinned actions, least-privilege
+#              permissions, cache-poisoning, unpinned images) — blocking, so the
+#              workflows can't silently regress into the hardening we just did.
 name: ci
 
 on:
@@ -18,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
@@ -33,9 +37,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           cache: pip
       - run: pip install -e .[dev]
       - run: PYTHONPATH=src pytest -q --tb=line
+
+  zizmor:
+    # Blocking workflow-security audit — a non-functional gate is worse than
+    # none (cf. the dead rebase-test detector). Pinned to match local runs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - run: pip install zizmor==1.25.2
+      - run: zizmor --persona=regular .github/workflows/
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,8 @@ jobs:
         language: [python, javascript-typescript]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,12 +22,17 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   drift:
     name: bundle drift check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
     tags: ['v*.*.*']
   workflow_dispatch:
 
+# Least-privilege default; the publish job elevates to packages: write itself.
 permissions:
   contents: read
-  packages: write
 
 jobs:
   # Tag pushes block on tests + drift check first. Main-branch pushes also
@@ -18,12 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
-          cache: 'pip'
       - run: pip install -e .[dev]
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      # release.yml runs only on trusted push/tags (never PRs), so there is no
+      # PR→privileged-cache poisoning vector; setup-node isn't configured to
+      # cache here anyway (no `cache:` input).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '20'
       - run: npm ci || npm install
@@ -35,8 +39,13 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the image to GHCR
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,21 +25,25 @@ on:
     - cron: "0 7 * * 1"
   workflow_dispatch:
 
+# Least-privilege at the workflow level. The SARIF-uploading jobs (bandit,
+# semgrep, trivy) elevate to security-events: write + actions: read themselves
+# (actions: read is required by codeql-action/upload-sarif to read run metadata,
+# else it fails "Resource not accessible by integration").
 permissions:
   contents: read
-  security-events: write
-  pull-requests: read
-  # actions: read is required by codeql-action/upload-sarif so it can
-  # read the workflow run metadata. Without it the SARIF upload step
-  # fails with "Resource not accessible by integration".
-  actions: read
 
 jobs:
   bandit:
     name: bandit (Python static analysis)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload-sarif (best-effort)
+      actions: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with: { python-version: "3.11" }
       - run: pip install bandit[sarif]
@@ -69,8 +73,12 @@ jobs:
   pip-audit:
     name: pip-audit (dep CVEs)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # no SARIF upload — stays minimal
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with: { python-version: "3.11" }
       - run: pip install pip-audit
@@ -90,10 +98,20 @@ jobs:
   semgrep:
     name: semgrep (pattern security)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload-sarif (best-effort)
+      actions: read
     container:
-      image: semgrep/semgrep:latest
+      # Pinned by digest (v1.142.0). trivy-action's Mar-2026 tag-poisoning is
+      # exactly why mutable tags on security tooling are a risk. dependabot's
+      # github-actions ecosystem keeps container images current; bump manually
+      # if a newer rule set is wanted sooner.
+      image: semgrep/semgrep@sha256:03402a5040a88a570dec58375ef1a19fa777dd61575afdc7d5527ddf308dd765
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: semgrep ci
         env:
           SEMGREP_RULES: >-
@@ -113,8 +131,14 @@ jobs:
     name: trivy (container image CVEs)
     runs-on: ubuntu-latest
     needs: []
+    permissions:
+      contents: read
+      security-events: write # upload-sarif (best-effort)
+      actions: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: build image (no push)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7

--- a/.github/workflows/tone-gate.yml
+++ b/.github/workflows/tone-gate.yml
@@ -27,12 +27,17 @@ on:
     paths:
       - README.md
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: scan for tone tripwires
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: scan
         run: |
           set -e


### PR DESCRIPTION
Closes #174. Makes GitHub Actions security a **permanent gate** instead of a one-off run — insurance against the workflows silently regressing on the supply-chain hardening from #173.

## Findings cleared (zizmor: was 4 HIGH + mediums after the #173 pinning → now 0)
- **HIGH `unpinned-images`** — pinned `semgrep/semgrep:latest` → `@sha256` digest (v1.142.0). trivy-action's Mar-2026 tag-poisoning is the exact case for pinning security-tool images.
- **HIGH `excessive-permissions`** — `release.yml` `packages: write` moved from workflow level to the **publish job only**; workflow defaults to `contents: read`.
- **HIGH `cache-poisoning` ×2** — dropped `cache: pip` from `release.yml`'s push-only test job; the residual low-confidence `setup-node` finding is a **documented inline ignore** (release runs only on trusted push/tags → no PR→cache poisoning vector; setup-node isn't configured to cache anyway).
- **`excessive-permissions` (medium)** — `security.yml` permissions scoped **per-job**: only the SARIF-uploading jobs (bandit/semgrep/trivy) get `security-events: write` + `actions: read`; pip-audit stays `contents: read`. Added `contents: read` to frontend + tone-gate.
- **`artipacked` (medium ×11)** — `persist-credentials: false` on every checkout (via `zizmor --fix`; none of our workflows push via git, so safe).

## The gate
New `ci.yml` **`zizmor`** job runs `zizmor --persona=regular .github/workflows/` on push + PR, pinned to **zizmor 1.25.2** (matches local). **Blocking** — per the dead-`rebase-test` lesson, a `continue-on-error` gate that always passes is worse than none.

Local: `zizmor` → **No findings to report** (1 documented ignore, 15 default suppressions). All 6 workflows YAML-valid.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>