### PR TITLE
deploy: bump subgen pin r7 -> r8 (strongpad baked default)

### DIFF
--- a/deploy/templates/tier1-no-docker.compose.yaml
+++ b/deploy/templates/tier1-no-docker.compose.yaml
@@ -52,7 +52,7 @@ services:
         max-file: "3"
 
   subgen:
-    image: ghcr.io/coaxk/subarr-subgen:2026.05.3-r7   # pin exactly (current; v4.10+ arena/per-request caps; r7 = Blackwell/RTX 50xx CUDA 12.8 + gnupg CVE patch)
+    image: ghcr.io/coaxk/subarr-subgen:2026.05.3-r8   # pin exactly (current; v4.10+ arena/per-request caps; r8 = +strongpad regroup default (#168); r7 = Blackwell CUDA 12.8 + gnupg CVE)
     container_name: subgen
     restart: unless-stopped
     networks:

--- a/deploy/templates/tier2-socket-proxy.compose.yaml
+++ b/deploy/templates/tier2-socket-proxy.compose.yaml
@@ -108,7 +108,7 @@ services:
         max-file: "3"
 
   subgen:
-    image: ghcr.io/coaxk/subarr-subgen:2026.05.3-r7   # pin exactly (current; v4.10+ caps for arena/Tuning Lab; r7 = Blackwell/RTX 50xx CUDA 12.8 + gnupg CVE patch)
+    image: ghcr.io/coaxk/subarr-subgen:2026.05.3-r8   # pin exactly (current; v4.10+ caps for arena/Tuning Lab; r8 = +strongpad regroup default (#168); r7 = Blackwell CUDA 12.8 + gnupg CVE)
     container_name: subgen
     restart: unless-stopped
     networks:

--- a/deploy/templates/tier3-config-mounts.compose.yaml
+++ b/deploy/templates/tier3-config-mounts.compose.yaml
@@ -86,7 +86,7 @@ services:
     logging: { driver: json-file, options: { max-size: 5m, max-file: "3" } }
 
   subgen:
-    image: ghcr.io/coaxk/subarr-subgen:2026.05.3-r7   # pin exactly (current; v4.10+ caps for arena/Tuning Lab; r7 = Blackwell/RTX 50xx CUDA 12.8 + gnupg CVE patch)
+    image: ghcr.io/coaxk/subarr-subgen:2026.05.3-r8   # pin exactly (current; v4.10+ caps for arena/Tuning Lab; r8 = +strongpad regroup default (#168); r7 = Blackwell CUDA 12.8 + gnupg CVE)
     container_name: subgen
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Bumps the subgen image pin in all three deploy templates to `2026.05.3-r8`, which bakes the verified #168 strongpad `CUSTOM_REGROUP` as the image default. Templates keep the explicit env (documents + tweakable); the bake mainly benefits bare-image installs. r8 build: see coaxk/subarr-subgen tag v2026.05.3-r8. Strongpad held on held-out languages (de/sr) in the verify — median CPS ~13-15, zero micro-cues.