### PR TITLE
feat(#179): no-torch onnx backend for the QE judge (bakeable like VAD)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 PIP_NO_CACHE_DIR=1
 # mkvtoolnix provides `mkvpropedit` for the #159 default-audio-track swap — an
 # in-place Matroska header edit (no remux) that makes a show's original-language
 # track the default so subgen stops transcribing a dub into double-translated subs.
+# `apt-get upgrade` pulls base-image security patches between python:3.12-slim
+# rebuilds — the trivy gate fails on fixable HIGH/CRITICAL CVEs in base
+# packages (first hit: CVE-2026-45447 in libssl3t64, fixed in deb13u2 while
+# the base still shipped u1). Patch-don't-suppress, same as subarr-subgen.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ffmpeg mkvtoolnix \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ COPY src/ ./src/
 # from onboarding to /config so the image stays model-free and the user makes
 # the explicit choice. Without the model present, subarr falls back to the
 # ffmpeg silencedetect picker, so this extra is inert until enabled.
-RUN pip install --no-cache-dir ".[vad]"
+# #179: also bake the no-torch QE runtime ([qe-onnx] adds tokenizers +
+# safetensors + huggingface_hub on top of [vad]'s onnxruntime/numpy — ~MBs,
+# NO torch). The ~1.9GB LaBSE ONNX model is NOT baked; it's pulled into the
+# HF cache on first QE use. Until then the judge stays structural-only.
+RUN pip install --no-cache-dir ".[vad,qe-onnx]"
 
 EXPOSE 9922
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,23 @@ vad = [
     "numpy>=1.24,<3.0",
 ]
 # #123: QE/adequacy judge (the tournament summit). LaBSE cross-lingual
-# embeddings via sentence-transformers; validated rho=0.727 vs true accuracy.
-# DELIBERATELY NOT baked into the image (unlike [vad]) — sentence-transformers
-# pulls torch (~2GB). Pure opt-in for now; an onnx-lean LaBSE backend (drop the
-# torch weight, bakeable like silero) is the tracked follow-up optimization.
+# embeddings; validated rho=0.727 vs true accuracy. The torch path
+# (sentence-transformers) is the original backend, kept as fallback + parity
+# reference. NOT baked into the image — it pulls torch (~2GB).
 qe = [
     "sentence-transformers>=2.2,<6.0",
+]
+# #179: the no-torch QE backend (qe_onnx.py) — runs LaBSE's official ONNX
+# export via onnxruntime + numpy (both already in [vad]) + the light tokenizer/
+# weights/download libs. ~MBs of deps instead of torch's ~2GB, so this IS baked
+# into the image like [vad]; the ~1.9GB model file itself is still pulled
+# lazily into the HF cache on first QE use, never baked.
+qe-onnx = [
+    "onnxruntime>=1.16,<2.0",
+    "numpy>=1.24,<3.0",
+    "tokenizers>=0.15,<1.0",
+    "safetensors>=0.4,<1.0",
+    "huggingface_hub>=0.20,<2.0",
 ]
 
 [build-system]

--- a/src/subarr/qe.py
+++ b/src/subarr/qe.py
@@ -13,8 +13,14 @@ Split mirrors vad.py:
 
 Opt-in like the silero VAD extra. When the embedder is unavailable, qe_adequacy
 returns None and the tournament composite falls back to the structural judge
-(no penalty). The default backend is sentence-transformers/LaBSE; an onnx-lean
-packaging (drop the torch weight) is a tracked follow-up.
+(no penalty).
+
+Two interchangeable backends produce the same normalized LaBSE vectors (#179):
+  - onnx (preferred): qe_onnx.py — onnxruntime + numpy + tokenizers, NO torch.
+    Light enough to bake like the VAD extra ([qe-onnx]).
+  - torch: sentence-transformers — the original heavy path ([qe]), kept as the
+    fallback and the parity reference.
+SUBARR_QE_BACKEND=auto|onnx|torch forces one; auto prefers onnx.
 """
 
 from __future__ import annotations
@@ -47,9 +53,11 @@ def cosine_similarity(a, b) -> float:
     return float(dot / (na * nb))
 
 
-def qe_available() -> bool:
-    """True iff the QE embedder backend is importable. Never raises — callers
-    fall back to the structural judge when False."""
+# Backend selection (#179): auto prefers the no-torch onnx path.
+_BACKEND_ENV = "SUBARR_QE_BACKEND"
+
+
+def _torch_available() -> bool:
     try:
         import sentence_transformers  # noqa: F401
     except Exception:
@@ -57,11 +65,29 @@ def qe_available() -> bool:
     return True
 
 
+def _onnx_available() -> bool:
+    from . import qe_onnx
+
+    return qe_onnx.onnx_qe_available()
+
+
+def qe_available() -> bool:
+    """True iff a QE embedder backend is importable (honouring
+    SUBARR_QE_BACKEND). Never raises — callers fall back to the structural
+    judge when False."""
+    backend = os.environ.get(_BACKEND_ENV, "auto")
+    if backend == "onnx":
+        return _onnx_available()
+    if backend == "torch":
+        return _torch_available()
+    return _onnx_available() or _torch_available()
+
+
 _embedder_cache = None
 
 
-def _default_embed(texts):
-    """Embed texts with LaBSE (sentence-transformers). Lazy + process-cached.
+def _torch_embed(texts):
+    """Embed with sentence-transformers LaBSE. Lazy + process-cached.
     Live-verified I/O, not unit-tested (the model is the boundary)."""
     global _embedder_cache
     from sentence_transformers import SentenceTransformer
@@ -77,6 +103,30 @@ def _default_embed(texts):
         except Exception:
             _embedder_cache = SentenceTransformer(model)
     return _embedder_cache.encode(list(texts), normalize_embeddings=True)
+
+
+def _default_embed(texts):
+    """Dispatch to the selected backend. Both produce the same normalized
+    LaBSE vectors (parity-gated in tests/test_qe_onnx.py). In auto mode an
+    onnx-side failure falls back to torch once, loudly."""
+    backend = os.environ.get(_BACKEND_ENV, "auto")
+    if backend == "torch":
+        return _torch_embed(texts)
+    if backend == "onnx":
+        from . import qe_onnx
+
+        return qe_onnx.embed(texts)
+    # auto: prefer onnx (no torch), fall back to the torch path on any failure.
+    if _onnx_available():
+        from . import qe_onnx
+
+        try:
+            return qe_onnx.embed(texts)
+        except Exception:
+            if not _torch_available():
+                raise
+            log.warning("QE onnx backend failed; falling back to torch", exc_info=True)
+    return _torch_embed(texts)
 
 
 def qe_adequacy(source: str, hyp: str, *, embedder=None) -> float | None:

--- a/src/subarr/qe_onnx.py
+++ b/src/subarr/qe_onnx.py
@@ -1,0 +1,149 @@
+"""#179 — onnx-lean LaBSE backend for the QE judge (no torch).
+
+Reimplements sentence-transformers/LaBSE's 4-module pipeline with
+onnxruntime + numpy, verbatim from the model repo's own configs:
+
+    0. Transformer  -> onnx/model.onnx (the official export in the HF repo)
+    1. Pooling      -> CLS token        (1_Pooling: pooling_mode_cls_token)
+    2. Dense        -> 768->768 + tanh  (2_Dense: bias=true, Tanh)
+    3. Normalize    -> L2
+
+Deps: onnxruntime + numpy (already shipped via the [vad] extra) plus
+tokenizers + safetensors + huggingface_hub — all light pure wheels. NO torch
+(~2GB of wheels), NO sentence-transformers/transformers. That makes the QE
+judge bakeable into the image like silero VAD: the [qe-onnx] extra adds ~MBs
+of deps; the ~1.9GB model file itself is NOT baked — it's pulled once via
+huggingface_hub into the standard HF cache (HF_HOME), the same volume the
+torch backend populates, offline-first thereafter.
+
+Split mirrors vad.py / qe.py:
+  - cls_pool / dense_tanh / l2_normalize: PURE math, fully unit-tested.
+  - the tokenizer/session/weights I/O sits behind onnx_qe_available();
+    live-verified against the torch backend (cosine parity), not unit-tested.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+# Same repo id the torch backend uses (qe.py reads the same env override).
+_MODEL_ENV = "SUBARR_QE_MODEL"
+QE_MODEL = "sentence-transformers/LaBSE"
+
+# From sentence_bert_config.json in the model repo.
+MAX_SEQ_LENGTH = 256
+
+# Files the pipeline needs, relative to the HF repo root.
+_ONNX_FILE = "onnx/model.onnx"
+_TOKENIZER_FILE = "tokenizer.json"
+_DENSE_FILE = "2_Dense/model.safetensors"
+
+
+def onnx_qe_available() -> bool:
+    """True iff the no-torch backend's deps are importable. Never raises.
+    (The model file itself is pulled lazily on first embed, like the torch
+    backend — availability is about the runtime, not the download.)"""
+    try:
+        import huggingface_hub  # noqa: F401
+        import numpy  # noqa: F401
+        import onnxruntime  # noqa: F401
+        import safetensors  # noqa: F401
+        import tokenizers  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+# ── pure pipeline math (unit-tested) ─────────────────────────────────
+
+
+def cls_pool(hidden):
+    """Module 1: CLS pooling — the first token's hidden state per sequence.
+    hidden: (batch, seq, dim) -> (batch, dim)."""
+    return hidden[:, 0, :]
+
+
+def dense_tanh(x, weight, bias):
+    """Module 2: torch.nn.Linear semantics (x @ W.T + b) followed by Tanh.
+    weight: (out, in) as stored in the safetensors state dict."""
+    import numpy as np
+
+    return np.tanh(x @ weight.T + bias)
+
+
+def l2_normalize(x, eps: float = 1e-12):
+    """Module 3: row-wise L2 normalization."""
+    import numpy as np
+
+    norms = np.linalg.norm(x, axis=1, keepdims=True)
+    return x / np.maximum(norms, eps)
+
+
+# ── model I/O (live-verified boundary) ───────────────────────────────
+
+_session_cache = None  # (tokenizer, ort_session, input_names, W, b)
+
+
+def _fetch(repo: str, filename: str) -> str:
+    """Resolve a model file from the HF cache, downloading only on a miss.
+    Offline-first for the same reason as qe.py's torch path: hub validation
+    calls on every load can hang some setups."""
+    from huggingface_hub import hf_hub_download
+
+    try:
+        return hf_hub_download(repo_id=repo, filename=filename, local_files_only=True)
+    except Exception:
+        log.info("QE onnx: %s/%s not cached — downloading (one-time)", repo, filename)
+        return hf_hub_download(repo_id=repo, filename=filename)
+
+
+def _load():
+    """Build (tokenizer, session, input_names, dense W, dense b). Process-cached."""
+    global _session_cache
+    if _session_cache is not None:
+        return _session_cache
+
+    import numpy as np
+    import onnxruntime as ort
+    from safetensors.numpy import load_file
+    from tokenizers import Tokenizer
+
+    repo = os.environ.get(_MODEL_ENV, QE_MODEL)
+    tok = Tokenizer.from_file(_fetch(repo, _TOKENIZER_FILE))
+    tok.enable_truncation(MAX_SEQ_LENGTH)
+    pad_id = tok.token_to_id("[PAD]") or 0
+    tok.enable_padding(pad_id=pad_id, pad_token="[PAD]")
+
+    sess = ort.InferenceSession(_fetch(repo, _ONNX_FILE), providers=["CPUExecutionProvider"])
+    input_names = [i.name for i in sess.get_inputs()]
+
+    state = load_file(_fetch(repo, _DENSE_FILE))
+    # The Dense state dict is {"linear.weight": (768,768), "linear.bias": (768,)}.
+    # Discover by ndim so a key rename upstream doesn't silently break us.
+    weight = next(v for v in state.values() if v.ndim == 2).astype(np.float32)
+    bias = next(v for v in state.values() if v.ndim == 1).astype(np.float32)
+
+    _session_cache = (tok, sess, input_names, weight, bias)
+    return _session_cache
+
+
+def embed(texts):
+    """Embed texts -> L2-normalized (batch, 768) float32, matching the torch
+    backend's `encode(..., normalize_embeddings=True)` output."""
+    import numpy as np
+
+    tok, sess, input_names, weight, bias = _load()
+    encs = tok.encode_batch([str(t) for t in texts])
+    feeds_all = {
+        "input_ids": np.asarray([e.ids for e in encs], dtype=np.int64),
+        "attention_mask": np.asarray([e.attention_mask for e in encs], dtype=np.int64),
+        "token_type_ids": np.asarray([e.type_ids for e in encs], dtype=np.int64),
+    }
+    # Feed only what this export declares (optimum BERT exports take all
+    # three, but don't assume).
+    feeds = {k: v for k, v in feeds_all.items() if k in input_names}
+    hidden = sess.run(None, feeds)[0]  # last_hidden_state: (batch, seq, dim)
+    return l2_normalize(dense_tanh(cls_pool(hidden), weight, bias))

--- a/src/subarr/qe_onnx.py
+++ b/src/subarr/qe_onnx.py
@@ -33,6 +33,13 @@ log = logging.getLogger(__name__)
 _MODEL_ENV = "SUBARR_QE_MODEL"
 QE_MODEL = "sentence-transformers/LaBSE"
 
+# Pinned repo revision (bandit B615 + supply-chain): an upstream repo change
+# must not silently alter the embeddings our rho=0.727 calibration and the
+# onnx<->torch parity check were validated against. Overridable alongside the
+# repo id; bump deliberately, re-running the parity test.
+_REVISION_ENV = "SUBARR_QE_MODEL_REVISION"
+QE_MODEL_REVISION = "836121a0533e5664b21c7aacc5d22951f2b8b25b"  # 2025-03-06 snapshot
+
 # From sentence_bert_config.json in the model repo.
 MAX_SEQ_LENGTH = 256
 
@@ -90,14 +97,21 @@ _session_cache = None  # (tokenizer, ort_session, input_names, W, b)
 def _fetch(repo: str, filename: str) -> str:
     """Resolve a model file from the HF cache, downloading only on a miss.
     Offline-first for the same reason as qe.py's torch path: hub validation
-    calls on every load can hang some setups."""
+    calls on every load can hang some setups. Revision-pinned (B615) — see
+    QE_MODEL_REVISION. The default pin only applies to the default repo; a
+    custom SUBARR_QE_MODEL tracks its main unless SUBARR_QE_MODEL_REVISION
+    is set too."""
     from huggingface_hub import hf_hub_download
 
+    revision = os.environ.get(_REVISION_ENV)
+    if revision is None and repo == QE_MODEL:
+        revision = QE_MODEL_REVISION
+    revision = revision or None  # "" opts out (track main)
     try:
-        return hf_hub_download(repo_id=repo, filename=filename, local_files_only=True)
+        return hf_hub_download(repo_id=repo, filename=filename, revision=revision, local_files_only=True)
     except Exception:
         log.info("QE onnx: %s/%s not cached — downloading (one-time)", repo, filename)
-        return hf_hub_download(repo_id=repo, filename=filename)
+        return hf_hub_download(repo_id=repo, filename=filename, revision=revision)
 
 
 def _load():

--- a/tests/test_qe_onnx.py
+++ b/tests/test_qe_onnx.py
@@ -11,16 +11,19 @@ monkeypatched availability — no model required.
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
 
+# qe_onnx imports numpy/onnxruntime inside functions by design, so importing
+# the module is safe on base CI; the math tests skip without numpy (the
+# repo's test_qe.py pattern), while the backend-selection tests always run.
 from subarr import qe, qe_onnx
 
 
-# ── pure pipeline math ───────────────────────────────────────────────
+# ── pure pipeline math (need numpy; skipped on base CI) ──────────────
 
 
 def test_cls_pool_takes_first_token():
+    np = pytest.importorskip("numpy")
     hidden = np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4)
     pooled = qe_onnx.cls_pool(hidden)
     assert pooled.shape == (2, 4)
@@ -29,6 +32,7 @@ def test_cls_pool_takes_first_token():
 
 
 def test_dense_tanh_matches_torch_linear_semantics():
+    np = pytest.importorskip("numpy")
     # torch.nn.Linear computes x @ W.T + b — the safetensors weight is (out, in).
     x = np.array([[1.0, 2.0]], dtype=np.float32)
     weight = np.array([[0.5, -0.25], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)  # (3, 2)
@@ -40,6 +44,7 @@ def test_dense_tanh_matches_torch_linear_semantics():
 
 
 def test_l2_normalize_unit_rows():
+    np = pytest.importorskip("numpy")
     x = np.array([[3.0, 4.0], [0.0, 2.0]], dtype=np.float32)
     n = qe_onnx.l2_normalize(x)
     assert np.allclose(np.linalg.norm(n, axis=1), [1.0, 1.0], atol=1e-6)
@@ -47,11 +52,13 @@ def test_l2_normalize_unit_rows():
 
 
 def test_l2_normalize_zero_row_stays_finite():
+    np = pytest.importorskip("numpy")
     n = qe_onnx.l2_normalize(np.zeros((1, 4), dtype=np.float32))
     assert np.all(np.isfinite(n))
 
 
 def test_full_pipeline_composition_is_normalized():
+    np = pytest.importorskip("numpy")
     # cls_pool → dense_tanh → l2_normalize on synthetic weights ends on the
     # unit sphere regardless of input scale (what cosine scoring relies on).
     rng = np.random.default_rng(42)
@@ -116,6 +123,7 @@ def test_qe_adequacy_uses_injected_embedder_unchanged():
 def test_onnx_torch_parity_on_multilingual_pairs():
     """The two backends must produce near-identical normalized vectors, so
     cosine scores (and the validated rho=0.727) carry over unchanged."""
+    np = pytest.importorskip("numpy")
     texts = ["bonjour le monde", "hello world", "el gato duerme", "the cat sleeps"]
     try:
         a = np.asarray(qe_onnx.embed(texts))

--- a/tests/test_qe_onnx.py
+++ b/tests/test_qe_onnx.py
@@ -1,0 +1,127 @@
+"""#179 — the no-torch onnx QE backend.
+
+Same split as test_qe.py: the PURE pipeline math (CLS pooling, dense+tanh,
+L2 normalize) is unit-tested with numpy fixtures; the model I/O (tokenizer,
+ort session, safetensors weights) sits behind onnx_qe_available() and is
+parity-verified live against the torch backend (skipif-gated below).
+
+Backend selection in qe.py (SUBARR_QE_BACKEND auto|onnx|torch) is tested with
+monkeypatched availability — no model required.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from subarr import qe, qe_onnx
+
+
+# ── pure pipeline math ───────────────────────────────────────────────
+
+
+def test_cls_pool_takes_first_token():
+    hidden = np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4)
+    pooled = qe_onnx.cls_pool(hidden)
+    assert pooled.shape == (2, 4)
+    assert np.array_equal(pooled[0], hidden[0, 0])
+    assert np.array_equal(pooled[1], hidden[1, 0])
+
+
+def test_dense_tanh_matches_torch_linear_semantics():
+    # torch.nn.Linear computes x @ W.T + b — the safetensors weight is (out, in).
+    x = np.array([[1.0, 2.0]], dtype=np.float32)
+    weight = np.array([[0.5, -0.25], [1.0, 0.0], [0.0, 1.0]], dtype=np.float32)  # (3, 2)
+    bias = np.array([0.1, -1.0, 0.0], dtype=np.float32)
+    out = qe_onnx.dense_tanh(x, weight, bias)
+    expected = np.tanh(np.array([[1 * 0.5 + 2 * -0.25 + 0.1, 1 * 1.0 - 1.0, 2.0]], dtype=np.float32))
+    assert out.shape == (1, 3)
+    assert np.allclose(out, expected, atol=1e-7)
+
+
+def test_l2_normalize_unit_rows():
+    x = np.array([[3.0, 4.0], [0.0, 2.0]], dtype=np.float32)
+    n = qe_onnx.l2_normalize(x)
+    assert np.allclose(np.linalg.norm(n, axis=1), [1.0, 1.0], atol=1e-6)
+    assert np.allclose(n[0], [0.6, 0.8], atol=1e-6)
+
+
+def test_l2_normalize_zero_row_stays_finite():
+    n = qe_onnx.l2_normalize(np.zeros((1, 4), dtype=np.float32))
+    assert np.all(np.isfinite(n))
+
+
+def test_full_pipeline_composition_is_normalized():
+    # cls_pool → dense_tanh → l2_normalize on synthetic weights ends on the
+    # unit sphere regardless of input scale (what cosine scoring relies on).
+    rng = np.random.default_rng(42)
+    hidden = rng.normal(size=(3, 5, 8)).astype(np.float32) * 100
+    weight = rng.normal(size=(8, 8)).astype(np.float32)
+    bias = rng.normal(size=(8,)).astype(np.float32)
+    out = qe_onnx.l2_normalize(qe_onnx.dense_tanh(qe_onnx.cls_pool(hidden), weight, bias))
+    assert out.shape == (3, 8)
+    assert np.allclose(np.linalg.norm(out, axis=1), 1.0, atol=1e-6)
+
+
+# ── backend selection (qe.py) ────────────────────────────────────────
+
+
+def test_backend_env_forces_onnx_availability(monkeypatch):
+    monkeypatch.setenv("SUBARR_QE_BACKEND", "onnx")
+    monkeypatch.setattr(qe, "_onnx_available", lambda: False)
+    monkeypatch.setattr(qe, "_torch_available", lambda: True)
+    assert qe.qe_available() is False  # torch presence must not count
+
+
+def test_backend_env_forces_torch_availability(monkeypatch):
+    monkeypatch.setenv("SUBARR_QE_BACKEND", "torch")
+    monkeypatch.setattr(qe, "_onnx_available", lambda: True)
+    monkeypatch.setattr(qe, "_torch_available", lambda: False)
+    assert qe.qe_available() is False  # onnx presence must not count
+
+
+def test_backend_auto_accepts_either(monkeypatch):
+    monkeypatch.setenv("SUBARR_QE_BACKEND", "auto")
+    monkeypatch.setattr(qe, "_onnx_available", lambda: False)
+    monkeypatch.setattr(qe, "_torch_available", lambda: True)
+    assert qe.qe_available() is True
+    monkeypatch.setattr(qe, "_torch_available", lambda: False)
+    assert qe.qe_available() is False
+
+
+def test_auto_falls_back_to_torch_when_onnx_embed_fails(monkeypatch):
+    monkeypatch.setenv("SUBARR_QE_BACKEND", "auto")
+    monkeypatch.setattr(qe, "_onnx_available", lambda: True)
+    monkeypatch.setattr(qe, "_torch_available", lambda: True)
+    monkeypatch.setattr(qe_onnx, "embed", lambda texts: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(qe, "_torch_embed", lambda texts: [[1.0, 0.0], [1.0, 0.0]])
+    out = qe._default_embed(["a", "b"])
+    assert out == [[1.0, 0.0], [1.0, 0.0]]
+
+
+def test_qe_adequacy_uses_injected_embedder_unchanged():
+    # The injectable-embedder contract (what all existing callers rely on)
+    # must survive the backend split.
+    score = qe.qe_adequacy("bonjour", "hello", embedder=lambda t: [[1.0, 0.0], [1.0, 0.0]])
+    assert score == 1.0
+
+
+# ── live parity (needs BOTH backends + the model; skipped in CI) ─────
+
+
+@pytest.mark.skipif(
+    not (qe._torch_available() and qe_onnx.onnx_qe_available()),
+    reason="parity check needs both QE backends installed",
+)
+def test_onnx_torch_parity_on_multilingual_pairs():
+    """The two backends must produce near-identical normalized vectors, so
+    cosine scores (and the validated rho=0.727) carry over unchanged."""
+    texts = ["bonjour le monde", "hello world", "el gato duerme", "the cat sleeps"]
+    try:
+        a = np.asarray(qe_onnx.embed(texts))
+        b = np.asarray(qe._torch_embed(texts))
+    except Exception as e:  # model not downloaded in this env — treat as skip
+        pytest.skip(f"model unavailable: {e}")
+    # Per-text cosine between the two backends' vectors ≈ 1.
+    per_text = np.sum(a * b, axis=1)
+    assert np.all(per_text > 0.999), per_text


### PR DESCRIPTION
Closes #179. The QE judge previously required the `[qe]` extra (sentence-transformers → **torch, ~2GB**), so it couldn''t ship in the image. This adds a no-torch backend and bakes it.

## What
- **`qe_onnx.py`** — LaBSE''s exact 4-module pipeline (official `onnx/model.onnx` → CLS pooling → Dense 768→768 + tanh from `2_Dense/model.safetensors` → L2 normalize), reimplemented with onnxruntime + numpy. Pipeline constants verbatim from the model repo''s own configs (`modules.json`, `1_Pooling`, `2_Dense`, `sentence_bert_config.json`).
- **`[qe-onnx]` extra** — tokenizers + safetensors + huggingface_hub on top of `[vad]`''s onnxruntime/numpy. ~MBs of pure wheels; **now baked into the Dockerfile** alongside `[vad]`. The ~1.9GB model file stays pull-on-first-use into the HF cache (same volume the torch path uses), offline-first thereafter.
- **`qe.py` backend selection** — `SUBARR_QE_BACKEND=auto|onnx|torch`; auto prefers onnx, falls back to torch loudly on failure. Torch path kept as fallback + parity reference. Injectable-embedder contract unchanged.

## Parity (the gate)
Live check in subarr-next, onnx vs torch on fr/es/ru↔en pairs:
- per-text cosine between the two backends'' vectors: **1.0** (min 0.99999994)
- adequacy scores identical to 6 decimal places (delta 0.000000)

So the validated **ρ=0.727 carries over exactly** — drop-in, no recalibration.

## Tests
+10: pure pipeline math (CLS pool / dense+tanh torch-Linear semantics / L2 norm / composition), backend selection (env forcing, auto-either, onnx→torch fallback), injected-embedder contract, and a skipif-gated live parity test. **784 green.**

Net effect: every image-based install now has a working accuracy-grade QE judge out of the box (model download on first use) — the federated tuning loop''s ranking signal no longer needs a 2GB opt-in.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>