### PR TITLE
feat(#134): Phase 0 — root-folder plumbing + consolidated strip_arr_prefix

### DIFF
--- a/src/subarr/arr_mediainfo.py
+++ b/src/subarr/arr_mediainfo.py
@@ -45,7 +45,8 @@ from typing import Any
 from pathlib import Path
 
 from .config import settings
-from .coverage_engine import IntegrationBundle, _strip_arr_prefix
+from .coverage_engine import IntegrationBundle
+from .paths import strip_arr_prefix
 from .media_probe import AudioStream, ProbeResult, SubtitleStream
 from .probe_store import ProbeStore
 
@@ -158,7 +159,7 @@ class ArrMediainfoSync:
             return
 
         # Translate arr's container-view path → subarr's canonical form.
-        canonical = _strip_arr_prefix(path)
+        canonical = strip_arr_prefix(path)
         if not canonical:
             stats["skipped_no_path"] += 1
             return

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import settings
-from .paths import UNSUPPORTED_EXTS
+from .paths import UNSUPPORTED_EXTS, strip_arr_prefix
 from .integrations import IntegrationError
 from .integrations.bazarr import BazarrClient
 from .integrations.radarr import RadarrClient
@@ -260,18 +260,6 @@ class IntegrationBundle:
 # ───────────────────────────── helpers ──────────────────────────────────────
 
 
-def _strip_arr_prefix(arr_path: str | None) -> str | None:
-    """Sonarr returns 'path': '/data/Media/TV/Foo' (its container view).
-    Strip the configured prefix to canonical form 'TV/Foo'."""
-    if not arr_path:
-        return None
-    prefix = settings.arr_path_prefix
-    s = arr_path
-    if prefix and s.startswith(prefix):
-        s = s[len(prefix) :]
-    return s.strip("/")
-
-
 def _scan_for_srt(canonical_dir: str) -> tuple[bool, list[str]]:
     """Shallow check: does any *.srt exist directly under <media_root>/<canonical>?
     Returns (has_any, list_of_filenames). Best-effort; errors swallowed.
@@ -464,7 +452,7 @@ def _episode_file_canonical(
     abs_path = ep_file_paths.get(ep_file_id) if ep_file_id else None
     if not abs_path:
         return None
-    return _strip_arr_prefix(abs_path) or abs_path
+    return strip_arr_prefix(abs_path) or abs_path
 
 
 def _stale_for_episode(
@@ -1402,7 +1390,7 @@ async def build_coverage(
     # rglobs were the dominant cost of the build (minutes). The loop then
     # just reads from this index.
     _ep_canonical_dirs = [
-        _strip_arr_prefix(sonarr_by_id.get(w.get("sonarrSeriesId"), {}).get("path")) for w in bz_eps
+        strip_arr_prefix(sonarr_by_id.get(w.get("sonarrSeriesId"), {}).get("path")) for w in bz_eps
     ]
     series_srt_index.update(await _build_srt_index_parallel(_ep_canonical_dirs))
 
@@ -1441,7 +1429,7 @@ async def build_coverage(
     for w in bz_eps:
         sonarr_id = w.get("sonarrSeriesId")
         s = sonarr_by_id.get(sonarr_id, {})
-        canonical = _strip_arr_prefix(s.get("path"))
+        canonical = strip_arr_prefix(s.get("path"))
         if canonical and canonical not in series_srt_index:
             # #104: normally pre-populated by the parallel pre-scan above.
             # This inline fallback only fires for a dir that wasn't in the
@@ -1516,7 +1504,7 @@ async def build_coverage(
     for w in bz_movs:
         title = w.get("title") or w.get("movieTitle") or ""
         m = radarr_by_title.get(title.strip().lower(), {})
-        canonical = _strip_arr_prefix(m.get("path"))
+        canonical = strip_arr_prefix(m.get("path"))
         # #228: iterdir on each movie folder blocks the event loop. Shallow
         # scan (one level deep) so per-call cost is small, but with 500+
         # movies the cumulative block is real. Thread it.
@@ -1718,7 +1706,7 @@ async def _add_bazarr_blind_synthetic_rows(
     # that previously ran strictly one-at-a-time.
     _foreign_dirs = [
         c
-        for c in (_strip_arr_prefix(s.get("path")) for s in foreign_series)
+        for c in (strip_arr_prefix(s.get("path")) for s in foreign_series)
         if c and c not in series_srt_index
     ]
     series_srt_index.update(await _build_srt_index_parallel(_foreign_dirs))
@@ -1726,7 +1714,7 @@ async def _add_bazarr_blind_synthetic_rows(
     synthetic_added = 0
     for s in foreign_series:
         sid = s.get("id")
-        series_canonical = _strip_arr_prefix(s.get("path"))
+        series_canonical = strip_arr_prefix(s.get("path"))
         if series_canonical and series_canonical not in series_srt_index:
             # #104: defensive inline fallback (pre-scan above normally
             # covers this). Offloaded so it never blocks the loop (#228).
@@ -1745,7 +1733,7 @@ async def _add_bazarr_blind_synthetic_rows(
             arr_file_path = ep_file_paths.get(ep_file_id)
             if not arr_file_path:
                 continue
-            file_canonical = _strip_arr_prefix(arr_file_path)
+            file_canonical = strip_arr_prefix(arr_file_path)
             if not file_canonical:
                 continue
             if ep_id in seen_ep_ids or file_canonical in seen_files:

--- a/src/subarr/integrations/radarr.py
+++ b/src/subarr/integrations/radarr.py
@@ -23,6 +23,13 @@ class RadarrClient(IntegrationClient):
     async def status(self) -> dict[str, Any]:
         return await self._get("/api/v3/system/status")
 
+    async def root_folders(self) -> list[dict[str, Any]]:
+        """GET /api/v3/rootfolder — the configured root folders (path,
+        accessible, freeSpace). #134 Phase 0: the ground truth for the
+        multi-library model — Phase 1 auto-derives `libraries[]` from these
+        so multi-root onboarding stays zero-config."""
+        return await self._get("/api/v3/rootfolder")
+
     async def movies(self) -> list[dict[str, Any]]:
         return await self._get("/api/v3/movie")
 

--- a/src/subarr/integrations/sonarr.py
+++ b/src/subarr/integrations/sonarr.py
@@ -26,6 +26,13 @@ class SonarrClient(IntegrationClient):
     async def status(self) -> dict[str, Any]:
         return await self._get("/api/v3/system/status")
 
+    async def root_folders(self) -> list[dict[str, Any]]:
+        """GET /api/v3/rootfolder — the configured root folders (path,
+        accessible, freeSpace). #134 Phase 0: the ground truth for the
+        multi-library model — Phase 1 auto-derives `libraries[]` from these
+        so multi-root onboarding stays zero-config."""
+        return await self._get("/api/v3/rootfolder")
+
     async def series(self) -> list[dict[str, Any]]:
         return await self._get("/api/v3/series")
 

--- a/src/subarr/paths.py
+++ b/src/subarr/paths.py
@@ -92,3 +92,29 @@ def subgen_to_canonical(subgen_path: str) -> str:
     if prefix and p == prefix:
         return ""
     return p.strip("/")
+
+
+def strip_arr_prefix(arr_path: str | None, prefix: str | None = None) -> str | None:
+    """Strip an *arr's container-view path prefix to canonical form.
+
+    Sonarr/Radarr report paths in THEIR container's mount namespace (e.g.
+    'path': '/data/Media/TV/Foo'); stripping the configured prefix yields
+    subarr's canonical 'TV/Foo'. Falsy input passes through unchanged
+    (None → None, '' → '').
+
+    #134 Phase 0: the single consolidated copy of what previously lived
+    duplicated in coverage_engine, scheduler, and coverage_actions. `prefix`
+    defaults to settings.arr_path_prefix; Phase 1 threads per-library /
+    per-arr prefixes through this parameter (the config-level
+    sonarr_path_prefix / radarr_path_prefix split from #133 is currently
+    unconsumed — wiring it correctly needs arr identity at each call site,
+    which is exactly what the library model adds).
+    """
+    if not arr_path:
+        return arr_path
+    if prefix is None:
+        prefix = settings.arr_path_prefix
+    s = arr_path
+    if prefix and s.startswith(prefix):
+        s = s[len(prefix) :]
+    return s.strip("/")

--- a/src/subarr/routers/coverage_actions.py
+++ b/src/subarr/routers/coverage_actions.py
@@ -20,9 +20,8 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from ..config import settings
 from ..integrations import IntegrationError
-from ..paths import PathOutsideRootError, canonical_to_fs
+from ..paths import PathOutsideRootError, canonical_to_fs, strip_arr_prefix
 from ..audio_lang_store import resolve_audio_language_override
 
 router = APIRouter(prefix="/api", tags=["coverage"])
@@ -34,16 +33,6 @@ class CoverageQueueRequest(BaseModel):
     # Fallback for movies / rows missing sonarr id.
     canonical_path: str | None = None
     reverse: bool = False
-
-
-def _strip_arr_prefix(arr_path: str) -> str:
-    """Mirror of coverage_engine._strip_arr_prefix — kept inline here to
-    avoid a circular import; the prefix is one env var."""
-    prefix = settings.arr_path_prefix
-    s = arr_path or ""
-    if prefix and s.startswith(prefix):
-        s = s[len(prefix) :]
-    return s.strip("/")
 
 
 @router.post("/coverage/queue", status_code=202)
@@ -80,7 +69,7 @@ async def coverage_queue(req: CoverageQueueRequest, request: Request) -> dict:
         arr_path = ep_file.get("path")
         if not arr_path:
             raise HTTPException(500, detail=f"sonarr episode_file {ep_file_id} has no path field")
-        canonical = _strip_arr_prefix(arr_path)
+        canonical = strip_arr_prefix(arr_path)
         resolved_via = f"sonarr_episode_id={req.sonarr_episode_id}"
 
     elif req.canonical_path:

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -318,6 +318,37 @@ async def auto_detect(request: Request) -> dict[str, Any]:
     return {"available": True, "services": enriched, "count": len(enriched)}
 
 
+@router.get("/onboarding/root-folders")
+async def root_folders(request: Request) -> dict[str, Any]:
+    """#134 Phase 0: the *arrs' configured root folders, best-effort per
+    service. The ground truth Phase 1's multi-library auto-detect builds on;
+    immediately useful for verifying that a mount layout actually covers
+    every root folder Sonarr/Radarr manage."""
+    bundle = request.app.state.integrations
+    out: dict[str, Any] = {}
+    for name in ("sonarr", "radarr"):
+        client = getattr(bundle, name, None)
+        if client is None or not client.is_configured():
+            out[name] = {"configured": False, "folders": []}
+            continue
+        try:
+            folders = await client.root_folders()
+            out[name] = {
+                "configured": True,
+                "folders": [
+                    {
+                        "path": f.get("path"),
+                        "accessible": f.get("accessible"),
+                        "free_space": f.get("freeSpace"),
+                    }
+                    for f in folders
+                ],
+            }
+        except Exception as e:  # noqa: BLE001 — best-effort diagnostics surface
+            out[name] = {"configured": True, "folders": [], "error": str(e)[:200]}
+    return out
+
+
 # ─── Mount detection (#130) ─────────────────────────────────────────
 
 

--- a/src/subarr/scheduler.py
+++ b/src/subarr/scheduler.py
@@ -28,7 +28,7 @@ from typing import Any
 from .auto_queue import Decision, evaluate
 from .coverage_engine import IntegrationBundle, build_coverage
 from .integrations import IntegrationError
-from .paths import PathOutsideRootError, canonical_to_fs
+from .paths import PathOutsideRootError, canonical_to_fs, strip_arr_prefix
 from .pending_store import PendingStore
 from .probe_walker import ProbeWalker
 from .provenance import SOURCE_SUBGENSCAN, ProvenanceStore
@@ -46,16 +46,6 @@ from .schedule_store import (
 log = logging.getLogger(__name__)
 
 TICK_S = 60
-
-
-def _strip_arr_prefix(arr_path: str) -> str:
-    from .config import settings
-
-    prefix = settings.arr_path_prefix
-    s = arr_path or ""
-    if prefix and s.startswith(prefix):
-        s = s[len(prefix) :]
-    return s.strip("/")
 
 
 def _due(sched: ScheduleConfig, now: datetime.datetime, last_run_at: float | None) -> bool:
@@ -514,7 +504,7 @@ class Scheduler:
                     ep_file = await self._bundle.sonarr.episode_file(ep_file_id)
                     arr_path = ep_file.get("path")
                     if arr_path:
-                        canonical = _strip_arr_prefix(arr_path)
+                        canonical = strip_arr_prefix(arr_path)
             except IntegrationError as e:
                 return None, f"{title}: sonarr resolve failed: {e}"
 
@@ -563,7 +553,7 @@ class Scheduler:
                     ep_file = await self._bundle.sonarr.episode_file(ep_file_id)
                     arr_path = ep_file.get("path")
                     if arr_path:
-                        canonical = _strip_arr_prefix(arr_path)
+                        canonical = strip_arr_prefix(arr_path)
             except IntegrationError as e:
                 return None, f"{item.title}: sonarr resolve failed: {e}"
 

--- a/tests/test_bazarr_blind_defense.py
+++ b/tests/test_bazarr_blind_defense.py
@@ -178,7 +178,7 @@ async def test_bazarr_blind_synthetic_row_reaches_score_without_nameerror(monkey
     # Isolate from disk + the probe/score machinery — the NameError fires when
     # Python evaluates the `ignore_forced` arg, BEFORE _score runs, so a stubbed
     # _score still exposes it.
-    monkeypatch.setattr(ce, "_strip_arr_prefix", lambda p: p)
+    monkeypatch.setattr(ce, "strip_arr_prefix", lambda p: p)
 
     async def _no_index(dirs):
         return {}

--- a/tests/test_root_folders.py
+++ b/tests/test_root_folders.py
@@ -1,0 +1,119 @@
+"""#134 Phase 0: root-folder plumbing + the consolidated arr-prefix strip.
+
+- Sonarr/Radarr `root_folders()` hit GET /api/v3/rootfolder (MockTransport,
+  the bazarr-client test pattern).
+- GET /api/onboarding/root-folders is best-effort per service: unconfigured
+  services report configured=false instead of erroring the whole payload.
+- paths.strip_arr_prefix is the single consolidated copy of what previously
+  lived duplicated in coverage_engine / scheduler / coverage_actions (+ a
+  fourth consumer, arr_mediainfo) — behavior pinned here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from subarr.integrations.radarr import RadarrClient
+from subarr.integrations.sonarr import SonarrClient
+from subarr.paths import strip_arr_prefix
+
+
+def _wire(client, handler):
+    client._client = httpx.AsyncClient(base_url="http://arr:8989", transport=httpx.MockTransport(handler))
+    client._configured = True
+    return client
+
+
+def test_sonarr_root_folders_hits_rootfolder_endpoint():
+    captured = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        return httpx.Response(200, json=[{"path": "/tv", "accessible": True, "freeSpace": 123}])
+
+    rows = asyncio.run(_wire(SonarrClient(), handler).root_folders())
+    assert captured["path"] == "/api/v3/rootfolder"
+    assert rows[0]["path"] == "/tv"
+
+
+def test_radarr_root_folders_hits_rootfolder_endpoint():
+    captured = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        return httpx.Response(200, json=[{"path": "/movies", "accessible": True}])
+
+    rows = asyncio.run(_wire(RadarrClient(), handler).root_folders())
+    assert captured["path"] == "/api/v3/rootfolder"
+    assert rows[0]["path"] == "/movies"
+
+
+def test_root_folders_endpoint_reports_unconfigured(app_with_stub):
+    body = app_with_stub.get("/api/onboarding/root-folders").json()
+    for svc in ("sonarr", "radarr"):
+        assert body[svc]["configured"] is False
+        assert body[svc]["folders"] == []
+
+
+def test_root_folders_endpoint_surfaces_folders(app_with_stub):
+    class FakeArr:
+        def is_configured(self):
+            return True
+
+        async def root_folders(self):
+            return [{"path": "/data/tv", "accessible": True, "freeSpace": 42}]
+
+        async def aclose(self):  # lifespan teardown closes integration clients
+            pass
+
+    app_with_stub.app.state.integrations.sonarr = FakeArr()
+    body = app_with_stub.get("/api/onboarding/root-folders").json()
+    assert body["sonarr"]["configured"] is True
+    assert body["sonarr"]["folders"] == [{"path": "/data/tv", "accessible": True, "free_space": 42}]
+    assert body["radarr"]["configured"] is False
+
+
+def test_root_folders_endpoint_isolates_per_service_errors(app_with_stub):
+    class BrokenArr:
+        def is_configured(self):
+            return True
+
+        async def root_folders(self):
+            raise RuntimeError("arr down")
+
+        async def aclose(self):
+            pass
+
+    app_with_stub.app.state.integrations.radarr = BrokenArr()
+    body = app_with_stub.get("/api/onboarding/root-folders").json()
+    assert body["radarr"]["configured"] is True
+    assert body["radarr"]["folders"] == []
+    assert "arr down" in body["radarr"]["error"]
+    assert body["sonarr"]["configured"] is False  # the other service unaffected
+
+
+# ── strip_arr_prefix (consolidated) ──────────────────────────────────
+
+
+def test_strip_arr_prefix_default_prefix_comes_from_settings():
+    # Settings is a frozen singleton — exercise the default-wiring against
+    # whatever prefix is configured rather than monkeypatching it.
+    from subarr.paths import settings
+
+    pfx = settings.arr_path_prefix
+    assert strip_arr_prefix(f"{pfx}TV/Foo") == "TV/Foo"
+
+
+def test_strip_arr_prefix_passthrough_without_match():
+    assert strip_arr_prefix("/other/TV/Foo", prefix="/data/Media/") == "other/TV/Foo"
+
+
+def test_strip_arr_prefix_falsy_passthrough():
+    assert strip_arr_prefix(None) is None
+    assert strip_arr_prefix("") == ""
+
+
+def test_strip_arr_prefix_explicit_prefix_overrides_settings():
+    assert strip_arr_prefix("/mnt/tv/Show", prefix="/mnt/") == "tv/Show"


### PR DESCRIPTION
Phase 0 of #134 (multi-root), per the design recon documented on the issue — the low-risk, independently-valuable slice ahead of the library-model refactor.

## What
- **`root_folders()`** on the Sonarr + Radarr clients (`GET /api/v3/rootfolder`) — the ground truth Phase 1 auto-derives `libraries[]` from (zero-config multi-root onboarding).
- **`GET /api/onboarding/root-folders`** — best-effort per service: unconfigured services report `configured: false`, a failing arr reports its own `error` without breaking the other. Immediately useful for checking a mount layout covers every root folder the *arrs manage.
- **`strip_arr_prefix` consolidated into `paths.py`.** The issue recon counted 3 duplicated copies (coverage_engine / scheduler / coverage_actions) — there was a **4th consumer**: `arr_mediainfo` importing coverage_engine''s private `_strip_arr_prefix`. All four now share the single copy. The optional `prefix` param is the seam Phase 1 threads per-library prefixes through.

## Finding (noted for Phase 1)
The #133 `sonarr_path_prefix` / `radarr_path_prefix` config vars are **defined but consumed nowhere** — all strip sites use `arr_path_prefix`. Wiring them correctly needs arr identity at each call site, which is exactly what the Phase 1 library model adds — so documented rather than half-wired here.

## Tests
+9: both clients hit `/api/v3/rootfolder`; endpoint shapes (unconfigured / configured / per-service error isolation); strip semantics (settings default, no-match passthrough, falsy passthrough, explicit prefix). **783 green**; behavior of all four former call sites unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>