### PR TITLE
feat(#134): Phase 1 slices 3-4 — multi-library walkers + direct-join sweep

### DIFF
--- a/docs/superpowers/plans/2026-06-11-134-phase1-slices3-6.md
+++ b/docs/superpowers/plans/2026-06-11-134-phase1-slices3-6.md
@@ -1,0 +1,1024 @@
+# #134 Phase 1 — Slices 3–6 (multi-library walkers, sweep, UI, verification) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish #134 Phase 1 on top of the merged foundation (PR #184): every walker and direct `media_root /` join becomes library-aware, a Libraries management surface ships in Settings + onboarding (incl. manual "Add library"), and the result is verified against the live dev DB.
+
+**Architecture:** The foundation made `paths.py` library-aware and recon confirmed all canonical consumers are opaque-key-safe. What remains is mechanical: (PR-A) replace the 9 remaining direct `settings.media_root / <canonical>` joins with `canonical_to_fs()` and make the two filesystem walkers (audio-audit worklist, sidecar root guard) iterate `settings.libraries`; (PR-B) a new `routers/libraries.py` (GET/PUT/validate) persisting extras to the `config_store` `"libraries"` key + a shared `libraries-editor.jsx` component mounted in Settings and the onboarding paths step; (PR-C) live-DB + e2e verification on :9923 and docs.
+
+**Tech Stack:** Python 3.12 / FastAPI, pytest (`PYTHONPATH=src`), ruff 0.15.15, React JSX → esbuild IIFE bundles (`npm run build:frontend`).
+
+**Recon verdicts this plan relies on (verified 2026-06-11):**
+- All 19 files calling the 5 path fns treat canonicals as opaque keys; zero `.split("/")` first-segment parsing anywhere (backend or JSX). The #58 subgen-space invariant holds (`pending_feeder.py:184`, `completion_watcher.py:191` translate via `canonical_to_subgen_batch` — already library-aware).
+- Frontend groups Coverage/Library trees by metadata (`title`, `ep`), never by parsing canonicals → no render changes needed.
+- Empty `probe_roots` = "no probe step" by design (`scheduler.py:322`); roots are canonicals so `@slug/...` roots flow through untouched. No scheduler change.
+- PlexClient `media_root` is only used by `translate_path()` for the optional single `PLEX_PATH_PREFIX` knob, with a documented benign unknown-root fallback → **deferred**: per-library Plex prefixes are out of scope (YAGNI; noted in #134 as a follow-up if anyone hits it).
+- Nothing writes the `"libraries"` config_store key yet — PR-B adds the only writer.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `tests/conftest.py` | Modify | Promote the `two_libraries` fixture (currently local to `test_paths.py`) for reuse |
+| `src/subarr/probe_walker.py:132` | Modify | Root walk resolves via `canonical_to_fs` |
+| `src/subarr/coverage_engine.py:275,295` | Modify | `.srt` scans resolve via `canonical_to_fs` |
+| `src/subarr/completion_watcher.py:335,378` | Modify | Sidecar full-path joins via `canonical_to_fs` |
+| `src/subarr/arr_mediainfo.py:171` | Modify | Mediainfo path join via `canonical_to_fs` |
+| `src/subarr/routers/admin.py:79` | Modify | Plex partial-scan canonical join via `canonical_to_fs` |
+| `src/subarr/app.py:425-452` | Modify | `_library_worklist` walks all library roots |
+| `src/subarr/routers/sidecar.py:35-70` | Modify | `_resolve_under_root` accepts any library root |
+| `src/subarr/routers/libraries.py` | **Create** | GET/PUT `/api/settings/libraries` + POST validate |
+| `src/subarr/app.py` (router block) | Modify | Register libraries router |
+| `tests/test_multilib_walkers.py` | **Create** | PR-A behavior tests |
+| `tests/test_libraries_api.py` | **Create** | PR-B endpoint tests |
+| `src/subarr/static/v1/home-hifi/libraries-editor.jsx` | **Create** | Shared Libraries CRUD component (NOT in chrome.jsx — avoids all-bundle rebuild) |
+| `src/subarr/static/v1/home-hifi/settings.jsx` | Modify | "Libraries" rail section + detail panel |
+| `src/subarr/static/v1/home-hifi/onboarding.jsx` | Modify | Paths step: detected root folders + Add library |
+| `src/subarr/static/v1/home-hifi/coverage.jsx:1773` | Modify | Reword stale `SONARR_PATH_PREFIX` hint |
+| `README.md` + compose docs | Modify | Multi-library mount examples (PR-C) |
+
+---
+
+# PR-A — slices 3+4: backend multi-root correctness
+
+Everything here is behavior-preserving for single-library installs (`canonical_to_fs("X")` ≡ `media_root / "X"` when only library 0 exists — pinned by the foundation's tests).
+
+### Task A0: Promote `two_libraries` fixture to conftest
+
+**Files:**
+- Modify: `tests/conftest.py`
+- Modify: `tests/test_paths.py` (delete the local fixture; keep using it by name)
+
+- [ ] **Step 1: Move the fixture**
+
+Cut the `two_libraries` fixture (and its `import json` if now unused there) from `tests/test_paths.py` and add to `tests/conftest.py` (below the `subarr_env` fixture), with imports adjusted:
+
+```python
+@pytest.fixture
+def two_libraries(subarr_env, monkeypatch, tmp_path: Path):
+    """Library 0 = the fixture media_root (empty slug); library 'disk2'
+    rooted at a second tmp dir. Reloads config+paths so settings.libraries
+    reflects both. Returns the disk2 root Path."""
+    import json
+
+    d2 = tmp_path / "disk2"
+    (d2 / "Movies").mkdir(parents=True)
+    (d2 / "Movies" / "film.mkv").write_bytes(b"")
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps(
+            {
+                "libraries": [
+                    {
+                        "slug": "disk2",
+                        "name": "Disk 2",
+                        "fs_root": str(d2),
+                        "subgen_prefix": "/media2",
+                        "arr_prefix": "/data/d2/",
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config, paths
+
+    importlib.reload(config)
+    importlib.reload(paths)
+    return d2
+```
+
+Note: conftest already has `import importlib` and `from pathlib import Path` at top — verify, add if missing.
+
+- [ ] **Step 2: Run the path tests to prove the move is clean**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_paths.py -q`
+Expected: 17 passed (same as before the move).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/conftest.py tests/test_paths.py
+git commit -m "test(#134): promote two_libraries fixture to conftest"
+```
+
+### Task A1: probe_walker root walk via canonical_to_fs
+
+**Files:**
+- Modify: `src/subarr/probe_walker.py:132`
+- Test: `tests/test_multilib_walkers.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_multilib_walkers.py
+"""#134 Phase 1 slices 3-4: walkers + direct media_root joins are library-aware."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def test_probe_walker_walks_non_default_library(two_libraries, subarr_env):
+    """start_walk('@disk2/Movies') must enumerate files under disk2's root,
+    not media_root, and record canonicals with the @disk2/ head."""
+    from subarr.probe_store import ProbeStore
+    from subarr.probe_walker import ProbeWalker
+    from subarr.config import settings
+
+    store = ProbeStore(settings.db_path)
+    walker = ProbeWalker(store)
+
+    async def run():
+        state = await walker.start_walk("@disk2/Movies")
+        while state.status == "running":
+            await asyncio.sleep(0.05)
+        return state
+
+    state = asyncio.run(run())
+    # The walk must FIND the file (enumeration worked under disk2's root).
+    # ffprobe on the empty stub file fails -> recorded as an error with the
+    # @disk2/ canonical, proving fs_to_canonical emitted the library head.
+    assert state.total_files == 1
+    assert state.status == "done"
+    paths_seen = [e.get("path", "") for e in state.errors]
+    assert any(p.startswith("@disk2/Movies/") for p in paths_seen)
+
+
+def test_probe_walker_unknown_library_errors_cleanly(two_libraries, subarr_env):
+    from subarr.probe_store import ProbeStore
+    from subarr.probe_walker import ProbeWalker
+    from subarr.config import settings
+
+    walker = ProbeWalker(ProbeStore(settings.db_path))
+
+    async def run():
+        state = await walker.start_walk("@nope/x")
+        while state.status == "running":
+            await asyncio.sleep(0.05)
+        return state
+
+    state = asyncio.run(run())
+    assert state.status == "error"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py -q`
+Expected: FAIL — first test finds 0 files (walker looked under `media_root/@disk2/Movies`, which doesn't exist → status "error" / root-not-found).
+
+- [ ] **Step 3: Implement**
+
+In `src/subarr/probe_walker.py`, `_run()` (line ~132), replace:
+
+```python
+            root_fs = settings.media_root / state.root
+```
+
+with:
+
+```python
+            try:
+                root_fs = canonical_to_fs(state.root)
+            except PathOutsideRootError:
+                state.status = "error"
+                state.errors.append({"error": f"invalid root: {state.root}"})
+                state.finished_at = time.time()
+                return
+```
+
+(`canonical_to_fs` and `PathOutsideRootError` are already imported at the top of the file. The `settings` import becomes unused ONLY if nothing else in the file uses it — it does not; check and remove the `from .config import settings` import if ruff flags it.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py tests/test_eager_probe.py tests/test_probe_router.py -q`
+Expected: PASS (new tests + existing probe tests unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/subarr/probe_walker.py tests/test_multilib_walkers.py
+git commit -m "feat(#134): probe walker resolves roots via canonical_to_fs (multi-library)"
+```
+
+### Task A2: coverage_engine .srt scans via canonical_to_fs
+
+**Files:**
+- Modify: `src/subarr/coverage_engine.py:275,295`
+- Test: `tests/test_multilib_walkers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_multilib_walkers.py
+def test_srt_scan_resolves_in_non_default_library(two_libraries, subarr_env):
+    from subarr import coverage_engine
+
+    show = two_libraries / "Movies"
+    (show / "film.en.srt").write_text("1\n")
+    # Shallow scan of the canonical dir must look under disk2's root.
+    assert coverage_engine._subtitles_exist("@disk2/Movies") is True
+    assert coverage_engine._subtitles_exist("@disk2/Empty-Nothing") is False
+```
+
+> Note: confirm the exact callable name at implementation time — recon places a shallow scan helper at `coverage_engine.py:264-283` ("does any *.srt exist directly under <media_root>/<canonical>?") and a recursive variant at :285-300. Use the real names (`_subtitles_exist` / the `_scan_for_srt*` pair) in the test; the assertion shape stays the same.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py -q -k srt`
+Expected: FAIL — the helper joined `media_root / "@disk2/Movies"`, found nothing.
+
+- [ ] **Step 3: Implement**
+
+In `src/subarr/coverage_engine.py`, in BOTH scan helpers (lines ~275 and ~295), replace:
+
+```python
+        full = settings.media_root / Path(canonical_dir)
+```
+
+with:
+
+```python
+        try:
+            full = canonical_to_fs(canonical_dir)
+        except PathOutsideRootError:
+            return False  # (or [] in the recursive variant returning a list)
+```
+
+Add to the existing paths import at the top (line ~28):
+
+```python
+from .paths import UNSUPPORTED_EXTS, PathOutsideRootError, canonical_to_fs, strip_arr_prefix
+```
+
+Match each helper's empty-return type exactly (bool vs list — read the function before editing).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py tests/test_coverage.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/subarr/coverage_engine.py tests/test_multilib_walkers.py
+git commit -m "feat(#134): coverage srt scans resolve via canonical_to_fs"
+```
+
+### Task A3: remaining direct joins — completion_watcher, arr_mediainfo, admin
+
+**Files:**
+- Modify: `src/subarr/completion_watcher.py:335,378`
+- Modify: `src/subarr/arr_mediainfo.py:171`
+- Modify: `src/subarr/routers/admin.py:79`
+- Test: `tests/test_multilib_walkers.py` + existing `tests/test_plex_partial_scan.py`
+
+- [ ] **Step 1: Write the failing test (admin partial-scan path resolution)**
+
+```python
+# append to tests/test_multilib_walkers.py
+def test_admin_partial_scan_resolves_library_canonical(two_libraries, subarr_env):
+    """The /api/plex/partial-scan canonical branch must resolve @disk2/ под
+    disk2's root. We don't need a live Plex: resolve through the same fn the
+    router now uses and assert equality with canonical_to_fs."""
+    from subarr.paths import canonical_to_fs
+
+    expected = two_libraries / "Movies" / "film.mkv"
+    assert canonical_to_fs("@disk2/Movies/film.mkv") == expected.resolve()
+```
+
+(The endpoint itself is covered by `tests/test_plex_partial_scan.py`; this task's real verification is Step 4 — those existing tests must stay green after the swap. completion_watcher/arr_mediainfo joins are deep-integration paths; their regression net is the full suite + the same one-line swap pattern already proven in A1/A2.)
+
+- [ ] **Step 2: Implement all three swaps**
+
+`src/subarr/routers/admin.py` (~line 74-79) — replace:
+
+```python
+    from pathlib import Path
+
+    p = req.path
+    # Treat anything that isn't absolute as canonical-relative-to-media_root.
+    if not p.startswith("/"):
+        p = str(settings.media_root / Path(p))
+```
+
+with:
+
+```python
+    p = req.path
+    # Treat anything that isn't absolute as a canonical (library-aware, #134).
+    if not p.startswith("/"):
+        from ..paths import canonical_to_fs
+
+        p = str(canonical_to_fs(p))
+```
+
+`src/subarr/completion_watcher.py` line ~335 — replace:
+
+```python
+        subarr_full = str(_settings.media_root / Path(video_canonical))
+```
+
+with:
+
+```python
+        subarr_full = str(canonical_to_fs(video_canonical))
+```
+
+and line ~378 — replace:
+
+```python
+        full = settings.media_root / Path(video_canonical)
+```
+
+with:
+
+```python
+        full = canonical_to_fs(video_canonical)
+```
+
+Add `canonical_to_fs` to completion_watcher's existing `from .paths import ...` line.
+
+`src/subarr/arr_mediainfo.py` line ~171 — replace:
+
+```python
+    subarr_path = settings.media_root / Path(canonical)
+```
+
+with:
+
+```python
+    subarr_path = canonical_to_fs(canonical)
+```
+
+Add `canonical_to_fs` to arr_mediainfo's existing `from .paths import strip_arr_prefix` import.
+
+In each file, if `settings` / `Path` becomes unused, ruff will flag it — remove the dead import then.
+
+- [ ] **Step 3: Run targeted + related suites**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py tests/test_plex_partial_scan.py tests/test_provenance_watcher.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/subarr/completion_watcher.py src/subarr/arr_mediainfo.py src/subarr/routers/admin.py tests/test_multilib_walkers.py
+git commit -m "feat(#134): remaining direct media_root joins -> canonical_to_fs"
+```
+
+### Task A4: audio-audit worklist walks all libraries
+
+**Files:**
+- Modify: `src/subarr/app.py:425-452` (`_library_worklist`)
+- Test: `tests/test_multilib_walkers.py`
+
+- [ ] **Step 1: Read the current function**
+
+Read `src/subarr/app.py` lines 415-460 in full before editing — the exact shape (tag_map, mtime collection) must be preserved; only the root iteration changes.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# append to tests/test_multilib_walkers.py
+def test_audio_audit_worklist_spans_all_libraries(two_libraries, subarr_env):
+    import importlib
+    from subarr import app as app_mod
+
+    importlib.reload(app_mod)
+    items = app_mod._library_worklist()  # adjust name/signature to actual
+    canons = [c for (c, *_rest) in items]
+    assert any(c.startswith("@disk2/") for c in canons), canons
+    assert any(not c.startswith("@") for c in canons), canons  # library 0 too
+```
+
+> Adjust the call signature to the real function (read it in Step 1 — it may take args or be a closure; if it's a closure inside lifespan, extract it to a module-level `_build_library_worklist(libraries)` helper as part of this task so it's testable, and have lifespan use the helper).
+
+- [ ] **Step 3: Implement**
+
+Change the single-root walk:
+
+```python
+    root = settings.media_root
+    ...
+    walk = os.walk(root)
+```
+
+to iterate every library root, keeping the per-file logic identical (`fs_to_canonical` already emits `@slug/` heads):
+
+```python
+    for lib in settings.libraries:
+        if not lib.fs_root.is_dir():
+            continue  # unreachable mount: skip, don't abort the audit
+        for dirpath, _dirs, files in os.walk(lib.fs_root):
+            ...  # existing body unchanged — fs_to_canonical handles the head
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/subarr/app.py tests/test_multilib_walkers.py
+git commit -m "feat(#134): audio-audit worklist walks all library roots"
+```
+
+### Task A5: sidecar root guard accepts any library root
+
+**Files:**
+- Modify: `src/subarr/routers/sidecar.py:35-70`
+- Test: `tests/test_multilib_walkers.py`
+
+- [ ] **Step 1: Read `src/subarr/routers/sidecar.py` lines 1-90** to capture `_resolve_under_root`'s exact contract (error type, return) and the line-64/70 default-root usage.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# append to tests/test_multilib_walkers.py
+def test_sidecar_root_guard_accepts_all_library_roots(two_libraries, subarr_env):
+    from subarr.routers import sidecar
+
+    p = two_libraries / "Movies" / "film.mkv"
+    resolved = sidecar._resolve_under_root(str(p))  # must NOT raise
+    assert resolved == p.resolve()
+
+
+def test_sidecar_root_guard_still_rejects_outside(two_libraries, subarr_env, tmp_path):
+    import pytest as _pytest
+    from subarr.routers import sidecar
+
+    with _pytest.raises(Exception):
+        sidecar._resolve_under_root(str(tmp_path / "outside" / "x.srt"))
+```
+
+(Match the actual raise type from Step 1 — likely `HTTPException` or `ValueError`; tighten the assertion accordingly.)
+
+- [ ] **Step 3: Implement**
+
+In `_resolve_under_root`, replace the single-root containment check:
+
+```python
+    root = settings.media_root.resolve()
+    # <containment check against root>
+```
+
+with an any-library check preserving the original error path:
+
+```python
+    p = Path(path_str).resolve()
+    for lib in settings.libraries:
+        root = lib.fs_root.resolve()
+        try:
+            p.relative_to(root)
+            return p
+        except ValueError:
+            continue
+    # <original outside-root error raise, unchanged>
+```
+
+For lines ~64/70 (default scan root / candidate join): default root stays library 0 (`settings.libraries[0].fs_root` ≡ `media_root`) and the candidate join becomes `canonical_to_fs(candidate)` if the input is canonical — read the function and apply the same pattern as A3.
+
+- [ ] **Step 4: Run sidecar + security suites**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_multilib_walkers.py tests/test_security_hardening.py -q`
+Expected: PASS (outside-root rejection still enforced — security behavior unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/subarr/routers/sidecar.py tests/test_multilib_walkers.py
+git commit -m "feat(#134): sidecar root guard accepts any library root"
+```
+
+### Task A6: PR-A gate — full suite + lint, open PR
+
+- [ ] **Step 1:** `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/ -q --ignore=tests/e2e` → expected: ≥818 passed (background-run it; ~6.5 min).
+- [ ] **Step 2:** `ruff check src/subarr tests; ruff format src/subarr tests` → clean; `bandit -ll -ii --skip B101 -r src/subarr` → clean.
+- [ ] **Step 3:** Push branch `feat/134-phase1-walkers`, open PR titled `feat(#134): Phase 1 slices 3-4 — multi-library walkers + direct-join sweep`, merge on green via `gh pr merge --squash --admin`.
+
+---
+
+# PR-B — slice 5: Libraries API + UI
+
+### Task B1: `routers/libraries.py` — GET/PUT/validate endpoints
+
+**Files:**
+- Create: `src/subarr/routers/libraries.py`
+- Modify: `src/subarr/app.py` (import + `app.include_router(r_libraries.router)` in the router block at :752-783 and the import list at :68)
+- Test: `tests/test_libraries_api.py`
+
+Design (locked):
+- `GET /api/settings/libraries` → full list incl. default (read-only marker), for display.
+- `PUT /api/settings/libraries` → body is the EXTRAS list only (default is env/legacy-managed via existing media_root settings). Server validates via `build_libraries()`, assigns slugs for new entries (slugify of name), preserves incoming slugs (immutability), persists `config_store.save_override("libraries", extras)`, applies live via `object.__setattr__(settings, "libraries", libs)`. Whole-list replace, not per-slug CRUD — simpler, and the UI always has the full list.
+- `POST /api/settings/libraries/validate` → `{fs_root}` → reachability sample (same shape as onboarding probe-paths: ok/samples/total).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_libraries_api.py
+"""#134 slice 5: /api/settings/libraries CRUD + validation."""
+
+from __future__ import annotations
+
+
+def test_get_libraries_lists_default(app_with_stub):
+    r = app_with_stub.get("/api/settings/libraries")
+    assert r.status_code == 200
+    libs = r.json()["libraries"]
+    assert libs[0]["slug"] == ""
+    assert libs[0]["is_default"] is True
+
+
+def test_put_libraries_persists_and_applies(app_with_stub, tmp_path, monkeypatch):
+    import subarr.config_store as cs
+
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(tmp_path / "ov.json"))
+    body = {
+        "libraries": [
+            {"name": "Disk 2", "fs_root": str(tmp_path), "subgen_prefix": "/media2", "arr_prefix": "/data/d2/"}
+        ]
+    }
+    r = app_with_stub.put("/api/settings/libraries", json=body)
+    assert r.status_code == 200
+    out = r.json()["libraries"]
+    assert [lib["slug"] for lib in out] == ["", "disk-2"]
+    # persisted
+    assert cs.load_overrides()["libraries"][0]["slug"] == "disk-2"
+    # applied live
+    from subarr.config import settings
+
+    assert [lib.slug for lib in settings.libraries] == ["", "disk-2"]
+
+
+def test_put_libraries_rejects_duplicate_slug(app_with_stub, tmp_path, monkeypatch):
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(tmp_path / "ov.json"))
+    body = {
+        "libraries": [
+            {"slug": "x", "name": "A", "fs_root": "/a", "arr_prefix": "/data/a/"},
+            {"slug": "x", "name": "B", "fs_root": "/b", "arr_prefix": "/data/b/"},
+        ]
+    }
+    r = app_with_stub.put("/api/settings/libraries", json=body)
+    assert r.status_code == 422
+
+
+def test_validate_library_path(app_with_stub, tmp_path):
+    (tmp_path / "TV").mkdir()
+    r = app_with_stub.post("/api/settings/libraries/validate", json={"fs_root": str(tmp_path)})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    r2 = app_with_stub.post("/api/settings/libraries/validate", json={"fs_root": str(tmp_path / "nope")})
+    assert r2.json()["ok"] is False
+```
+
+- [ ] **Step 2: Run to verify 404 failures**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_libraries_api.py -q`
+Expected: FAIL with 404s (router doesn't exist).
+
+- [ ] **Step 3: Implement the router**
+
+```python
+# src/subarr/routers/libraries.py
+"""#134 slice 5: manage the multi-library list from the UI.
+
+The default library (slug "") mirrors the legacy media_root scalars and is
+managed through the existing settings/env surface — read-only here. PUT
+replaces the EXTRAS list wholesale: validated via build_libraries (the same
+gate config.load() uses), persisted to the config_store "libraries" key, and
+applied to the running frozen Settings via object.__setattr__ (the
+established live-reload pattern)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from .. import config_store
+from ..config import settings
+from ..libraries import Library, LibraryConfigError, build_libraries, slugify
+
+router = APIRouter(prefix="/api/settings", tags=["libraries"])
+
+
+class LibraryIn(BaseModel):
+    slug: str | None = None  # present = existing entry (immutable); absent = new
+    name: str
+    fs_root: str
+    subgen_prefix: str | None = None
+    arr_prefix: str
+
+
+class LibrariesPut(BaseModel):
+    libraries: list[LibraryIn]
+
+
+class ValidateRequest(BaseModel):
+    fs_root: str
+
+
+def _serialize(lib: Library, *, is_default: bool) -> dict:
+    return {
+        "slug": lib.slug,
+        "name": lib.name,
+        "fs_root": str(lib.fs_root),
+        "subgen_prefix": lib.subgen_prefix,
+        "arr_prefix": lib.arr_prefix,
+        "is_default": is_default,
+        "reachable": lib.fs_root.is_dir(),
+    }
+
+
+@router.get("/libraries")
+async def get_libraries() -> dict:
+    libs = settings.libraries
+    return {"libraries": [_serialize(lib, is_default=(i == 0)) for i, lib in enumerate(libs)]}
+
+
+@router.put("/libraries")
+async def put_libraries(body: LibrariesPut) -> dict:
+    extras: list[dict] = []
+    for item in body.libraries:
+        d = {
+            "slug": (item.slug or "").strip() or slugify(item.name),
+            "name": item.name,
+            "fs_root": item.fs_root,
+            "arr_prefix": item.arr_prefix,
+        }
+        if item.subgen_prefix:
+            d["subgen_prefix"] = item.subgen_prefix
+        extras.append(d)
+
+    default = settings.libraries[0]
+    try:
+        libs = build_libraries(default, extras)
+    except LibraryConfigError as e:
+        raise HTTPException(422, detail=str(e))
+
+    config_store.save_override("libraries", extras)
+    object.__setattr__(settings, "libraries", libs)
+    return {"libraries": [_serialize(lib, is_default=(i == 0)) for i, lib in enumerate(libs)]}
+
+
+@router.post("/libraries/validate")
+async def validate_library(body: ValidateRequest) -> dict:
+    p = Path(body.fs_root)
+    if not p.is_dir():
+        return {"ok": False, "error": "not a directory or not reachable", "samples": [], "total": 0}
+    try:
+        entries = sorted(p.iterdir(), key=lambda e: e.name.lower())
+    except OSError as e:
+        return {"ok": False, "error": f"unreadable: {e}", "samples": [], "total": 0}
+    samples = [("📁 " + e.name + "/") if e.is_dir() else ("📄 " + e.name) for e in entries[:5]]
+    return {"ok": True, "error": None, "samples": samples, "total": len(entries)}
+```
+
+Register in `app.py`: add `libraries as r_libraries,` to the `from .routers import (...)` block (line ~68, alphabetical) and `app.include_router(r_libraries.router)` in the include block (line ~752-783).
+
+Also add `libraries` to the conftest `subarr_env` reload list (the routers group) so tests get fresh module state.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `$env:PYTHONPATH="C:\Projects\subarr\src"; python -m pytest tests/test_libraries_api.py tests/test_config_libraries.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/subarr/routers/libraries.py src/subarr/app.py tests/test_libraries_api.py tests/conftest.py
+git commit -m "feat(#134): /api/settings/libraries GET/PUT/validate"
+```
+
+### Task B2: shared `libraries-editor.jsx` component
+
+**Files:**
+- Create: `src/subarr/static/v1/home-hifi/libraries-editor.jsx`
+
+A self-contained component (own module — NOT chrome.jsx, so only the two importing bundles rebuild). Uses the page-global `React` (repo convention — check how settings.jsx accesses React and match it).
+
+- [ ] **Step 1: Implement the component**
+
+```jsx
+// src/subarr/static/v1/home-hifi/libraries-editor.jsx
+// #134 slice 5: Libraries CRUD shared by Settings and Onboarding.
+// Default library (slug "") is read-only here — it's managed by the legacy
+// media_root settings/env surface. Extras are edited as a full list and
+// saved wholesale via PUT /api/settings/libraries.
+
+const { useState, useEffect } = React;
+
+const Api = {
+  get: () => fetch('/api/settings/libraries').then((r) => r.json()),
+  put: (libraries) =>
+    fetch('/api/settings/libraries', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ libraries }),
+    }).then(async (r) => ({ ok: r.ok, body: await r.json() })),
+  validate: (fs_root) =>
+    fetch('/api/settings/libraries/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fs_root }),
+    }).then((r) => r.json()),
+  rootFolders: () => fetch('/api/onboarding/root-folders').then((r) => r.json()),
+};
+
+const EMPTY_DRAFT = { slug: null, name: '', fs_root: '', subgen_prefix: '', arr_prefix: '' };
+
+export function LibrariesEditor({ showDetected = false }) {
+  const [libs, setLibs] = useState(null); // server truth (incl. default)
+  const [extras, setExtras] = useState([]); // editable rows (non-default)
+  const [draft, setDraft] = useState(null); // add/edit form, EMPTY_DRAFT shape
+  const [checks, setChecks] = useState({}); // fs_root -> validate result
+  const [detected, setDetected] = useState(null); // root-folders payload
+  const [msg, setMsg] = useState(null);
+
+  const reload = () =>
+    Api.get().then((d) => {
+      setLibs(d.libraries);
+      setExtras(d.libraries.filter((l) => !l.is_default));
+    });
+
+  useEffect(() => {
+    reload();
+    if (showDetected) Api.rootFolders().then(setDetected).catch(() => {});
+  }, []);
+
+  const save = async (nextExtras) => {
+    setMsg(null);
+    const res = await Api.put(
+      nextExtras.map(({ slug, name, fs_root, subgen_prefix, arr_prefix }) => ({
+        slug: slug || null,
+        name,
+        fs_root,
+        subgen_prefix: subgen_prefix || null,
+        arr_prefix,
+      })),
+    );
+    if (!res.ok) {
+      setMsg({ kind: 'err', text: res.body.detail || 'save failed' });
+      return false;
+    }
+    setLibs(res.body.libraries);
+    setExtras(res.body.libraries.filter((l) => !l.is_default));
+    setMsg({ kind: 'ok', text: 'Libraries saved' });
+    return true;
+  };
+
+  const check = async (fs_root) => {
+    const r = await Api.validate(fs_root);
+    setChecks((c) => ({ ...c, [fs_root]: r }));
+    return r;
+  };
+
+  const removeLib = (slug) => save(extras.filter((l) => l.slug !== slug));
+
+  const submitDraft = async () => {
+    if (!draft.name || !draft.fs_root || !draft.arr_prefix) {
+      setMsg({ kind: 'err', text: 'name, filesystem root and *arr prefix are required' });
+      return;
+    }
+    const next = draft.slug
+      ? extras.map((l) => (l.slug === draft.slug ? draft : l))
+      : [...extras, draft];
+    if (await save(next)) setDraft(null);
+  };
+
+  // Detected *arr root folders not already covered by a configured arr_prefix.
+  const uncovered = [];
+  if (detected && libs) {
+    const prefixes = libs.map((l) => l.arr_prefix).filter(Boolean);
+    for (const svc of ['sonarr', 'radarr']) {
+      for (const f of detected[svc]?.folders || []) {
+        if (!prefixes.some((p) => f.path.startsWith(p.replace(/\/$/, '')))) {
+          uncovered.push({ service: svc, ...f });
+        }
+      }
+    }
+  }
+
+  if (!libs) return <div style={{ opacity: 0.6 }}>Loading libraries…</div>;
+
+  const row = { display: 'flex', gap: 8, alignItems: 'center', padding: '6px 0' };
+  const mono = { fontFamily: 'monospace', fontSize: 12, opacity: 0.85 };
+  const btn = { cursor: 'pointer', padding: '4px 10px', borderRadius: 6 };
+
+  return (
+    <div>
+      {libs.map((l) => (
+        <div key={l.slug || '(default)'} style={row}>
+          <span style={{ minWidth: 90, fontWeight: 600 }}>{l.is_default ? 'default' : l.name}</span>
+          <span style={mono}>{l.fs_root}</span>
+          <span style={mono}>arr: {l.arr_prefix}</span>
+          <span style={mono}>subgen: {l.subgen_prefix}</span>
+          <span style={{ color: l.reachable ? '#3fb950' : '#f85149', fontSize: 12 }}>
+            {l.reachable ? '● reachable' : '● unreachable'}
+          </span>
+          {!l.is_default && (
+            <>
+              <button style={btn} onClick={() => setDraft({ ...EMPTY_DRAFT, ...l })}>Edit</button>
+              <button style={btn} onClick={() => removeLib(l.slug)}>Remove</button>
+            </>
+          )}
+          {l.is_default && (
+            <span style={{ fontSize: 11, opacity: 0.55 }}>managed by media-root settings</span>
+          )}
+        </div>
+      ))}
+
+      {showDetected && uncovered.length > 0 && (
+        <div style={{ margin: '10px 0', padding: 10, borderRadius: 8, background: 'rgba(88,166,255,.08)' }}>
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>
+            Detected *arr root folders not covered by any library:
+          </div>
+          {uncovered.map((f) => (
+            <div key={f.service + f.path} style={row}>
+              <span style={mono}>[{f.service}] {f.path}</span>
+              <button
+                style={btn}
+                onClick={() =>
+                  setDraft({
+                    ...EMPTY_DRAFT,
+                    name: f.path.split('/').filter(Boolean).pop() || 'library',
+                    arr_prefix: f.path.endsWith('/') ? f.path : f.path + '/',
+                  })
+                }
+              >
+                Add as library…
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {draft ? (
+        <div style={{ marginTop: 10, padding: 10, borderRadius: 8, background: 'rgba(255,255,255,.04)' }}>
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>{draft.slug ? `Edit ${draft.name}` : 'Add library'}</div>
+          {[
+            ['name', 'Name', 'e.g. 4K Movies'],
+            ['fs_root', 'Filesystem root (subarr view)', '/media/disk2'],
+            ['arr_prefix', '*arr path prefix', '/data/disk2/'],
+            ['subgen_prefix', 'subgen prefix (blank = same as default)', '/media2'],
+          ].map(([k, label, ph]) => (
+            <div key={k} style={{ marginBottom: 6 }}>
+              <div style={{ fontSize: 12, opacity: 0.7 }}>{label}</div>
+              <input
+                style={{ width: '100%', fontFamily: 'monospace' }}
+                value={draft[k] || ''}
+                placeholder={ph}
+                onChange={(e) => setDraft({ ...draft, [k]: e.target.value })}
+              />
+            </div>
+          ))}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button style={btn} onClick={() => check(draft.fs_root)}>Test path</button>
+            <button style={btn} onClick={submitDraft}>Save</button>
+            <button style={btn} onClick={() => setDraft(null)}>Cancel</button>
+          </div>
+          {checks[draft.fs_root] && (
+            <div style={{ marginTop: 6, fontSize: 12, color: checks[draft.fs_root].ok ? '#3fb950' : '#f85149' }}>
+              {checks[draft.fs_root].ok
+                ? `OK — ${checks[draft.fs_root].total} entries (${checks[draft.fs_root].samples.join(', ')})`
+                : checks[draft.fs_root].error}
+            </div>
+          )}
+        </div>
+      ) : (
+        <button style={{ ...btn, marginTop: 8 }} onClick={() => setDraft({ ...EMPTY_DRAFT })}>
+          + Add library
+        </button>
+      )}
+
+      {msg && (
+        <div style={{ marginTop: 8, fontSize: 12, color: msg.kind === 'ok' ? '#3fb950' : '#f85149' }}>{msg.text}</div>
+      )}
+    </div>
+  );
+}
+```
+
+> Style note: before committing, eyeball settings.jsx's existing inline-style idioms (colors come from its theme constants if present) and align — match the file's conventions over the placeholder hexes above.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/subarr/static/v1/home-hifi/libraries-editor.jsx
+git commit -m "feat(#134): LibrariesEditor shared component"
+```
+
+### Task B3: mount in Settings + onboarding, reword stale hint
+
+**Files:**
+- Modify: `src/subarr/static/v1/home-hifi/settings.jsx` (rail + detail panel)
+- Modify: `src/subarr/static/v1/home-hifi/onboarding.jsx` (paths step)
+- Modify: `src/subarr/static/v1/home-hifi/coverage.jsx:1773`
+
+- [ ] **Step 1: Settings rail + panel**
+
+In settings.jsx: `import { LibrariesEditor } from './libraries-editor.jsx';` at top (match existing relative-import style). In `buildRailItems` (~line 839-912), add to the "subarr" section list a `{ id: 'libraries', label: 'Libraries' }` item (alongside Providers/Language rules/System actions). In the detail-panel switch that renders the selected rail item, add the case:
+
+```jsx
+{selected === 'libraries' && (
+  <div>
+    <h2>Libraries</h2>
+    <p style={{ opacity: 0.7, fontSize: 13 }}>
+      Each library is one media location: a filesystem root (subarr's view), the
+      prefix subgen sees it at, and the path prefix Sonarr/Radarr report. The
+      default library comes from SUBARR_MEDIA_ROOT.
+    </p>
+    <LibrariesEditor showDetected={true} />
+  </div>
+)}
+```
+
+(Adapt to the file's actual render structure — read the Providers section as the template.)
+
+- [ ] **Step 2: Onboarding paths step**
+
+In onboarding.jsx, in the `paths` step component (after the existing media_root + probe UI), add a collapsed-by-default section:
+
+```jsx
+<details style={{ marginTop: 14 }}>
+  <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
+    Multiple media locations? Add more libraries (optional)
+  </summary>
+  <div style={{ marginTop: 8 }}>
+    <LibrariesEditor showDetected={true} />
+  </div>
+</details>
+```
+
+with the same import added at top. (The editor saves directly via PUT — no wizard-progress plumbing needed; libraries have no env backing so the clobber guard doesn't apply.)
+
+- [ ] **Step 3: coverage.jsx stale hint (line ~1773)**
+
+Replace:
+
+```
+ARR_PATH_PREFIX / SONARR_PATH_PREFIX in Settings.
+```
+
+with:
+
+```
+ARR_PATH_PREFIX or the library's *arr prefix in Settings → Libraries.
+```
+
+- [ ] **Step 4: Build bundles + verify drift-clean**
+
+Run: `cd C:\Projects\subarr; npm run build:frontend`
+Expected: builds clean. Only `settings.bundle.js`, `onboarding.bundle.js`, `coverage.bundle.js` (+ their .map files) change — verify with `git status`; if other bundles changed, STOP and find out why before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/subarr/static/v1/home-hifi/settings.jsx src/subarr/static/v1/home-hifi/onboarding.jsx src/subarr/static/v1/home-hifi/coverage.jsx src/subarr/static/v1/home-hifi/*.bundle.js src/subarr/static/v1/home-hifi/*.bundle.js.map
+git commit -m "feat(#134): Libraries UI in Settings + onboarding; reword stale prefix hint"
+```
+
+### Task B4: PR-B gate — suite, lint, deploy-check on :9923, open PR
+
+- [ ] **Step 1:** Full suite + ruff + bandit (same commands as A6) → green.
+- [ ] **Step 2:** Deploy-check on :9923 (subarr-next bind-mounts the main worktree): `wsl -e bash -lc "docker restart subarr-next"`, then open `http://localhost:9923/settings` → Libraries section renders, Add library → Test path → Save round-trips; onboarding page (if accessible post-complete, use the Settings surface as primary verification). **Test on 9923, never 9922.**
+- [ ] **Step 3:** Push `feat/134-phase1-ui`, open PR `feat(#134): Phase 1 slice 5 — Libraries management UI`, merge on green (`gh pr merge --squash --admin`).
+
+---
+
+# PR-C — slice 6: live-DB verification + docs
+
+Procedural; no new code expected. Branch only if doc changes warrant it.
+
+### Task C1: live-DB + e2e verification on :9923
+
+- [ ] **Step 1:** Snapshot the live dev DB: copy subarr-next's DB file to a scratch path (locate via the container's `SUBARR_DB_PATH`; `wsl -e bash -lc "docker exec subarr-next printenv SUBARR_DB_PATH"`).
+- [ ] **Step 2:** Record pre-refactor coverage counts from the running instance: `GET /api/coverage` summary totals (rows, gaps, verified) — save the JSON.
+- [ ] **Step 3:** Restart subarr-next on current main; confirm boot clean (`docker logs subarr-next --tail 50`), coverage rebuild completes, and counts match Step 2 (±in-flight churn). Single-library legacy behavior: canonicals in `/api/coverage` responses carry NO `@` heads.
+- [ ] **Step 4:** Multi-library smoke: via Settings → Libraries add a second library pointing at a real second directory (any small folder with one video file works); run a probe walk of `@<slug>/`; confirm the file appears with the `@slug/` canonical in probe results, coverage includes it, and queueing it forms the right subgen path (`canonical_to_subgen_batch` per-library prefix). Then remove the test library.
+- [ ] **Step 5:** Confirm the 6 canonical-keyed tables needed no backfill: `sqlite3 <db> "SELECT COUNT(*) FROM media_probe WHERE canonical_path LIKE '@%'"` → 0 for a legacy DB (and >0 only after the multi-lib smoke if its rows were kept).
+
+### Task C2: docs
+
+- [ ] **Step 1:** README: add a "Multiple media locations" section — the libraries model, Settings → Libraries screenshot-level description, compose example with two disjoint mounts on subarr AND subgen (mirroring prefixes), the note that the default library == `SUBARR_MEDIA_ROOT` and extra libraries live in the UI (no env).
+- [ ] **Step 2:** Update issue #134 with the completion comment + close criteria check; move board item to Done when all three PRs are merged and C1 passes.
+
+---
+
+## Self-Review
+
+1. **Spec coverage:** slice 3 (walkers) → A1/A2/A4 + scheduler verified-no-change; slice 4 (sweep) → recon verdict (all opaque-safe) + A3/A5 direct joins + tests; slice 5 → B1 (API+persistence+live-apply), B2/B3 (Settings + onboarding + manual Add library — explicit user requirement — + detected-root suggestions + stale hint); slice 6 → C1/C2. Acceptance criteria from the handoff: multi-lib e2e on :9923 = C1.4; single-library byte-identity = A-task regression suites + C1.3; live-DB loads with matching counts = C1.2-3; dead-config removal already shipped in PR #184.
+2. **Placeholder scan:** A2/A4/A5 carry explicit "read the function first, match the real name/signature" steps where recon couldn't pin exact shapes — these are verification steps, not deferred work; all other steps have complete code.
+3. **Type consistency:** `LibraryIn`/`LibrariesPut`/`ValidateRequest` match `build_libraries`' extras dict contract (slug/name/fs_root/arr_prefix/subgen_prefix); `_serialize` output matches what `LibrariesEditor` consumes (`slug,name,fs_root,subgen_prefix,arr_prefix,is_default,reachable`); editor PUT body matches `LibrariesPut`.
+
+## Process
+
+- Three branches/PRs in order: `feat/134-phase1-walkers` → `feat/134-phase1-ui` → (C usually rides docs on main or a small PR). Each merged via `gh pr merge --squash --admin` on green (5 required gates; trivy base-CVE pattern applies across open PRs).
+- Frontend: rebuild bundles after any JSX edit; commit only changed bundles; never hand-merge bundle conflicts.
+- Board #6: #134 stays In Progress until C1 passes, then Done.

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -187,6 +187,44 @@ def _arena_audio_tracks(app_, media_path):
     return out
 
 
+def _walk_all_library_files():
+    """#134: enumerate every video file across ALL library roots for the
+    audio-audit deep scan. Yields (canonical, mtime|None); canonicals carry
+    @slug/ heads for non-default libraries (fs_to_canonical). Unreachable
+    roots are skipped, never abort the audit."""
+    import os
+    from pathlib import Path as _P
+
+    from .paths import VIDEO_EXTS, fs_to_canonical
+
+    seen: set[str] = set()
+    for lib in settings.libraries:
+        try:
+            if not lib.fs_root.is_dir():
+                continue
+            walk = os.walk(lib.fs_root)
+        except Exception:
+            continue
+        for dirpath, _dirs, files in walk:
+            for fn in files:
+                dot = fn.rfind(".")
+                if dot < 0 or fn[dot:].lower() not in VIDEO_EXTS:
+                    continue
+                fp = os.path.join(dirpath, fn)
+                try:
+                    c = fs_to_canonical(_P(fp))
+                except Exception:
+                    continue
+                if c in seen:
+                    continue
+                seen.add(c)
+                try:
+                    mt = os.stat(fp).st_mtime
+                except OSError:
+                    mt = None
+                yield (c, mt)
+
+
 @asynccontextmanager
 async def lifespan(app_: FastAPI):
     # Schema migrations run BEFORE any store touches the DB. After they
@@ -416,41 +454,12 @@ async def lifespan(app_: FastAPI):
         return out
 
     def _library_worklist():
-        # Opt-in deep scan: every video file under the media root, not just the
-        # tracked set. Tags come from coverage where known (else None → bilingual/
-        # multitrack still detected, mislabel needs a tag to disagree with).
-        import os
-        from .paths import VIDEO_EXTS, fs_to_canonical
-
-        root = settings.media_root
+        # Opt-in deep scan: every video file across ALL library roots (#134),
+        # not just the tracked set. Tags come from coverage where known (else
+        # None → bilingual/multitrack still detected, mislabel needs a tag to
+        # disagree with).
         tag_map = _coverage_tag_map()
-        out = []
-        seen = set()
-        try:
-            walk = os.walk(root)
-        except Exception:
-            return []
-        for dirpath, _dirs, files in walk:
-            for fn in files:
-                dot = fn.rfind(".")
-                if dot < 0 or fn[dot:].lower() not in VIDEO_EXTS:
-                    continue
-                fp = os.path.join(dirpath, fn)
-                try:
-                    from pathlib import Path as _P
-
-                    c = fs_to_canonical(_P(fp))
-                except Exception:
-                    continue
-                if c in seen:
-                    continue
-                seen.add(c)
-                try:
-                    mt = os.stat(fp).st_mtime
-                except OSError:
-                    mt = None
-                out.append((c, tag_map.get(c), mt))
-        return out
+        return [(c, tag_map.get(c), mt) for c, mt in _walk_all_library_files()]
 
     def _audit_worklist(scope: str = "coverage"):
         return _library_worklist() if scope == "library" else _coverage_worklist()

--- a/src/subarr/arr_mediainfo.py
+++ b/src/subarr/arr_mediainfo.py
@@ -42,11 +42,9 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-from pathlib import Path
 
-from .config import settings
 from .coverage_engine import IntegrationBundle
-from .paths import strip_arr_prefix
+from .paths import PathOutsideRootError, canonical_to_fs, strip_arr_prefix
 from .media_probe import AudioStream, ProbeResult, SubtitleStream
 from .probe_store import ProbeStore
 
@@ -167,13 +165,14 @@ class ArrMediainfoSync:
         # Cache-key inputs: stat the file IF visible on our mount; if not,
         # use arr's `size` + 0.0 mtime fallback so we still surface the data
         # (won't auto-invalidate when the file changes — next ffprobe walk
-        # will, which is the source-of-truth path anyway).
-        subarr_path = settings.media_root / Path(canonical)
+        # will, which is the source-of-truth path anyway). #134: resolve via
+        # the library-aware layer; an unresolvable canonical takes the same
+        # fallback as an invisible mount.
         try:
-            st = subarr_path.stat()
+            st = canonical_to_fs(canonical).stat()
             mtime = st.st_mtime
             size = st.st_size
-        except OSError:
+        except (OSError, PathOutsideRootError):
             mtime = 0.0
             size = int(row.get("size") or 0)
 

--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from .aftercare import evaluate_subtitle
 from .integrations import IntegrationError
+from .paths import PathOutsideRootError, canonical_to_fs
 from .integrations.bazarr import BazarrClient
 from .integrations.plex import PlexClient
 from .provenance import ProvenanceStore
@@ -330,9 +331,12 @@ class CompletionWatcher:
             return
         if not self._plex.is_configured():
             return
-        from pathlib import Path
-
-        subarr_full = str(_settings.media_root / Path(video_canonical))
+        try:
+            # #134: library-aware resolve (@slug/ heads).
+            subarr_full = str(canonical_to_fs(video_canonical))
+        except PathOutsideRootError:
+            log.warning("plex partial-scan skipped: unresolvable canonical %s", video_canonical)
+            return
         try:
             result = await self._plex.partial_scan(subarr_full)
             log.info(
@@ -372,14 +376,12 @@ class CompletionWatcher:
         """Locate the .srt subgen wrote next to the video. Subgen's default
         naming is <basename>.en.srt; fall back to any .srt sharing the
         basename if the language tag differs."""
-        from pathlib import Path
-        from .config import settings
-
-        full = settings.media_root / Path(video_canonical)
         try:
+            # #134: library-aware resolve (@slug/ heads).
+            full = canonical_to_fs(video_canonical)
             if not full.exists():
                 return None
-        except OSError:
+        except (OSError, PathOutsideRootError):
             return None
         stem = full.stem
         parent = full.parent

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import settings
-from .paths import UNSUPPORTED_EXTS, strip_arr_prefix
+from .paths import UNSUPPORTED_EXTS, canonical_to_fs, strip_arr_prefix
 from .integrations import IntegrationError
 from .integrations.bazarr import BazarrClient
 from .integrations.radarr import RadarrClient
@@ -272,7 +272,10 @@ def _scan_for_srt(canonical_dir: str) -> tuple[bool, list[str]]:
     if not canonical_dir:
         return False, []
     try:
-        full = settings.media_root / Path(canonical_dir)
+        # #134: library-aware resolve (@slug/ heads). PathOutsideRootError is
+        # a ValueError subclass, so unknown libraries fall into the existing
+        # benign-empty handling below.
+        full = canonical_to_fs(canonical_dir)
         if not full.is_dir():
             return False, []
         srts = sorted(p.name for p in full.iterdir() if p.is_file() and p.suffix.lower() == ".srt")
@@ -292,7 +295,8 @@ def _scan_for_srt_recursive(canonical_dir: str) -> list[str]:
     if not canonical_dir:
         return []
     try:
-        full = settings.media_root / Path(canonical_dir)
+        # #134: library-aware resolve — see _scan_for_srt.
+        full = canonical_to_fs(canonical_dir)
         if not full.is_dir():
             return []
         return sorted(str(p.relative_to(full)) for p in full.rglob("*.srt") if p.is_file())

--- a/src/subarr/probe_walker.py
+++ b/src/subarr/probe_walker.py
@@ -18,7 +18,6 @@ import uuid
 from pathlib import Path
 from typing import Any, AsyncIterator
 
-from .config import settings
 from .media_probe import ProbeError, probe
 from .paths import VIDEO_EXTS, PathOutsideRootError, canonical_to_fs, fs_to_canonical
 from .probe_store import ProbeStore
@@ -129,7 +128,16 @@ class ProbeWalker:
 
     async def _run(self, state: WalkState) -> None:
         try:
-            root_fs = settings.media_root / state.root
+            # #134: resolve via the library-aware path layer — state.root is a
+            # canonical and may carry an @<slug>/ head selecting a non-default
+            # library root.
+            try:
+                root_fs = canonical_to_fs(state.root)
+            except PathOutsideRootError:
+                state.status = "error"
+                state.errors.append({"error": f"invalid root: {state.root}"})
+                state.finished_at = time.time()
+                return
             if not root_fs.exists() or not root_fs.is_dir():
                 state.status = "error"
                 state.errors.append({"error": f"root not found: {state.root}"})

--- a/src/subarr/routers/admin.py
+++ b/src/subarr/routers/admin.py
@@ -7,7 +7,6 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from ..config import settings
 from ..docker_client import DockerUnavailable
 from ..integrations import IntegrationError
 
@@ -71,12 +70,12 @@ async def plex_partial_scan(req: PartialScanRequest, request: Request) -> dict:
     plex = request.app.state.integrations.plex
     if not plex.is_configured():
         raise HTTPException(503, detail="Plex not configured (PLEX_URL/PLEX_TOKEN)")
-    from pathlib import Path
-
     p = req.path
-    # Treat anything that isn't absolute as canonical-relative-to-media_root.
+    # Treat anything that isn't absolute as a canonical (library-aware, #134).
     if not p.startswith("/"):
-        p = str(settings.media_root / Path(p))
+        from ..paths import canonical_to_fs
+
+        p = str(canonical_to_fs(p))
     try:
         return await plex.partial_scan(p)
     except IntegrationError as e:

--- a/src/subarr/routers/sidecar.py
+++ b/src/subarr/routers/sidecar.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from ..config import settings
+from ..paths import PathOutsideRootError, canonical_to_fs
 from ..sidecar_scanner import apply_rename, scan
 
 router = APIRouter(prefix="/api", tags=["sidecar"])
@@ -32,17 +33,19 @@ log = logging.getLogger(__name__)
 
 
 def _resolve_under_root(path_str: str) -> Path:
-    """Resolve a user-supplied path and verify it sits inside the media root.
+    """Resolve a user-supplied path and verify it sits inside ANY configured
+    library root (#134 — was: the single media root).
 
     Defence against ../-traversal and absolute-path escape attempts.
     """
     p = Path(path_str).resolve()
-    root = settings.media_root.resolve()
-    try:
-        p.relative_to(root)
-    except ValueError:
-        raise HTTPException(400, detail=f"path escapes media root: {p}")
-    return p
+    for lib in settings.libraries:
+        try:
+            p.relative_to(lib.fs_root.resolve())
+            return p
+        except ValueError:
+            continue
+    raise HTTPException(400, detail=f"path escapes media root: {p}")
 
 
 @router.get("/sidecar/scan")
@@ -63,12 +66,17 @@ def sidecar_scan(
     if root is None:
         scan_root = settings.media_root
     else:
-        # Allow caller to pass either a path relative to media_root OR an
-        # absolute path that resolves under it.
+        # Allow caller to pass either a canonical (library-aware: may carry
+        # an @<slug>/ head, #134) OR an absolute path that resolves under
+        # any library root.
         candidate = Path(root)
         if not candidate.is_absolute():
-            candidate = settings.media_root / candidate
-        scan_root = _resolve_under_root(str(candidate))
+            try:
+                scan_root = canonical_to_fs(root)
+            except PathOutsideRootError:
+                raise HTTPException(400, detail=f"invalid root: {root}")
+        else:
+            scan_root = _resolve_under_root(str(candidate))
     if not scan_root.exists():
         raise HTTPException(404, detail=f"root not found: {scan_root}")
     if loose_threshold < 0.0 or loose_threshold > 1.0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,40 @@ def media_root(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def two_libraries(subarr_env, monkeypatch, tmp_path: Path):
+    """Library 0 = the fixture media_root (empty slug); library 'disk2'
+    rooted at a second tmp dir. Reloads config+paths so settings.libraries
+    reflects both. Returns the disk2 root Path. (#134 Phase 1)"""
+    import json
+
+    d2 = tmp_path / "disk2"
+    (d2 / "Movies").mkdir(parents=True)
+    (d2 / "Movies" / "film.mkv").write_bytes(b"")
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps(
+            {
+                "libraries": [
+                    {
+                        "slug": "disk2",
+                        "name": "Disk 2",
+                        "fs_root": str(d2),
+                        "subgen_prefix": "/media2",
+                        "arr_prefix": "/data/d2/",
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config, paths
+
+    importlib.reload(config)
+    importlib.reload(paths)
+    return d2
+
+
+@pytest.fixture
 def subarr_env(monkeypatch, tmp_path: Path, media_root: Path):
     compose = tmp_path / "compose.yaml"
     _make_compose(compose)

--- a/tests/test_multilib_walkers.py
+++ b/tests/test_multilib_walkers.py
@@ -65,6 +65,19 @@ def test_srt_scan_resolves_in_non_default_library(two_libraries):
     assert coverage_engine._scan_for_srt_recursive("@nope/x") == []
 
 
+def test_audio_audit_walk_spans_all_libraries(two_libraries):
+    """The audio-audit deep-scan worklist must enumerate video files across
+    EVERY library root, emitting @slug/ canonicals for non-default ones."""
+    import importlib
+
+    from subarr import app as app_mod
+
+    importlib.reload(app_mod)
+    canons = [c for c, _mt in app_mod._walk_all_library_files()]
+    assert any(c.startswith("@disk2/") for c in canons), canons
+    assert any(not c.startswith("@") for c in canons), canons  # library 0 too
+
+
 def test_library_canonical_resolves_for_partial_scan(two_libraries):
     """The /api/plex/partial-scan canonical branch (and the completion
     watcher's sidecar lookups) now resolve via canonical_to_fs — a @disk2/

--- a/tests/test_multilib_walkers.py
+++ b/tests/test_multilib_walkers.py
@@ -63,3 +63,13 @@ def test_srt_scan_resolves_in_non_default_library(two_libraries):
     # unknown library -> benign empty (PathOutsideRootError is a ValueError)
     assert coverage_engine._scan_for_srt("@nope/x") == (False, [])
     assert coverage_engine._scan_for_srt_recursive("@nope/x") == []
+
+
+def test_library_canonical_resolves_for_partial_scan(two_libraries):
+    """The /api/plex/partial-scan canonical branch (and the completion
+    watcher's sidecar lookups) now resolve via canonical_to_fs — a @disk2/
+    canonical must land under disk2's root, not media_root."""
+    from subarr.paths import canonical_to_fs
+
+    expected = (two_libraries / "Movies" / "film.mkv").resolve()
+    assert canonical_to_fs("@disk2/Movies/film.mkv") == expected

--- a/tests/test_multilib_walkers.py
+++ b/tests/test_multilib_walkers.py
@@ -48,3 +48,18 @@ def test_probe_walker_unknown_library_errors_cleanly(two_libraries):
 
     state = asyncio.run(run())
     assert state.status == "error"
+
+
+def test_srt_scan_resolves_in_non_default_library(two_libraries):
+    from subarr import coverage_engine
+
+    movies = two_libraries / "Movies"
+    (movies / "film.en.srt").write_text("1\n")
+    has, srts = coverage_engine._scan_for_srt("@disk2/Movies")
+    assert has is True and srts == ["film.en.srt"]
+    # recursive variant too
+    rel = coverage_engine._scan_for_srt_recursive("@disk2/Movies")
+    assert rel == ["film.en.srt"]
+    # unknown library -> benign empty (PathOutsideRootError is a ValueError)
+    assert coverage_engine._scan_for_srt("@nope/x") == (False, [])
+    assert coverage_engine._scan_for_srt_recursive("@nope/x") == []

--- a/tests/test_multilib_walkers.py
+++ b/tests/test_multilib_walkers.py
@@ -1,0 +1,50 @@
+"""#134 Phase 1 slices 3-4: walkers + direct media_root joins are library-aware."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def test_probe_walker_walks_non_default_library(two_libraries):
+    """start_walk('@disk2/Movies') must enumerate files under disk2's root,
+    not media_root, and record canonicals with the @disk2/ head."""
+    from subarr.config import settings
+    from subarr.migrate import run_migrations
+    from subarr.probe_store import ProbeStore
+    from subarr.probe_walker import ProbeWalker
+
+    run_migrations(settings.db_path)
+    store = ProbeStore(settings.db_path)
+    walker = ProbeWalker(store)
+
+    async def run():
+        state = await walker.start_walk("@disk2/Movies")
+        while state.status == "running":
+            await asyncio.sleep(0.05)
+        return state
+
+    state = asyncio.run(run())
+    # The walk must FIND the file (enumeration worked under disk2's root).
+    # ffprobe on the empty stub file fails -> recorded as an error with the
+    # @disk2/ canonical, proving fs_to_canonical emitted the library head.
+    assert state.total_files == 1
+    assert state.status == "done"
+    paths_seen = [e.get("path", "") for e in state.errors]
+    assert any(p.startswith("@disk2/Movies/") for p in paths_seen)
+
+
+def test_probe_walker_unknown_library_errors_cleanly(two_libraries):
+    from subarr.config import settings
+    from subarr.probe_store import ProbeStore
+    from subarr.probe_walker import ProbeWalker
+
+    walker = ProbeWalker(ProbeStore(settings.db_path))
+
+    async def run():
+        state = await walker.start_walk("@nope/x")
+        while state.status == "running":
+            await asyncio.sleep(0.05)
+        return state
+
+    state = asyncio.run(run())
+    assert state.status == "error"

--- a/tests/test_multilib_walkers.py
+++ b/tests/test_multilib_walkers.py
@@ -78,6 +78,30 @@ def test_audio_audit_walk_spans_all_libraries(two_libraries):
     assert any(not c.startswith("@") for c in canons), canons  # library 0 too
 
 
+def test_sidecar_root_guard_accepts_all_library_roots(two_libraries):
+    import importlib
+
+    from subarr.routers import sidecar
+
+    importlib.reload(sidecar)
+    p = two_libraries / "Movies" / "film.mkv"
+    resolved = sidecar._resolve_under_root(str(p))  # must NOT raise
+    assert resolved == p.resolve()
+
+
+def test_sidecar_root_guard_still_rejects_outside(two_libraries, tmp_path):
+    import importlib
+
+    import pytest
+    from fastapi import HTTPException
+
+    from subarr.routers import sidecar
+
+    importlib.reload(sidecar)
+    with pytest.raises(HTTPException):
+        sidecar._resolve_under_root(str(tmp_path / "outside" / "x.srt"))
+
+
 def test_library_canonical_resolves_for_partial_scan(two_libraries):
     """The /api/plex/partial-scan canonical branch (and the completion
     watcher's sidecar lookups) now resolve via canonical_to_fs — a @disk2/

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,9 +8,6 @@ scan from the GUI caught it. These tests pin the contract.
 
 from __future__ import annotations
 
-import importlib
-import json
-
 import pytest
 
 
@@ -62,38 +59,6 @@ def test_canonical_to_subgen_batch_handles_unicode(subarr_env):
         canonical_to_subgen_batch("TV/Cette nuit-là/Season 1/ep.mkv")
         == "/media/TV/Cette nuit-là/Season 1/ep.mkv"
     )
-
-
-@pytest.fixture
-def two_libraries(subarr_env, monkeypatch, tmp_path):
-    """Library 0 = the fixture media_root (empty slug); library 'disk2'
-    rooted at a second tmp dir. Reloads config+paths so settings.libraries
-    reflects both."""
-    d2 = tmp_path / "disk2"
-    (d2 / "Movies").mkdir(parents=True)
-    (d2 / "Movies" / "film.mkv").write_bytes(b"")
-    store = tmp_path / "ov.json"
-    store.write_text(
-        json.dumps(
-            {
-                "libraries": [
-                    {
-                        "slug": "disk2",
-                        "name": "Disk 2",
-                        "fs_root": str(d2),
-                        "subgen_prefix": "/media2",
-                        "arr_prefix": "/data/d2/",
-                    }
-                ]
-            }
-        )
-    )
-    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
-    from subarr import config, paths
-
-    importlib.reload(config)
-    importlib.reload(paths)
-    return d2
 
 
 def test_canonical_to_fs_default_library(subarr_env):


### PR DESCRIPTION
## Summary

Slices 3–4 of #134 Phase 1, on top of the merged foundation (#184). Recon verified all 19 canonical-consumer files treat keys as opaque (zero `.split("/")` parsing, frontend included; #58 subgen invariant holds) — so this PR is the complete remaining backend work: the 9 direct `settings.media_root / <canonical>` joins become `canonical_to_fs()`, and the two filesystem walkers iterate all library roots.

- **probe_walker**: root walks resolve via `canonical_to_fs` (`@slug/` roots walk the right library; invalid roots error cleanly).
- **coverage_engine**: `_scan_for_srt` / `_scan_for_srt_recursive` library-aware (PathOutsideRootError folds into the existing benign-empty ValueError handling).
- **completion_watcher**: Plex partial-scan path + aftercare sidecar finder library-aware with benign fallbacks.
- **arr_mediainfo**: stat path library-aware; unresolvable canonicals take the existing invisible-mount fallback.
- **admin**: `/api/plex/partial-scan` canonical branch library-aware.
- **app**: audio-audit deep scan extracted to module-level `_walk_all_library_files()`, iterating every library root (unreachable roots skipped).
- **sidecar**: `_resolve_under_root` accepts any library root; scan root accepts `@slug/` canonicals. Escape rejection unchanged (security suite green).

Single-library behavior is byte-identical (`canonical_to_fs(x)` ≡ `media_root / x` with one library — pinned by the foundation tests).

Scheduler needs no change: probe_roots are canonicals, `@slug/` roots flow through; empty = no probe step (documented).

## Test Plan
- [x] New `tests/test_multilib_walkers.py` (7 tests): @disk2 walk enumeration + canonical heads, unknown-library error, srt scans in non-default library, audit worklist spans libraries, sidecar guard accepts all roots / still rejects outside.
- [x] `two_libraries` fixture promoted to conftest.
- [x] Full backend suite: **825 passed, 1 skipped**. ruff + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)