### PR TITLE
fix(#167): hold degraded coverage builds instead of clobbering the warm snapshot

### DIFF
--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -49,6 +49,30 @@ log = logging.getLogger(__name__)
 # 5-min refresh cadence.
 _EAGER_PROBE_CAP = 400
 
+# #167: publish gate. A build whose CRITICAL source failed (configured but
+# errored) while the cached snapshot had it healthy is a degraded build —
+# build_coverage degrades integration failures to empty data (best-effort by
+# design), which yields a structurally-valid snapshot where every row is
+# unprobed (no series paths) and the Sonarr-derived synthetic rows vanish.
+# Publishing that clobbers a good warm snapshot for ~10 minutes after a
+# stack restart. Held builds keep serving the warm snapshot; the cap stops
+# a genuinely-down integration from pinning a stale snapshot forever.
+_CRITICAL_SOURCES = ("bazarr", "sonarr", "radarr")
+_MAX_CONSECUTIVE_HOLDS = 3
+
+
+def degraded_sources(new_sources: dict | None, cached_sources: dict | None) -> list[str]:
+    """Critical sources that FAILED in the new build (configured + ok:false)
+    but were healthy in the cached snapshot's build. configured:false is not
+    a failure — an intentionally unwired integration never degrades a build."""
+    out: list[str] = []
+    for name in _CRITICAL_SOURCES:
+        n = (new_sources or {}).get(name) or {}
+        c = (cached_sources or {}).get(name) or {}
+        if n.get("configured") and not n.get("ok") and c.get("ok"):
+            out.append(name)
+    return out
+
 
 def eager_probe_targets(items: list[dict[str, Any]], cap: int = _EAGER_PROBE_CAP) -> list[str]:
     """Canonical paths of rows the probe-gate is hiding because they're
@@ -148,6 +172,8 @@ class CoverageCache:
         self._pending_args: tuple | None = None  # args for the follow-up
         self._refresh_task: asyncio.Task | None = None
         self._debounce_handle: asyncio.TimerHandle | None = None
+        # #167: consecutive degraded-build holds (see degraded_sources).
+        self._consecutive_holds = 0
 
     # ─── #104: debounce / coalesce ──────────────────────────────────
     @property
@@ -355,6 +381,27 @@ class CoverageCache:
                 )
                 body = report.to_dict()
                 duration = time.time() - started
+
+                # #167 publish gate: a build whose critical source newly
+                # failed is degraded (all-unprobed rows, vanished synthetic
+                # rows) — hold it and keep serving the warm snapshot instead
+                # of clobbering it. Cap consecutive holds so a genuinely-down
+                # integration still publishes (and surfaces) eventually.
+                cached = self._cached
+                held = degraded_sources(body["sources"], cached.sources if cached else None)
+                if held and cached is not None and self._consecutive_holds < _MAX_CONSECUTIVE_HOLDS:
+                    self._consecutive_holds += 1
+                    log.warning(
+                        "coverage build HELD, not published (#167): %s failed while the "
+                        "cached snapshot has them healthy (hold %d/%d) — serving the warm "
+                        "snapshot; will retry next refresh",
+                        ", ".join(held),
+                        self._consecutive_holds,
+                        _MAX_CONSECUTIVE_HOLDS,
+                    )
+                    return cached
+                self._consecutive_holds = 0
+
                 snap = self.store(
                     items=body["items"],
                     totals=body["totals"],

--- a/tests/test_coverage_degraded_publish.py
+++ b/tests/test_coverage_degraded_publish.py
@@ -1,0 +1,153 @@
+"""#167 — a degraded build must not clobber a good warm snapshot.
+
+Root cause: build_coverage treats integration failure as empty data
+(best-effort by design), so a transient Sonarr/Bazarr outage right after a
+stack restart yields a structurally-valid build where every row is unprobed
+(no series paths) and synthetic rows vanish. CoverageCache.refresh published
+ANY completed build, replacing the warm snapshot with the degraded one for
+~10 minutes until later builds healed it.
+
+Fix: publish gate — hold a build whose critical source failed
+(configured + ok:false) while the cached snapshot had that source healthy,
+capped at 3 consecutive holds so a genuinely-down integration can't pin a
+stale snapshot forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+# ─── pure gate decision ──────────────────────────────────────────────
+
+
+def test_degraded_when_critical_source_newly_failing():
+    from subarr.coverage_cache import degraded_sources
+
+    new = {"sonarr": {"ok": False, "configured": True, "error": "boom"}}
+    cached = {"sonarr": {"ok": True, "configured": True}}
+    assert degraded_sources(new, cached) == ["sonarr"]
+
+
+def test_not_degraded_when_source_was_already_failing():
+    from subarr.coverage_cache import degraded_sources
+
+    new = {"sonarr": {"ok": False, "configured": True, "error": "boom"}}
+    cached = {"sonarr": {"ok": False, "configured": True, "error": "boom"}}
+    assert degraded_sources(new, cached) == []
+
+
+def test_not_degraded_when_unconfigured():
+    from subarr.coverage_cache import degraded_sources
+
+    # Radarr intentionally unwired: configured False is not a failure.
+    new = {"radarr": {"ok": False, "configured": False}}
+    cached = {"radarr": {"ok": True, "configured": True}}
+    assert degraded_sources(new, cached) == []
+
+
+def test_not_degraded_without_cached_baseline():
+    from subarr.coverage_cache import degraded_sources
+
+    new = {"bazarr": {"ok": False, "configured": True}}
+    assert degraded_sources(new, None) == []
+    assert degraded_sources(new, {}) == []
+
+
+# ─── refresh-level behavior ──────────────────────────────────────────
+
+
+class _FakeReport:
+    def __init__(self, sources, items=None):
+        self._sources = sources
+        self._items = items or []
+
+    def to_dict(self):
+        return {"items": self._items, "totals": {"items": len(self._items)}, "sources": self._sources}
+
+
+def _warm_cache(tmp_path):
+    """CoverageCache with a healthy persisted snapshot."""
+    from subarr.coverage_cache import CoverageCache
+    from subarr.migrate import run_migrations
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    cache = CoverageCache(db)
+    cache.store(
+        items=[{"canonical_path": "TV/Show", "verification_state": "verified"}],
+        totals={"items": 1},
+        sources={"sonarr": {"ok": True, "configured": True}, "bazarr": {"ok": True, "configured": True}},
+        build_duration_s=1.0,
+    )
+    return cache
+
+
+def test_refresh_holds_degraded_build(subarr_env, tmp_path, monkeypatch):
+    from subarr import coverage_engine
+
+    cache = _warm_cache(tmp_path)
+    good = cache.get_cached()
+
+    async def _degraded_build(*a, **kw):
+        return _FakeReport(
+            {
+                "sonarr": {"ok": False, "configured": True, "error": "down"},
+                "bazarr": {"ok": True, "configured": True},
+            },
+            items=[{"canonical_path": None, "verification_state": "unprobed"}] * 5,
+        )
+
+    monkeypatch.setattr(coverage_engine, "build_coverage", _degraded_build)
+    snap = asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
+    # The warm snapshot survives; the degraded build was NOT published.
+    assert snap.generated_at == good.generated_at
+    assert cache.get_cached().generated_at == good.generated_at
+    assert cache.get_cached().items[0]["verification_state"] == "verified"
+
+
+def test_refresh_publishes_after_hold_cap(subarr_env, tmp_path, monkeypatch):
+    """A genuinely-down integration must not pin a stale snapshot forever:
+    after 3 consecutive holds the degraded build publishes."""
+    from subarr import coverage_engine
+
+    cache = _warm_cache(tmp_path)
+    good = cache.get_cached()
+
+    async def _degraded_build(*a, **kw):
+        return _FakeReport(
+            {"sonarr": {"ok": False, "configured": True, "error": "down"}},
+            items=[{"canonical_path": None, "verification_state": "unprobed"}],
+        )
+
+    monkeypatch.setattr(coverage_engine, "build_coverage", _degraded_build)
+    for _ in range(3):  # holds 1..3
+        asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
+        assert cache.get_cached().generated_at == good.generated_at
+    # 4th consecutive degraded build publishes (cap exceeded).
+    asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
+    assert cache.get_cached().generated_at != good.generated_at
+
+
+def test_refresh_healthy_build_publishes_and_resets_holds(subarr_env, tmp_path, monkeypatch):
+    from subarr import coverage_engine
+
+    cache = _warm_cache(tmp_path)
+    good = cache.get_cached()
+
+    calls = {"n": 0}
+
+    async def _flaky_build(*a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _FakeReport({"sonarr": {"ok": False, "configured": True, "error": "down"}})
+        return _FakeReport(
+            {"sonarr": {"ok": True, "configured": True}},
+            items=[{"canonical_path": "TV/Show", "verification_state": "verified"}],
+        )
+
+    monkeypatch.setattr(coverage_engine, "build_coverage", _flaky_build)
+    asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
+    assert cache.get_cached().generated_at == good.generated_at  # held
+    asyncio.run(cache.refresh(bundle=None, probe_store=None, audio_lang_store=None))
+    assert cache.get_cached().generated_at != good.generated_at  # healthy → published


### PR DESCRIPTION
## Summary

Fixes #167. Root-caused beyond the issue hypothesis: not a generic settling race —

- `build_coverage` degrades integration failures to empty data (best-effort, by design): a failed Sonarr fetch records `sources.sonarr.ok=false` and returns `[]`.
- With no Sonarr series, no Bazarr row gets a series path → `canonical_path=None` → `_attach_probe_episode` exits early → **every row unprobed**; the ~100 Sonarr-derived synthetic rows also vanish (explains the observed 601→500 item drop).
- `CoverageCache.refresh` published ANY completed build → the degraded snapshot replaced the warm one until later builds healed it (~10 min of "Analyzing" after a stack restart where Sonarr boots slower than subarr).

**Fix — publish gate keyed to the root cause** (not the unprobed-ratio heuristic): a build whose critical source (`bazarr`/`sonarr`/`radarr`) is configured-but-failing while the cached snapshot had it healthy is **HELD** — the warm snapshot keeps serving, a loud `WARNING ... HELD, not published (#167)` lands in the logs, and the next refresh retries. Capped at **3 consecutive holds** so a genuinely-down integration still publishes (and surfaces) rather than pinning a stale snapshot forever. Unconfigured integrations never trigger the gate; first-ever builds (no baseline) always publish.

## Test Plan
- [x] `tests/test_coverage_degraded_publish.py` (7): gate decision matrix (newly-failing / already-failing / unconfigured / no-baseline) + refresh-level hold, hold-cap publish, healthy-publish-resets-holds.
- [x] Full suite green; ruff clean.
- [x] **Live end-to-end repro on :9923**: stopped the real Sonarr container → forced build → `HELD (1/3)`, warm snapshot served verbatim; Sonarr restarted → healthy build published with `sources.sonarr.ok=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)