### PR TITLE
feat(#202): /data persistence guard + retention telemetry signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ services:
       - UMASK=022
       - SUBARR_DB_PATH=/data/subarr.db     # SQLite + persisted settings live here
     volumes:
-      - ./subarr/data:/data                # subarr.db (override the path with SUBARR_DB_PATH)
+      - ./subarr/data:/data                # REQUIRED — your verifications + settings live here.
+                                           # Without a persistent volume, everything is wiped on
+                                           # every recreate (and subarr will warn you on boot).
       - /path/to/media:/media/library:rw   # same path Bazarr and subgen see
 ```
 
@@ -267,6 +269,7 @@ What to do about it:
 - For a consistent live copy of a running instance: `docker exec subarr sqlite3 /data/subarr.db ".backup /data/subarr-backup.db"`, then pick up the backup file. Copying `subarr.db` while subarr is writing can produce a torn copy (WAL); stopping the container first also works.
 - **Keep `/data` on a local disk, not NFS/SMB.** SQLite in WAL mode over network filesystems is a well-known corruption hazard. Your media library on NAS is fine — that's read-mostly; the database is not.
 - Subarr runs an integrity check (`PRAGMA quick_check`) on every boot. If your database is damaged you'll see it on the **Health page** and the red header pill — back up `/data` immediately at that point, before anything else writes.
+- **Make sure `/data` is an actual volume.** If you run without one (a bare container, or you removed the volume line), every `docker compose up` starts from an empty database — all your verifications gone, and a brand-new install each time. Subarr detects this on boot and flags it loudly on the Health page; if you see that warning, add a volume for `/data` before you do anything else.
 
 ## Security
 

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -108,6 +108,7 @@ from .aftercare_store import AfterCareStore
 from .scan_runner import ScanRunner
 from .scan_store import ScanStore
 from .crash_store import CrashStore
+from .data_persistence import check_data_persistence
 from .db_integrity import check_db_integrity
 from .error_store import ErrorStore
 from .task_health import TaskHealthStore
@@ -275,6 +276,10 @@ async def lifespan(app_: FastAPI):
     # loud (Health page + red pill), not silently half-working. Never blocks
     # boot on failure; milliseconds on healthy files.
     check_db_integrity(settings.db_path, app_.state.task_health)
+    # #196/#202: warn loudly if /data isn't a persistent volume (recreate =
+    # all verifications/intents lost + a fresh telemetry id). Verdict cached
+    # for the telemetry data_persistent signal. None = unknown (not a container).
+    app_.state.data_persistent = check_data_persistence(settings.db_path, app_.state.task_health)
     # Seed the roster so all supervised loops show on the Health page from boot
     # (as "never run yet"), not only after their first cycle. Each loop's first
     # record_success/failure carries its real cadence and corrects these.

--- a/src/subarr/data_persistence.py
+++ b/src/subarr/data_persistence.py
@@ -1,0 +1,79 @@
+"""#196/#202 — detect a non-persistent /data volume.
+
+If a user runs subarr without a persistent volume for `/data`, every
+`docker compose up` starts from an empty database: all their audio-language
+verifications, intents, and provenance are gone, and a fresh telemetry
+install_id is minted (which also inflated our fleet stats with phantom
+one-day installs). This is a classic *arr footgun and a brutal first
+impression. We detect it on boot and surface it loudly (Health page + log),
+and report it as a telemetry signal so we can measure how common it is.
+
+Heuristic: a real bind/named volume mounted at `/data` has a different
+filesystem device id than the container's root. If `/data`'s parent shares
+the root's device, it lives in the container's ephemeral writable layer.
+Only meaningful inside a container — returns None (unknown) otherwise, so
+dev hosts and bare-metal runs never see a false warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+TASK_NAME = "data-persistence"
+
+
+def data_dir_is_ephemeral(db_path: Path) -> bool | None:
+    """True  → /data is the container's writable layer (NOT persisted).
+    False → /data is a real mount (safe).
+    None  → can't tell (not in a container / not Linux) — never warn.
+    """
+    try:
+        if not os.path.exists("/.dockerenv"):
+            return None  # not a container — persistence is the host filesystem's job
+        data_dir = Path(db_path).parent
+        if not data_dir.exists():
+            return None
+        # A mount point has a different st_dev than the filesystem it's mounted
+        # under. Same device as `/` ⇒ /data is in the container overlay ⇒ wiped
+        # on every recreate.
+        return os.stat(data_dir).st_dev == os.stat("/").st_dev
+    except Exception:
+        return None
+
+
+def check_data_persistence(db_path: Path, health) -> bool | None:
+    """Record the persistence verdict into task_health and return whether
+    /data is PERSISTENT: True = persistent (safe), False = ephemeral (will be
+    wiped), None = couldn't tell. The return feeds the `data_persistent`
+    telemetry signal directly, so it's persistence-oriented, NOT the raw
+    ephemeral flag. Never raises — best-effort, boot continues."""
+    ephemeral = data_dir_is_ephemeral(db_path)
+    if ephemeral is None:
+        return None
+    try:
+        health.register(TASK_NAME, expected_interval_s=None)
+        if ephemeral:
+            from .db_integrity import DatabaseCorruptionError  # reuse a loud error type
+
+            err = DatabaseCorruptionError(
+                "/data is NOT a persistent volume — your subtitle verifications, "
+                "language intents, and history will be LOST on the next container "
+                "recreate. Mount a named volume or host path at /data. See the "
+                "README 'Backing up your data' section."
+            )
+            health.record_failure(TASK_NAME, err, expected_interval_s=None)
+            log.error(
+                "DATA PERSISTENCE WARNING: /data appears to be the container's "
+                "ephemeral layer, not a mounted volume. Everything in /data "
+                "(verifications, intents, provenance) will be lost on recreate. "
+                "Add a volume for /data."
+            )
+        else:
+            health.record_success(TASK_NAME, expected_interval_s=None)
+    except Exception:
+        log.debug("data-persistence health record failed", exc_info=True)
+    return not ephemeral

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -83,6 +83,11 @@ class TelemetryPayload:
     # keyed "ExcType:module:line". Type + location + count ONLY — never
     # messages, tracebacks, or paths (those stay local in task_health).
     crash_counts_24h: dict[str, int] = field(default_factory=dict)
+    # #196/#202 retention signals. install_age_days = days since this
+    # install_id was created (tells genuine retention from id-churn).
+    # data_persistent = is /data a real mount (None = couldn't tell).
+    install_age_days: float = 0.0
+    data_persistent: bool | None = None
     docker_tier: int = 1
 
     def to_dict(self) -> dict[str, Any]:
@@ -101,6 +106,8 @@ class TelemetryPayload:
             "walks_per_day_30d": self.walks_per_day_30d,
             "error_counts_30d": self.error_counts_30d,
             "crash_counts_24h": self.crash_counts_24h,
+            "install_age_days": self.install_age_days,
+            "data_persistent": self.data_persistent,
             "docker_tier": self.docker_tier,
         }
 
@@ -248,6 +255,10 @@ class TelemetryCollector:
             walks_per_day_30d=float(stats.get("walks_per_day_30d") or 0.0),
             error_counts_30d=stats.get("error_counts_30d") or {},
             crash_counts_24h=stats.get("crash_counts_24h") or {},
+            # install_age_days is telemetry's own data (created_at), computed
+            # here rather than via the provider.
+            install_age_days=round(max(0.0, (time.time() - st.created_at) / 86400.0), 1),
+            data_persistent=stats.get("data_persistent"),
             docker_tier=int(stats.get("docker_tier") or 1),
         )
 
@@ -474,6 +485,8 @@ def make_default_stats_provider(app_state) -> Any:
             "walks_per_day_30d": _walks_per_day_30d(app_state),
             "error_counts_30d": _error_counts_30d(app_state),
             "crash_counts_24h": _crash_counts_24h(app_state),
+            # #202: persistence verdict cached at boot (None = couldn't tell).
+            "data_persistent": getattr(app_state, "data_persistent", None),
             "docker_tier": docker_tier,
         }
 

--- a/tests/test_data_persistence.py
+++ b/tests/test_data_persistence.py
@@ -1,0 +1,116 @@
+"""#196/#202 — ephemeral /data detection + retention telemetry signals."""
+
+from __future__ import annotations
+
+import time
+
+
+def test_ephemeral_returns_none_outside_container(subarr_env, tmp_path, monkeypatch):
+    from subarr import data_persistence
+
+    # No /.dockerenv → not a container → unknown, never warns.
+    monkeypatch.setattr(data_persistence.os.path, "exists", lambda p: False)
+    assert data_persistence.data_dir_is_ephemeral(tmp_path / "subarr.db") is None
+
+
+def test_ephemeral_true_when_same_device_as_root(subarr_env, tmp_path, monkeypatch):
+    from subarr import data_persistence
+
+    monkeypatch.setattr(data_persistence.os.path, "exists", lambda p: True)  # pretend container
+
+    class _St:
+        st_dev = 42
+
+    monkeypatch.setattr(data_persistence.os, "stat", lambda p, **kw: _St())
+    # data dir and / share a device → /data is the container layer → ephemeral.
+    assert data_persistence.data_dir_is_ephemeral(tmp_path / "subarr.db") is True
+
+
+def test_ephemeral_false_when_distinct_device(subarr_env, tmp_path, monkeypatch):
+    from subarr import data_persistence
+
+    monkeypatch.setattr(data_persistence.os.path, "exists", lambda p: True)
+
+    def _stat(p, **kw):
+        class _St:
+            st_dev = 1 if str(p) == "/" else 2  # different device = a real mount
+
+        return _St()
+
+    monkeypatch.setattr(data_persistence.os, "stat", _stat)
+    assert data_persistence.data_dir_is_ephemeral(tmp_path / "subarr.db") is False
+
+
+def test_check_records_failure_when_ephemeral(subarr_env, tmp_path, monkeypatch):
+    from subarr import data_persistence
+    from subarr.migrate import run_migrations
+    from subarr.task_health import TaskHealthStore
+
+    db = tmp_path / "h.db"
+    run_migrations(db)
+    health = TaskHealthStore(db)
+    monkeypatch.setattr(data_persistence, "data_dir_is_ephemeral", lambda p: True)
+    # ephemeral → returns False (NOT persistent) and records a loud failure.
+    assert data_persistence.check_data_persistence(db, health) is False
+    states = {s.task_name: s for s in health.states()}
+    assert states["data-persistence"].last_error_type is not None
+
+
+def test_check_returns_true_and_success_when_persistent(subarr_env, tmp_path, monkeypatch):
+    from subarr import data_persistence
+    from subarr.migrate import run_migrations
+    from subarr.task_health import TaskHealthStore
+
+    db = tmp_path / "h.db"
+    run_migrations(db)
+    health = TaskHealthStore(db)
+    monkeypatch.setattr(data_persistence, "data_dir_is_ephemeral", lambda p: False)
+    assert data_persistence.check_data_persistence(db, health) is True
+    states = {s.task_name: s for s in health.states()}
+    assert states["data-persistence"].last_success_at is not None
+    assert states["data-persistence"].last_error_type is None
+
+
+def test_check_unknown_records_nothing(subarr_env, tmp_path, monkeypatch):
+    from subarr import data_persistence
+    from subarr.migrate import run_migrations
+    from subarr.task_health import TaskHealthStore
+
+    db = tmp_path / "h.db"
+    run_migrations(db)
+    health = TaskHealthStore(db)
+    monkeypatch.setattr(data_persistence, "data_dir_is_ephemeral", lambda p: None)
+    assert data_persistence.check_data_persistence(db, health) is None
+    assert health.states() == []  # unknown never surfaces a task
+
+
+def test_payload_carries_retention_signals(subarr_env, tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.telemetry import TelemetryCollector
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    col = TelemetryCollector(db_path=db, stats_provider=lambda: {"data_persistent": True})
+    d = col.build_payload().to_dict()
+    assert "install_age_days" in d and isinstance(d["install_age_days"], float)
+    assert d["install_age_days"] >= 0.0
+    assert d["data_persistent"] is True
+
+
+def test_install_age_grows_with_created_at(subarr_env, tmp_path):
+    import sqlite3
+
+    from subarr.migrate import run_migrations
+    from subarr.telemetry import TelemetryCollector
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    # Construct first so _ensure_row creates the telemetry_state row, THEN
+    # backdate created_at 10 days; age must reflect it.
+    col = TelemetryCollector(db_path=db)
+    conn = sqlite3.connect(str(db))
+    conn.execute("UPDATE telemetry_state SET created_at = ? WHERE id = 1", (time.time() - 10 * 86400,))
+    conn.commit()
+    conn.close()
+    age = col.build_payload().to_dict()["install_age_days"]
+    assert 9.5 <= age <= 10.5


### PR DESCRIPTION
From the gap review (#202) and the funnel finding. 98.7% of installs ping on exactly one day, and a big confound is non-persistent `/data`: run without a volume and every `docker compose up` mints a fresh install_id and wipes every verification. This adds the guard and the signal to measure it.

- **Boot guard** (`data_persistence.py`): a `st_dev` heuristic (does `/data` share the container root's device?) flags an ephemeral `/data`. Ephemeral → loud ERROR log + a red `data-persistence` task on the Health page. Only runs in a container (`/.dockerenv`); returns None (silent) on dev/bare-metal so there are no false warnings.
- **Two opt-out telemetry signals**: `install_age_days` (days since the install_id was created — distinguishes genuine retention from id-churn) and `data_persistent` (boolean; measures the footgun across the fleet). Both already ingested by the worker (deployed, migration 0003).
- **Docs**: compose example marks the `/data` volume REQUIRED with an inline warning; the "Backing up your data" section explains the boot warning.

## Test Plan
- [x] `tests/test_data_persistence.py` (8): ephemeral detection both directions + unknown-outside-container, health failure/success recording, payload carries both signals, install_age tracks created_at.
- [x] Full suite **875 passed**; ruff clean.
- [x] **Live-verified both directions**: subarr-next (has a volume) → healthy task + `data_persistent=True`, `install_age_days=13.4`; throwaway container with no `/data` volume → the ERROR warning fires, Health task `unhealthy=True`, `data_persistent=False`, `install_age_days=0`. Caught + fixed a semantic inversion via that live check.
- [x] Worker accepts the new fields live (verified before subarr ever sends them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)