### PR TITLE
feat(#199): unhandled request 500s feed the crash store

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -774,7 +774,16 @@ from starlette.middleware.gzip import GZipMiddleware  # noqa: E402
 from .security_headers import SecurityHeadersMiddleware  # noqa: E402
 from .auth import BasicAuthMiddleware  # noqa: E402
 from .api_security import ApiKeyMiddleware, CsrfOriginMiddleware  # noqa: E402
+from .request_crash_capture import RequestCrashCaptureMiddleware  # noqa: E402
 
+# #199: innermost — sees only exceptions that escaped route handlers (500s),
+# records the sanitized (type, module:line) into CrashStore, re-raises. The
+# recorder resolves app.state lazily because the store is built in lifespan,
+# after this module-level registration.
+app.add_middleware(
+    RequestCrashCaptureMiddleware,
+    crash_recorder=lambda exc: getattr(app.state, "crashes", None) and app.state.crashes.record(exc),
+)
 app.add_middleware(GZipMiddleware, minimum_size=1024)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(CsrfOriginMiddleware, enabled=settings.csrf_protection)

--- a/src/subarr/request_crash_capture.py
+++ b/src/subarr/request_crash_capture.py
@@ -1,0 +1,41 @@
+"""#199 — feed unhandled request-handler exceptions to the crash store.
+
+Crash telemetry (#157 P2) supervises the background loops; this closes the
+other half: an exception that escapes a route handler (a 500) is recorded as
+the same sanitized (exc_type, module:line) aggregate — visible locally in
+the Settings "Crash reports (24h)" row and fleet-wide via crash_counts_24h.
+
+Registered INNERMOST in the middleware stack so it only ever sees exceptions
+that actually escaped the app: handled HTTPExceptions (404s, validation
+errors) resolve inside the routing app and never reach it. The original
+exception is always re-raised, so FastAPI/Starlette's normal 500 handling —
+and its log line — are completely untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class RequestCrashCaptureMiddleware:
+    """ASGI wrapper: record-and-re-raise for unhandled handler exceptions."""
+
+    def __init__(self, app, *, crash_recorder=None):
+        self._app = app
+        self._recorder = crash_recorder
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or self._recorder is None:
+            await self._app(scope, receive, send)
+            return
+        try:
+            await self._app(scope, receive, send)
+        except Exception as exc:
+            # Best-effort: a broken recorder must never mask the real error.
+            try:
+                self._recorder(exc)
+            except Exception:
+                log.debug("request crash recorder failed", exc_info=True)
+            raise

--- a/tests/test_request_crash_capture.py
+++ b/tests/test_request_crash_capture.py
@@ -1,0 +1,121 @@
+"""#199 — unhandled request-handler exceptions feed the crash store.
+
+Crash telemetry (#157 P2) covered supervised loops only; a 500 storm in
+request handlers was invisible locally AND fleet-wide. This middleware
+records (exc_type, module:line) for any exception that escapes a route,
+then re-raises so FastAPI's normal 500 handling is untouched. Handled
+HTTPExceptions never reach it (they resolve inside the routing app).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+
+class _SpyStore:
+    def __init__(self):
+        self.recorded: list[BaseException] = []
+
+    def record(self, exc):
+        self.recorded.append(exc)
+
+
+def _boom(request):
+    raise ValueError("kaboom in a handler")
+
+
+def _fine(request):
+    return PlainTextResponse("ok")
+
+
+def _http_404(request):
+    raise StarletteHTTPException(status_code=404)
+
+
+def _client(store):
+    from subarr.request_crash_capture import RequestCrashCaptureMiddleware
+
+    app = Starlette(
+        routes=[
+            Route("/api/boom", _boom),
+            Route("/api/fine", _fine),
+            Route("/api/notfound", _http_404),
+        ]
+    )
+    wrapped = RequestCrashCaptureMiddleware(app, crash_recorder=store.record)
+    transport = httpx.ASGITransport(app=wrapped, raise_app_exceptions=False)
+    return httpx.AsyncClient(transport=transport, base_url="http://t")
+
+
+@pytest.mark.anyio
+async def test_unhandled_exception_recorded_and_500(subarr_env):
+    store = _SpyStore()
+    async with _client(store) as c:
+        r = await c.get("/api/boom")
+    assert r.status_code == 500
+    assert len(store.recorded) == 1
+    assert type(store.recorded[0]).__name__ == "ValueError"
+
+
+@pytest.mark.anyio
+async def test_success_and_handled_http_errors_not_recorded(subarr_env):
+    store = _SpyStore()
+    async with _client(store) as c:
+        ok = await c.get("/api/fine")
+        nf = await c.get("/api/notfound")
+    assert ok.status_code == 200
+    assert nf.status_code == 404
+    assert store.recorded == []
+
+
+def test_real_app_records_handler_crash_to_crash_store(subarr_env, app_with_stub):
+    """End-to-end through the real middleware stack: a route that raises
+    lands a sanitized row in app.state.crashes (the lazy app.state lookup
+    in app.py's recorder lambda is the seam under test)."""
+    import time
+
+    from fastapi.testclient import TestClient
+
+    import subarr.app as app_mod
+
+    @app_mod.app.get("/api/_test_boom_199")
+    async def _boom_route():  # pragma: no cover - body raises immediately
+        raise KeyError("induced for #199 test")
+
+    try:
+        with TestClient(app_mod.app, raise_server_exceptions=False) as c:
+            before = (
+                sum(c.app.state.crashes.counts_since(time.time() - 60).values())
+                if hasattr(c.app.state, "crashes")
+                else 0
+            )
+            r = c.get("/api/_test_boom_199")
+            assert r.status_code == 500
+            counts = c.app.state.crashes.counts_since(time.time() - 60)
+            assert any(k.startswith("KeyError:") for k in counts), counts
+            assert sum(counts.values()) == before + 1
+    finally:
+        app_mod.app.router.routes = [
+            rt for rt in app_mod.app.router.routes if getattr(rt, "path", "") != "/api/_test_boom_199"
+        ]
+
+
+@pytest.mark.anyio
+async def test_recorder_failure_never_masks_the_original_error(subarr_env):
+    from subarr.request_crash_capture import RequestCrashCaptureMiddleware
+
+    def bad_recorder(exc):
+        raise RuntimeError("recorder is broken")
+
+    app = Starlette(routes=[Route("/api/boom", _boom)])
+    wrapped = RequestCrashCaptureMiddleware(app, crash_recorder=bad_recorder)
+    transport = httpx.ASGITransport(app=wrapped, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/api/boom")
+    # Original 500 behavior preserved; the broken recorder is swallowed.
+    assert r.status_code == 500


### PR DESCRIPTION
Fixes #199 (gap review). Crash telemetry (#157 P2) supervised the background loops; this closes the request-handler half — a 500 storm was invisible locally and fleet-wide.

- **`RequestCrashCaptureMiddleware`** (innermost): records the sanitized `(exc_type, module:line)` into the existing CrashStore for any exception that escapes a route, then re-raises — FastAPI''s normal 500 handling and logging untouched. Handled `HTTPException`s resolve inside the routing app and never reach it. A broken recorder can never mask the original error.
- Visible locally in the Settings "Crash reports (24h)" row; fleet-wide via `crash_counts_24h`. Completes the net right before the launch influx exercises code paths at scale.

## Test Plan
- [x] 4 tests: unhandled → recorded + 500; success + handled 404 → not recorded; recorder failure swallowed; **real-app end-to-end** (induced route exception → 500 → sanitized row in `app.state.crashes` through the actual middleware stack + lazy state lookup).
- [x] ruff clean; full suite running locally + in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)