### PR TITLE
feat(#204): single-process guard - one subarr per database

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -114,6 +114,7 @@ from .error_store import ErrorStore
 from .task_health import TaskHealthStore
 from .schedule_store import ScheduleStore
 from .scheduler import Scheduler
+from .single_process import check_single_process
 from .subgen_client import SubgenClient
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
@@ -280,6 +281,10 @@ async def lifespan(app_: FastAPI):
     # all verifications/intents lost + a fresh telemetry id). Verdict cached
     # for the telemetry data_persistent signal. None = unknown (not a container).
     app_.state.data_persistent = check_data_persistence(settings.db_path, app_.state.task_health)
+    # #204: exactly one subarr process per database. The handle must live on
+    # app.state — the flock dies with it. Second worker / second container on
+    # the same /data → red Health task + loud log (we warn, never brick boot).
+    app_.state.process_lock = check_single_process(settings.db_path, app_.state.task_health)
     # Seed the roster so all supervised loops show on the Health page from boot
     # (as "never run yet"), not only after their first cycle. Each loop's first
     # record_success/failure carries its real cadence and corrects these.

--- a/src/subarr/single_process.py
+++ b/src/subarr/single_process.py
@@ -1,0 +1,103 @@
+"""#204 — exactly one subarr process per database.
+
+Every piece of in-memory state (coverage cache mirror, pending feeder,
+scheduler, watchdogs, SQLite WAL assumptions) is built for ONE process. Two
+ways users break that silently: `uvicorn --workers 2`-style multi-worker
+flags, and the nastier copy-paste accident of two containers mounting the
+same /data. Both double-submit the scheduler and corrupt caches with no
+error anywhere.
+
+The guard: an OS advisory lock (flock) on `<db dir>/subarr.lock`, held for
+the process lifetime. The second process fails to acquire and we surface it
+the same way as every silent-failure class — loud log + a red task on the
+Health page. We deliberately do NOT refuse to boot: a stale-NFS-lock false
+positive that bricked boots would be worse than the warning being ignorable
+(and /data-on-NFS is already warned against).
+
+POSIX-only (production is Linux containers). On platforms without fcntl
+(Windows dev) the guard reports unknown and stays silent.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+TASK_NAME = "single-process"
+
+try:  # pragma: no cover - import success/failure is platform-determined
+    import fcntl
+
+    _LOCK_SUPPORTED = True
+except ImportError:  # Windows dev hosts
+    fcntl = None  # type: ignore[assignment]
+    _LOCK_SUPPORTED = False
+
+
+class MultipleProcessesError(Exception):
+    """Another subarr process already holds this database's lock."""
+
+
+def acquire_process_lock(db_path: Path):
+    """Try to take the exclusive advisory lock for this database.
+
+    Returns an open file handle (KEEP A REFERENCE — the lock lives and dies
+    with it) or None when the lock is held elsewhere / unsupported platform /
+    any error (never raises)."""
+    if not _LOCK_SUPPORTED:
+        return None
+    try:
+        lock_path = Path(db_path).parent / "subarr.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "w")  # noqa: SIM115 - lifetime == process
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            handle.close()
+            return None
+        return handle
+    except Exception:
+        log.debug("process lock acquire failed", exc_info=True)
+        return None
+
+
+def release_process_lock(handle) -> None:
+    """Close the handle (drops the flock). Best-effort."""
+    try:
+        if handle is not None:
+            handle.close()
+    except Exception:
+        pass
+
+
+def check_single_process(db_path: Path, health):
+    """Acquire the lock and record the verdict in task_health.
+
+    Returns the lock handle (caller stores it for the process lifetime) or
+    None. On an unsupported platform records nothing and returns None."""
+    if not _LOCK_SUPPORTED:
+        return None
+    handle = acquire_process_lock(db_path)
+    try:
+        health.register(TASK_NAME, expected_interval_s=None)
+        if handle is None:
+            err = MultipleProcessesError(
+                "another subarr process holds this database's lock — running "
+                "multiple workers (or two containers sharing one /data) "
+                "double-submits the scheduler and corrupts in-memory state. "
+                "Run exactly one subarr process per database."
+            )
+            health.record_failure(TASK_NAME, err, expected_interval_s=None)
+            log.error(
+                "MULTIPLE SUBARR PROCESSES DETECTED: another process holds "
+                "%s/subarr.lock. Do not run uvicorn with --workers > 1, and do "
+                "not point two containers at the same /data.",
+                Path(db_path).parent,
+            )
+        else:
+            health.record_success(TASK_NAME, expected_interval_s=None)
+    except Exception:
+        log.debug("single-process health record failed", exc_info=True)
+    return handle

--- a/tests/test_single_process_guard.py
+++ b/tests/test_single_process_guard.py
@@ -1,0 +1,103 @@
+"""#204 — exactly one subarr process per database.
+
+All the in-memory state (coverage cache mirror, pending feeder, scheduler,
+watchdogs) assumes one process. `uvicorn --workers 2` — or the nastier
+copy-paste case, two CONTAINERS sharing one /data — silently double-submits
+the scheduler and splits caches. An OS-level advisory lock on
+/data/subarr.lock catches both: the second process fails to acquire and
+surfaces loudly. POSIX-only by design (production is Linux containers);
+on platforms without fcntl the guard reports unknown and stays silent.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import sys
+
+import pytest
+
+posix_only = pytest.mark.skipif(sys.platform == "win32", reason="flock is POSIX; guard is a no-op on Windows")
+
+
+def _hold_lock(db_path, q):  # pragma: no cover - runs in a child process
+    from subarr.single_process import acquire_process_lock
+
+    handle = acquire_process_lock(db_path)
+    q.put(handle is not None)
+    if handle is not None:
+        import time
+
+        time.sleep(10)
+
+
+def test_acquire_returns_handle_or_none_unknown(subarr_env, tmp_path):
+    from subarr import single_process
+
+    handle = single_process.acquire_process_lock(tmp_path / "subarr.db")
+    if sys.platform == "win32":
+        assert handle is None  # unknown/no-op platform
+    else:
+        assert handle is not None
+        single_process.release_process_lock(handle)
+
+
+@posix_only
+def test_second_process_fails_to_acquire(subarr_env, tmp_path):
+    db = tmp_path / "subarr.db"
+    q = multiprocessing.Queue()
+    p = multiprocessing.Process(target=_hold_lock, args=(db, q))
+    p.start()
+    try:
+        assert q.get(timeout=5) is True  # child holds the lock
+        from subarr.single_process import acquire_process_lock
+
+        assert acquire_process_lock(db) is None  # we must NOT get it
+    finally:
+        p.terminate()
+        p.join(timeout=5)
+
+
+def test_check_records_health_failure_when_lock_held(subarr_env, tmp_path, monkeypatch):
+    from subarr import single_process
+    from subarr.migrate import run_migrations
+    from subarr.task_health import TaskHealthStore
+
+    db = tmp_path / "h.db"
+    run_migrations(db)
+    health = TaskHealthStore(db)
+    # Simulate "another process holds the lock" regardless of platform.
+    monkeypatch.setattr(single_process, "acquire_process_lock", lambda p: None)
+    monkeypatch.setattr(single_process, "_LOCK_SUPPORTED", True)
+    got = single_process.check_single_process(db, health)
+    assert got is None  # no handle
+    states = {s.task_name: s for s in health.states()}
+    assert states["single-process"].last_error_type is not None
+
+
+def test_check_records_success_when_acquired(subarr_env, tmp_path, monkeypatch):
+    from subarr import single_process
+    from subarr.migrate import run_migrations
+    from subarr.task_health import TaskHealthStore
+
+    db = tmp_path / "h.db"
+    run_migrations(db)
+    health = TaskHealthStore(db)
+    sentinel = object()
+    monkeypatch.setattr(single_process, "acquire_process_lock", lambda p: sentinel)
+    monkeypatch.setattr(single_process, "_LOCK_SUPPORTED", True)
+    assert single_process.check_single_process(db, health) is sentinel
+    states = {s.task_name: s for s in health.states()}
+    assert states["single-process"].last_success_at is not None
+
+
+def test_unsupported_platform_is_silent(subarr_env, tmp_path, monkeypatch):
+    from subarr import single_process
+    from subarr.migrate import run_migrations
+    from subarr.task_health import TaskHealthStore
+
+    db = tmp_path / "h.db"
+    run_migrations(db)
+    health = TaskHealthStore(db)
+    monkeypatch.setattr(single_process, "_LOCK_SUPPORTED", False)
+    assert single_process.check_single_process(db, health) is None
+    assert health.states() == []  # never surfaces a task it can't evaluate


### PR DESCRIPTION
Fixes #204 (gap review). An advisory `flock` on `<db dir>/subarr.lock` held for the process lifetime: the second process (multi-worker flag, or the nastier copy-paste case of two containers mounting one `/data`) fails to acquire and surfaces as a loud ERROR log + a red `single-process` task on the Health page. Warn-not-brick by design — a stale-lock false positive that blocked boots would be worse than an ignorable warning. POSIX-only (production containers); silent on Windows dev.

## Test Plan
- [x] 5 tests: acquire/release, second-process-fails (real child process; runs on CI ubuntu), health failure recorded when held elsewhere, success when acquired, unsupported platform stays silent.
- [x] **Live in-container**: running app holds the lock + reports healthy; a second python process in the same container cannot acquire.
- [x] Boot-path suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)