### PR TITLE
#197: retention audit — boot-time prunes for unbounded tables

### DIFF
--- a/src/subarr/aftercare_store.py
+++ b/src/subarr/aftercare_store.py
@@ -46,6 +46,21 @@ class AfterCareStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._lock = threading.Lock()
 
+    def prune(self, days: int = 365) -> int:
+        """#197: one row per completed job, otherwise forever. A year keeps
+        the #95 passive-tuning signal window intact while bounding growth.
+        PROTECTIVE RULE: flagged-but-unreviewed rows are the user's review
+        backlog — never pruned, regardless of age. Run on boot."""
+        import time
+
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM aftercare_results WHERE completed_at < ? "
+                "AND NOT (flagged = 1 AND reviewed_at IS NULL)",
+                (time.time() - days * 86400,),
+            )
+            return cur.rowcount
+
     def record(
         self, *, canonical_path: str, completed_at: float, evaluation: AftercareEvaluation, source: str | None
     ) -> None:

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -260,8 +260,10 @@ async def lifespan(app_: FastAPI):
     # All schema is owned by migrations (run_migrations above, before any
     # store is constructed). Stores no longer self-create tables.
     app_.state.scans = ScanStore(settings.db_path)
+    app_.state.scans.prune()  # #197: scan history, 180d
     # Anonymous error-class log for telemetry (schema via migration 006).
     app_.state.errors = ErrorStore(settings.db_path)
+    app_.state.errors.prune()  # #197: telemetry reads 30d; keep 60d
     # #157 P2: sanitized fleet crash aggregates (type + module:line only).
     # Fed by TaskHealthStore.record_failure below; aggregated into the daily
     # ping as crash_counts_24h. Pruned on boot (error_events never was — don't
@@ -355,6 +357,7 @@ async def lifespan(app_: FastAPI):
     # #156: construct aftercare store before CompletionWatcher so it can be
     # passed in directly (watcher judges each completed job's .srt on the fly).
     app_.state.aftercare = AfterCareStore(settings.db_path)
+    app_.state.aftercare.prune()  # #197: 365d, never touches unreviewed flags
     app_.state.watcher = CompletionWatcher(
         provenance=app_.state.provenance,
         caps_provider=lambda: getattr(app_.state, "subgen_caps", None),
@@ -507,6 +510,7 @@ async def lifespan(app_: FastAPI):
         audio_lang=app_.state.audio_lang,
     )
     app_.state.pending = PendingStore(settings.db_path)
+    app_.state.pending.prune()  # #197: resolved walks 30d; pending never pruned
     app_.state.onboarding = OnboardingStore(settings.db_path)
     app_.state.scheduler = Scheduler(
         schedule_store=app_.state.schedule,

--- a/src/subarr/error_store.py
+++ b/src/subarr/error_store.py
@@ -53,6 +53,20 @@ class ErrorStore:
             log.debug("error_store.counts_since failed: %s", e)
             return {}
 
+    def prune(self, days: int = 60) -> None:
+        """#197: telemetry reads a 30d window; rows beyond ~2x that are dead
+        weight on long-running installs. Run on boot. Best-effort."""
+        try:
+            import time
+
+            with self._lock:
+                self._conn.execute(
+                    "DELETE FROM error_events WHERE occurred_at < ?",
+                    (time.time() - days * 86400,),
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            log.debug("error_store.prune failed: %s", e)
+
     def close(self) -> None:
         with self._lock:
             self._conn.close()

--- a/src/subarr/pending_store.py
+++ b/src/subarr/pending_store.py
@@ -95,6 +95,20 @@ class PendingStore:
         with self._lock:
             self._conn.close()
 
+    def prune(self, days: int = 30) -> int:
+        """#197: resolved/expired manual-confirm walks are history once
+        decided; their decisions cascade with them (FK). PROTECTIVE RULE:
+        status='pending' walks are the user's open approval queue — never
+        pruned, regardless of age. Run on boot."""
+        import time
+
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM pending_walks WHERE created_at < ? AND status != ?",
+                (time.time() - days * 86400, STATUS_PENDING),
+            )
+            return cur.rowcount
+
     # ── create ────────────────────────────────────────────────────────
 
     def create_walk(self, *, considered: int, items: list[dict]) -> PendingWalk:

--- a/src/subarr/scan_store.py
+++ b/src/subarr/scan_store.py
@@ -254,6 +254,19 @@ class ScanStore:
             cur = self._conn.execute("DELETE FROM scans WHERE id = ?", (scan_id,))
             return cur.rowcount > 0
 
+    def prune(self, days: int = 180) -> int:
+        """#197: scan history is otherwise unbounded (one row per run,
+        forever). Anything this old — whatever its status — is history; a
+        six-month-old 'running' row is an orphan, not a job. Run on boot."""
+        import time
+
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM scans WHERE created_at < ?",
+                (time.time() - days * 86400,),
+            )
+            return cur.rowcount
+
     def delete_where_status_in(self, statuses: list[str], older_than: float | None = None) -> int:
         """Bulk-purge scans matching a status list (e.g. ['done', 'error',
         'skipped']). Optional age cutoff (epoch) restricts to old rows."""

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,124 @@
+"""#197 — every table has an explicit growth answer; these pin the prunes.
+
+Unbounded-growth tables get boot-time pruning. The protective rules matter
+more than the cutoffs: PENDING manual-confirm walks are never pruned (the
+user's open queue), and flagged-but-unreviewed aftercare rows are never
+pruned (the user's review backlog).
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def _db(tmp_path):
+    from subarr.migrate import run_migrations
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    return db
+
+
+OLD = time.time() - 400 * 86400
+FRESH = time.time() - 3600
+
+
+def test_error_events_prune(subarr_env, tmp_path):
+    from subarr.error_store import ErrorStore
+
+    s = ErrorStore(_db(tmp_path))
+    s.record("OldError", when=OLD)
+    s.record("FreshError", when=FRESH)
+    s.prune(days=60)
+    counts = s.counts_since(0)
+    assert "OldError" not in counts and "FreshError" in counts
+
+
+def test_scans_prune_keeps_recent(subarr_env, tmp_path):
+    import sqlite3
+
+    from subarr.scan_store import ScanStore
+
+    db = _db(tmp_path)
+    s = ScanStore(db)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO scans (id, created_at, status, paths_json, results_json) VALUES (?,?,?,?,?)",
+        ("old1", OLD, "completed", "[]", "[]"),
+    )
+    conn.execute(
+        "INSERT INTO scans (id, created_at, status, paths_json, results_json) VALUES (?,?,?,?,?)",
+        ("new1", FRESH, "completed", "[]", "[]"),
+    )
+    conn.commit()
+    conn.close()
+    s.prune(days=180)
+    assert s.get("old1") is None
+    assert s.get("new1") is not None
+
+
+def test_aftercare_prune_never_touches_unreviewed_flags(subarr_env, tmp_path):
+    import sqlite3
+
+    db = _db(tmp_path)
+    from subarr.aftercare_store import AfterCareStore
+
+    s = AfterCareStore(db)
+    conn = sqlite3.connect(str(db))
+
+    def ins(cid, completed, flagged, reviewed):
+        conn.execute(
+            "INSERT INTO aftercare_results (canonical_path, completed_at, composite, cue_count, "
+            "flagged, reviewed_at, source, created_at) VALUES (?,?,?,?,?,?,?,?)",
+            (cid, completed, 0.5, 100, flagged, reviewed, "subgenscan", completed),
+        )
+
+    ins("old-clean.mkv", OLD, 0, None)  # old, unflagged → prune
+    ins("old-flag-unreviewed.mkv", OLD, 1, None)  # old, flagged, NOT reviewed → KEEP
+    ins("old-flag-reviewed.mkv", OLD, 1, OLD + 60)  # old, flagged, reviewed → prune
+    ins("fresh.mkv", FRESH, 0, None)  # fresh → keep
+    conn.commit()
+    conn.close()
+
+    s.prune(days=365)
+
+    conn = sqlite3.connect(str(db))
+    left = {r[0] for r in conn.execute("SELECT canonical_path FROM aftercare_results").fetchall()}
+    conn.close()
+    assert left == {"old-flag-unreviewed.mkv", "fresh.mkv"}
+
+
+def test_pending_walks_prune_never_touches_pending(subarr_env, tmp_path):
+    import sqlite3
+
+    db = _db(tmp_path)
+    from subarr.pending_store import PendingStore
+
+    s = PendingStore(db)
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    def walk(wid, created, status):
+        conn.execute(
+            "INSERT INTO pending_walks (id, created_at, status) VALUES (?,?,?)",
+            (wid, created, status),
+        )
+        conn.execute(
+            "INSERT INTO pending_decisions (walk_id, item_json) VALUES (?,?)",
+            (wid, "{}"),
+        )
+
+    walk("old-resolved", OLD, "approved_all")  # prune (+ decisions via CASCADE)
+    walk("old-pending", OLD, "pending")  # KEEP — user's open queue
+    walk("fresh-resolved", FRESH, "rejected")  # keep (fresh)
+    conn.commit()
+    conn.close()
+
+    s.prune(days=30)
+
+    conn = sqlite3.connect(str(db))
+    walks = {r[0] for r in conn.execute("SELECT id FROM pending_walks").fetchall()}
+    decisions = conn.execute("SELECT COUNT(*) FROM pending_decisions").fetchone()[0]
+    conn.close()
+    assert walks == {"old-pending", "fresh-resolved"}
+    assert decisions == 2  # the old-resolved walk's decision went with it


### PR DESCRIPTION
Closes #197.

Boot-time prune for the four tables the audit found unbounded:

- `error_events` — 60d (telemetry reads a 30d window)
- `scans` — 180d, any status (an ancient "running" row is an orphan)
- `aftercare_results` — 365d, preserving the #95 passive-tuning window; flagged-but-unreviewed rows are NEVER pruned
- `pending_walks` (+ decisions via FK cascade) — 30d for resolved/expired; status=pending NEVER pruned

Full per-table audit verdicts posted on the issue. 4 new tests pin the protective rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)