### PR TITLE
Settings grid: Tautulli + Ollama versions

### DIFF
--- a/src/subarr/integrations/ollama.py
+++ b/src/subarr/integrations/ollama.py
@@ -88,6 +88,19 @@ class OllamaClient:
     async def aclose(self) -> None:
         await self._client.aclose()
 
+    async def version(self) -> str | None:
+        """GET /api/version — Ollama's own version string for the Settings
+        status grid. Best-effort: returns None on any failure (the tags()
+        probe owns reachability; version is cosmetic)."""
+        try:
+            r = await self._client.get("/api/version")
+            if r.status_code == 200:
+                v = (r.json() or {}).get("version")
+                return str(v) if v else None
+        except (httpx.HTTPError, ValueError):
+            pass
+        return None
+
     async def tags(self) -> dict[str, Any]:
         """GET /api/tags — list of installed models. Used for health probe."""
         try:

--- a/src/subarr/integrations/tautulli.py
+++ b/src/subarr/integrations/tautulli.py
@@ -38,9 +38,17 @@ class TautulliClient(IntegrationClient):
         return resp.get("data")
 
     async def status(self) -> dict[str, Any]:
-        # cmd=status returns {response:{result:success, data:null}} when up.
-        await self._cmd("status")
-        return {"result": "success"}
+        # cmd=get_tautulli_info doubles as the liveness check AND returns
+        # tautulli_version for the Settings status grid (cmd=status returned
+        # data:null, leaving Tautulli the only versionless row). Fail-soft to
+        # the old bare status cmd for ancient Tautulli builds.
+        try:
+            data = await self._cmd("get_tautulli_info")
+            version = (data or {}).get("tautulli_version")
+            return {"result": "success", "version": version}
+        except IntegrationError:
+            await self._cmd("status")
+            return {"result": "success"}
 
     async def history(self, length: int = 200, days: int | None = 30) -> list[dict[str, Any]]:
         """Return playback history rows (newest first).

--- a/src/subarr/routers/integrations.py
+++ b/src/subarr/routers/integrations.py
@@ -223,6 +223,7 @@ async def _probe(name: str, client, summary_kind: str = "version") -> dict[str, 
                 "name": name,
                 "online": True,
                 "configured": True,
+                "version": await client.version(),
                 "badges": {
                     "models": len(models),
                     "model_names": ", ".join(m.get("name", "?") for m in models[:3])

--- a/tests/test_integration_versions.py
+++ b/tests/test_integration_versions.py
@@ -1,0 +1,64 @@
+"""Settings status grid: Tautulli + Ollama report their versions.
+
+Tautulli's liveness check now uses cmd=get_tautulli_info (which carries
+tautulli_version) with a fail-soft fallback to the bare status cmd; Ollama
+gains a best-effort GET /api/version.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_tautulli_status_returns_version(subarr_env):
+    from subarr.integrations.tautulli import TautulliClient
+
+    c = TautulliClient.__new__(TautulliClient)
+
+    async def fake_cmd(cmd, **params):
+        assert cmd == "get_tautulli_info"
+        return {"tautulli_version": "2.15.2"}
+
+    c._cmd = fake_cmd
+    out = await c.status()
+    assert out == {"result": "success", "version": "2.15.2"}
+
+
+@pytest.mark.asyncio
+async def test_tautulli_status_falls_back_to_bare_status(subarr_env):
+    from subarr.integrations import IntegrationError
+    from subarr.integrations.tautulli import TautulliClient
+
+    c = TautulliClient.__new__(TautulliClient)
+    calls = []
+
+    async def fake_cmd(cmd, **params):
+        calls.append(cmd)
+        if cmd == "get_tautulli_info":
+            raise IntegrationError("tautulli get_tautulli_info: unknown cmd")
+        return None
+
+    c._cmd = fake_cmd
+    out = await c.status()
+    assert out == {"result": "success"}
+    assert calls == ["get_tautulli_info", "status"]
+
+
+@pytest.mark.asyncio
+async def test_ollama_version_best_effort(subarr_env):
+    from subarr.integrations.ollama import OllamaClient
+
+    c = OllamaClient(base_url="http://ollama.test")
+    c._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"version": "0.9.1"})),
+        base_url="http://ollama.test",
+    )
+    assert await c.version() == "0.9.1"
+
+    c._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(500)),
+        base_url="http://ollama.test",
+    )
+    assert await c.version() is None


### PR DESCRIPTION
The Tautulli and Ollama rows in the Settings integrations grid were the only ones without a version.

- Tautulli: liveness check switched from `cmd=status` (returns data:null) to `cmd=get_tautulli_info` which carries `tautulli_version`; fail-soft fallback to the bare status cmd for old builds.
- Ollama: best-effort `GET /api/version` added to the probe (never fails the probe; tags() owns reachability).

Live-verified on :9923 against real upstreams: tautulli v2.17.1, ollama 0.30.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)