### PR TITLE
#226: README 'choices that matter' call-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ docker compose up -d
 # Open http://localhost:9922, onboarding wizard auto-detects your stack.
 ```
 
+> **Two choices that matter, everything else the wizard defaults sensibly:**
+> 1. **Which subgen.** Use `ghcr.io/coaxk/subarr-subgen` for the full feature set (queue + cancel, the Tuning Lab, per-request language overrides, calibrated multi-chunk detection). Stock `mccloud/subgen` also works in compat mode with fewer features. Details in [I already have subgen](#i-already-have-subgen-what-do-i-do) below.
+> 2. **GPU.** If you have an Nvidia GPU, pass it to your subgen container so you can run a larger Whisper model (`large-v3`). This is the single biggest lever on subtitle quality. CPU works, just slower.
+
 The wizard tries to auto-detect Sonarr/Radarr/Bazarr/Tautulli/subgen on your existing Docker network and prefills URLs. Manual entry is available at every step as a safety net. Auto-detect plus manual fallback at every step is the design rule.
 
 After onboarding you can edit any integration's URL and API key (and the Plex token) directly in Settings, with test-connection and live apply. Values you set via env vars stay authoritative and show as read-only.


### PR DESCRIPTION
Closes #226. Adds a 5-line call-out directly under the install commands surfacing the only two consequential install decisions (subgen image choice + GPU passthrough — the latter was undocumented in the quickstart), and delegates everything else to the first-run wizard. Distilled from the r/radarr launch thread where install questions reduced to exactly these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)