### PR TITLE
fix: dev-tagged subarr-subgen builds don't nag a backward update

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -122,6 +122,19 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name
 log = logging.getLogger(__name__)
 
 
+def _subgen_update_version(release_tag: str | None) -> str | None:
+    """Current subarr-subgen version for the update check (#224 + dev-build
+    guard). Only a real release tag (e.g. 'v2026.05.3-r9') is comparable to
+    the repo's release tags. A `dev-<sha>` local/soak build (scripts/build.sh)
+    or a missing tag is unreleased and uncomparable, so it resolves to None —
+    the checker then shows the latest release but never claims an update,
+    rather than falsely nagging an upgrade that points BACKWARD to the last
+    release."""
+    if not release_tag or release_tag.startswith("dev"):
+        return None
+    return release_tag
+
+
 def _arena_fallback_lang(app_, media_path):
     """Arena fallback source language when Whisper robust detection is
     inconclusive: the file's KNOWN spoken/audio language.
@@ -599,7 +612,9 @@ async def lifespan(app_: FastAPI):
     # never claims an update (missed_releases/update_available both treat
     # None as "don't guess"). Vanilla subgen comparison is equally broken
     # against our repo's tags — #223 redoes that flow properly.
-    _subgen_current = getattr(_subgen_caps, "release_tag", None) if _subgen_caps else None
+    _subgen_current = _subgen_update_version(
+        getattr(_subgen_caps, "release_tag", None) if _subgen_caps else None
+    )
     from .update_checker import UpdateChecker
 
     current_versions = {

--- a/tests/test_subgen_update_version.py
+++ b/tests/test_subgen_update_version.py
@@ -1,0 +1,32 @@
+"""#224 follow-up: a dev/soak subarr-subgen build must not nag an update.
+
+A locally-built image bakes a `dev-<sha>` release tag (scripts/build.sh).
+That can't be ranked against the repo's date-style release tags, so the
+update check must treat it as unknown (None) rather than reporting a
+difference — which would falsely point the user BACKWARD to the last
+release.
+"""
+
+from __future__ import annotations
+
+
+def test_real_release_tag_passes_through(subarr_env):
+    from subarr.app import _subgen_update_version
+
+    assert _subgen_update_version("v2026.05.3-r9") == "v2026.05.3-r9"
+    assert _subgen_update_version("v2026.05.3-r10") == "v2026.05.3-r10"
+
+
+def test_dev_build_tag_resolves_to_none(subarr_env):
+    from subarr.app import _subgen_update_version
+
+    # scripts/build.sh stamps RELEASE_TAG=dev-<short-sha>
+    assert _subgen_update_version("dev-5db497b") is None
+    assert _subgen_update_version("dev") is None
+
+
+def test_missing_tag_resolves_to_none(subarr_env):
+    from subarr.app import _subgen_update_version
+
+    assert _subgen_update_version(None) is None
+    assert _subgen_update_version("") is None


### PR DESCRIPTION
Your soak box (and any locally-built subarr-subgen) bakes a `dev-<sha>` release tag via scripts/build.sh. The #224 update comparison ranked `dev-5db497b` against the latest release `v2026.05.3-r8`, found them different, and reported "update available" — pointing BACKWARD to r8 even though the dev build is the newer r9 candidate.

Fix: a `dev-` (or missing) tag is an unreleased, uncomparable version → resolve to None, the same "unknown current → show latest, never claim an update" bucket #224 established. Extracted to a `_subgen_update_version` helper with tests.

Released images (r9+) carry proper `v2026.05.3-rN` tags and compare correctly — unaffected. Verified live on :9923: the subarr-subgen update badge cleared (has_update False).