### PR TITLE
ci: auto-create the GitHub Release from CHANGELOG (#229)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,35 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Auto-create the GitHub Release on a version tag, AFTER the image publishes
+  # (#229). A bare tag with no Release shows an empty title in releases.atom,
+  # which blanks the #203 update nudge fleet-wide — so the title must be
+  # non-empty and descriptive. Tag pushes only; idempotent (skips if the
+  # release already exists, e.g. a re-run or a manual pre-create).
+  release:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+    env:
+      GH_TOKEN: ${{ github.token }} # gh CLI auth
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: create GitHub Release from CHANGELOG (idempotent)
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "release $TAG already exists — skipping (idempotent)"
+            exit 0
+          fi
+          # Derives a non-empty title (the #203 contract) and writes the body;
+          # the script is stdlib-only, so the runner's python3 is enough.
+          TITLE="$(python3 scripts/changelog_section.py "$TAG" --body-out "$RUNNER_TEMP/notes.md")"
+          echo "release title: $TITLE"
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" --notes-file "$RUNNER_TEMP/notes.md" --verify-tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,21 +8,19 @@ lives in [docs/release-procedure.md](docs/release-procedure.md). Short form:
 3. Tag + push: `git tag -a v1.x.y -m "v1.x.y — summary" && git push origin v1.x.y`
 4. `release.yml` (workflow name `build-and-publish`) runs tests (hard gate),
    then builds + pushes the **multi-arch** (amd64 + arm64) image to GHCR as
-   `:1.x.y` / `:1.x` / `:1` / `:latest`. **It does NOT create a GitHub
-   Release** — that is a manual step (5), and skipping it is silent: the
-   tag still appears in `releases.atom` but with an empty title, so the
-   #203 update nudge shows blank entries to the whole fleet. (This bit us
-   on 1.5.2–1.5.4; see #229.)
-5. **Create the GitHub Release yourself** from the changelog section:
-   ```bash
-   gh release create v1.x.y --title "v1.x.y - <descriptive summary>" \
-     --notes-file <notes.md> --latest
-   ```
-   The release **title** doubles as the in-app update nudge's upgrade digest
-   (#203), so make it descriptive ("v1.5.0 - multi-library + arm64"), not the
-   bare tag. Verify it landed: `gh api repos/coaxk/subarr/releases --jq
-   '.[0] | .tag_name + " " + .name'` should show your title, not an empty
-   string.
+   `:1.x.y` / `:1.x` / `:1` / `:latest`, and finally **auto-creates the GitHub
+   Release** (#229). The `release` job derives a descriptive title from the
+   `CHANGELOG.md` section for the tag (`vX.Y.Z — <first bold phrase>`) and uses
+   that section as the body. This is what feeds the #203 update nudge, so it
+   must be non-empty — the job guarantees a usable title even if the changelog
+   section is missing. Idempotent: it skips if a release already exists.
+   - **Therefore: get the `CHANGELOG.md` entry right (step 2).** The title +
+     body come straight from it. The first **bold** phrase in the section
+     becomes the title suffix, so lead the section's notable line with a bold
+     phrase like `**Guided subgen setup.**`.
+5. **Verify the release landed** (no manual create needed anymore):
+   `gh api repos/coaxk/subarr/releases --jq '.[0] | .tag_name + " " + .name'`
+   should show your derived title within a minute, not an empty string.
 6. After a 7-day clean soak, promote to `:stable` (see the full doc).
 
 Telemetry/worker side has its own runbook:

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Extract a CHANGELOG.md section and derive a release title for a version tag.
+
+Used by release.yml (#229) to auto-create the GitHub Release on tag push. The
+#203 update nudge + Settings → Updates "notes" link read releases.atom, so a
+release MUST have a non-empty, descriptive title — a bare tag renders blank
+digest entries fleet-wide. This helper guarantees a usable title even when the
+changelog section is missing.
+
+CLI:
+  changelog_section.py <version> [--changelog CHANGELOG.md] --body-out FILE
+    Writes the changelog body (or a fallback) to FILE; prints the title to
+    stdout for the workflow to capture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+
+def _normalize(version: str) -> str:
+    """Strip a leading 'v' so 'v1.6.0' and '1.6.0' are equivalent."""
+    return version[1:] if version.startswith("v") else version
+
+
+def extract_section(changelog: str, version: str) -> str:
+    """Return the body of the `## [<version>] ...` section, or "" if absent.
+
+    Bounded below by the next top-level `## ` heading (the next version) or EOF,
+    so one release's notes never bleed into another's.
+    """
+    ver = _normalize(version)
+    lines = changelog.splitlines()
+    # Heading looks like: ## [1.6.0] - 2026-06-14
+    head_re = re.compile(r"^##\s+\[" + re.escape(ver) + r"\]")
+    next_re = re.compile(r"^##\s+")
+
+    start = None
+    for i, line in enumerate(lines):
+        if head_re.match(line):
+            start = i + 1
+            break
+    if start is None:
+        return ""
+
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if next_re.match(lines[j]):
+            end = j
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def derive_title(section: str, version: str) -> str:
+    """Build "v<version> — <first bold phrase>", or "v<version>" if none.
+
+    The bold phrase is the first `**...**` run in the section, with a trailing
+    issue ref `(#NNN)` and trailing punctuation stripped.
+    """
+    ver = _normalize(version)
+    base = f"v{ver}"
+    m = re.search(r"\*\*(.+?)\*\*", section)
+    if not m:
+        return base
+    phrase = m.group(1)
+    phrase = re.sub(r"\s*\(#\d+\)", "", phrase)  # drop "(#231)"
+    phrase = phrase.strip(" .:;,—-")
+    return f"{base} — {phrase}" if phrase else base
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("version", help="tag or version, e.g. v1.6.0 or 1.6.0")
+    ap.add_argument("--changelog", default="CHANGELOG.md")
+    ap.add_argument("--body-out", required=True, help="file to write the release body to")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.changelog, encoding="utf-8") as fh:
+            changelog = fh.read()
+    except OSError as e:
+        print(f"could not read {args.changelog}: {e}", file=sys.stderr)
+        changelog = ""
+
+    section = extract_section(changelog, args.version)
+    ver = _normalize(args.version)
+    body = section or (
+        f"Release v{ver}.\n\nSee [CHANGELOG.md]"
+        "(https://github.com/coaxk/subarr/blob/main/CHANGELOG.md) for details."
+    )
+    with open(args.body_out, "w", encoding="utf-8") as fh:
+        fh.write(body + "\n")
+
+    print(derive_title(section, args.version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_changelog_section.py
+++ b/tests/test_changelog_section.py
@@ -1,0 +1,80 @@
+"""#229: release.yml auto-creates the GitHub Release from CHANGELOG.md.
+
+The #203 update nudge reads releases.atom, so the derived title must never be
+empty and must not bleed one version's notes into another's. These tests pin
+the extraction + title-derivation logic the release job depends on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load scripts/changelog_section.py by path (it isn't an installed module).
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "changelog_section.py"
+_spec = importlib.util.spec_from_file_location("changelog_section", _SCRIPT)
+cs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cs)
+
+
+SAMPLE = """\
+# Changelog
+
+## [1.6.0] - 2026-06-14
+
+Headline: subarr now configures Whisper for your hardware.
+
+### Added
+- **Guided subgen setup (#231).** A detect-guide-apply flow.
+- **No-auth warning banner (#238).** Dismissible.
+
+## [1.5.4] - 2026-06-13
+
+### Fixed
+- **Log injection (CWE-117, #239).** Scrubbed.
+
+## [1.5.0] - 2026-06-11
+Multi-arch images.
+"""
+
+
+class TestExtractSection:
+    def test_extracts_only_the_target_version(self):
+        sec = cs.extract_section(SAMPLE, "1.6.0")
+        assert "Guided subgen setup" in sec
+        assert "No-auth warning banner" in sec
+        # must NOT bleed into the next version's notes
+        assert "Log injection" not in sec
+        assert "[1.5.4]" not in sec
+
+    def test_middle_version_is_bounded_both_sides(self):
+        sec = cs.extract_section(SAMPLE, "1.5.4")
+        assert "Log injection" in sec
+        assert "Guided subgen setup" not in sec  # not the one above
+        assert "Multi-arch" not in sec  # not the one below
+
+    def test_accepts_v_prefix(self):
+        assert cs.extract_section(SAMPLE, "v1.6.0") == cs.extract_section(SAMPLE, "1.6.0")
+
+    def test_unknown_version_returns_empty(self):
+        assert cs.extract_section(SAMPLE, "9.9.9") == ""
+
+
+class TestDeriveTitle:
+    def test_uses_first_bold_phrase_and_strips_issue_ref(self):
+        sec = cs.extract_section(SAMPLE, "1.6.0")
+        assert cs.derive_title(sec, "1.6.0") == "v1.6.0 — Guided subgen setup"
+
+    def test_strips_trailing_punctuation(self):
+        assert cs.derive_title("- **Hotfix:** stuff", "1.5.5") == "v1.5.5 — Hotfix"
+
+    def test_falls_back_to_bare_version_without_bold(self):
+        assert cs.derive_title("just prose, no bold", "1.5.0") == "v1.5.0"
+
+    def test_empty_section_falls_back_to_bare_version(self):
+        assert cs.derive_title("", "1.5.0") == "v1.5.0"
+
+    def test_title_is_never_empty(self):
+        # the #203 contract — whatever we feed it, a usable title comes out
+        for ver in ("1.0.0", "2.3.4", "v9.9.9"):
+            assert cs.derive_title("", ver).strip()


### PR DESCRIPTION
Closes #229.

release.yml built + pushed the image but never created a GitHub Release - releases were hand-made, and missed entirely for 1.5.2/1.5.3/1.5.4. A bare tag shows an empty title in `releases.atom`, which blanks the #203 update nudge fleet-wide.

**Change:** a tag-only `release` job runs after `publish` and creates the Release via native `gh` (no third-party action - consistent with the supply-chain posture). Title + body come from the matching `CHANGELOG.md` section via `scripts/changelog_section.py`:
- **title** = `vX.Y.Z — <first bold phrase>` (the #203 contract: never empty; falls back to bare version)
- **body** = the changelog section (or a generic note if absent)
- **idempotent**: skips if a release already exists

**TDD:** `tests/test_changelog_section.py` (9 cases) covers no cross-version bleed, v-prefix tolerance, bold-phrase extraction, issue-ref + punctuation stripping, and the never-empty guarantee. `RELEASING.md` updated (manual create step removed, verify step kept).

**Verification scope:** the parsing logic is unit-tested + smoke-checked against the live CHANGELOG (v1.6.0 -> \1.6.0 — Guided subgen setup\, v1.5.4 bounded correctly). The gh-create integration runs on the next real tag.