### PR TITLE
feat(aftercare): existing-subtitle audit engine (#216 phase 1)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -60,3 +60,23 @@ jobs:
             echo "::error::Frontend bundles are stale. Run 'npm run build:frontend' locally and commit the result."
             exit 1
           fi
+
+  # Frontend unit tests (#201). Pure-logic coverage (formatters, language
+  # normalization, filters, payload mappers) — the bug class behind #193/#188,
+  # which had zero tests. Runs beside the drift check; vitest, node env.
+  unit:
+    name: frontend unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm run test:frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,35 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Auto-create the GitHub Release on a version tag, AFTER the image publishes
+  # (#229). A bare tag with no Release shows an empty title in releases.atom,
+  # which blanks the #203 update nudge fleet-wide — so the title must be
+  # non-empty and descriptive. Tag pushes only; idempotent (skips if the
+  # release already exists, e.g. a re-run or a manual pre-create).
+  release:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+    env:
+      GH_TOKEN: ${{ github.token }} # gh CLI auth
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: create GitHub Release from CHANGELOG (idempotent)
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "release $TAG already exists — skipping (idempotent)"
+            exit 0
+          fi
+          # Derives a non-empty title (the #203 contract) and writes the body;
+          # the script is stdlib-only, so the runner's python3 is enough.
+          TITLE="$(python3 scripts/changelog_section.py "$TAG" --body-out "$RUNNER_TEMP/notes.md")"
+          echo "release title: $TITLE"
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" --notes-file "$RUNNER_TEMP/notes.md" --verify-tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,21 +8,19 @@ lives in [docs/release-procedure.md](docs/release-procedure.md). Short form:
 3. Tag + push: `git tag -a v1.x.y -m "v1.x.y — summary" && git push origin v1.x.y`
 4. `release.yml` (workflow name `build-and-publish`) runs tests (hard gate),
    then builds + pushes the **multi-arch** (amd64 + arm64) image to GHCR as
-   `:1.x.y` / `:1.x` / `:1` / `:latest`. **It does NOT create a GitHub
-   Release** — that is a manual step (5), and skipping it is silent: the
-   tag still appears in `releases.atom` but with an empty title, so the
-   #203 update nudge shows blank entries to the whole fleet. (This bit us
-   on 1.5.2–1.5.4; see #229.)
-5. **Create the GitHub Release yourself** from the changelog section:
-   ```bash
-   gh release create v1.x.y --title "v1.x.y - <descriptive summary>" \
-     --notes-file <notes.md> --latest
-   ```
-   The release **title** doubles as the in-app update nudge's upgrade digest
-   (#203), so make it descriptive ("v1.5.0 - multi-library + arm64"), not the
-   bare tag. Verify it landed: `gh api repos/coaxk/subarr/releases --jq
-   '.[0] | .tag_name + " " + .name'` should show your title, not an empty
-   string.
+   `:1.x.y` / `:1.x` / `:1` / `:latest`, and finally **auto-creates the GitHub
+   Release** (#229). The `release` job derives a descriptive title from the
+   `CHANGELOG.md` section for the tag (`vX.Y.Z — <first bold phrase>`) and uses
+   that section as the body. This is what feeds the #203 update nudge, so it
+   must be non-empty — the job guarantees a usable title even if the changelog
+   section is missing. Idempotent: it skips if a release already exists.
+   - **Therefore: get the `CHANGELOG.md` entry right (step 2).** The title +
+     body come straight from it. The first **bold** phrase in the section
+     becomes the title suffix, so lead the section's notable line with a bold
+     phrase like `**Guided subgen setup.**`.
+5. **Verify the release landed** (no manual create needed anymore):
+   `gh api repos/coaxk/subarr/releases --jq '.[0] | .tag_name + " " + .name'`
+   should show your derived title within a minute, not an empty string.
 6. After a 7-day clean soak, promote to `:stable` (see the full doc).
 
 Telemetry/worker side has its own runbook:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,42 @@
       "name": "subarr-frontend-build",
       "version": "0.0.0",
       "devDependencies": {
-        "esbuild": "0.28.1"
+        "esbuild": "0.28.1",
+        "vitest": "4.1.9"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -453,6 +488,506 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -493,6 +1028,721 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "scripts": {
     "build:frontend": "node scripts/build-frontend.mjs",
     "dev:frontend": "node scripts/build-frontend.mjs --watch",
-    "check:frontend": "node scripts/build-frontend.mjs && git diff --exit-code -- 'src/subarr/static/v1/home-hifi/*.bundle.js' 'src/subarr/static/v1/home-hifi/*.html'"
+    "check:frontend": "node scripts/build-frontend.mjs && git diff --exit-code -- 'src/subarr/static/v1/home-hifi/*.bundle.js' 'src/subarr/static/v1/home-hifi/*.html'",
+    "test:frontend": "vitest run"
   },
   "devDependencies": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "vitest": "4.1.9"
   }
 }

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Extract a CHANGELOG.md section and derive a release title for a version tag.
+
+Used by release.yml (#229) to auto-create the GitHub Release on tag push. The
+#203 update nudge + Settings → Updates "notes" link read releases.atom, so a
+release MUST have a non-empty, descriptive title — a bare tag renders blank
+digest entries fleet-wide. This helper guarantees a usable title even when the
+changelog section is missing.
+
+CLI:
+  changelog_section.py <version> [--changelog CHANGELOG.md] --body-out FILE
+    Writes the changelog body (or a fallback) to FILE; prints the title to
+    stdout for the workflow to capture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+
+def _normalize(version: str) -> str:
+    """Strip a leading 'v' so 'v1.6.0' and '1.6.0' are equivalent."""
+    return version[1:] if version.startswith("v") else version
+
+
+def extract_section(changelog: str, version: str) -> str:
+    """Return the body of the `## [<version>] ...` section, or "" if absent.
+
+    Bounded below by the next top-level `## ` heading (the next version) or EOF,
+    so one release's notes never bleed into another's.
+    """
+    ver = _normalize(version)
+    lines = changelog.splitlines()
+    # Heading looks like: ## [1.6.0] - 2026-06-14
+    head_re = re.compile(r"^##\s+\[" + re.escape(ver) + r"\]")
+    next_re = re.compile(r"^##\s+")
+
+    start = None
+    for i, line in enumerate(lines):
+        if head_re.match(line):
+            start = i + 1
+            break
+    if start is None:
+        return ""
+
+    end = len(lines)
+    for j in range(start, len(lines)):
+        if next_re.match(lines[j]):
+            end = j
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def derive_title(section: str, version: str) -> str:
+    """Build "v<version> — <first bold phrase>", or "v<version>" if none.
+
+    The bold phrase is the first `**...**` run in the section, with a trailing
+    issue ref `(#NNN)` and trailing punctuation stripped.
+    """
+    ver = _normalize(version)
+    base = f"v{ver}"
+    m = re.search(r"\*\*(.+?)\*\*", section)
+    if not m:
+        return base
+    phrase = m.group(1)
+    phrase = re.sub(r"\s*\(#\d+\)", "", phrase)  # drop "(#231)"
+    phrase = phrase.strip(" .:;,—-")
+    return f"{base} — {phrase}" if phrase else base
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("version", help="tag or version, e.g. v1.6.0 or 1.6.0")
+    ap.add_argument("--changelog", default="CHANGELOG.md")
+    ap.add_argument("--body-out", required=True, help="file to write the release body to")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.changelog, encoding="utf-8") as fh:
+            changelog = fh.read()
+    except OSError as e:
+        print(f"could not read {args.changelog}: {e}", file=sys.stderr)
+        changelog = ""
+
+    section = extract_section(changelog, args.version)
+    ver = _normalize(args.version)
+    body = section or (
+        f"Release v{ver}.\n\nSee [CHANGELOG.md]"
+        "(https://github.com/coaxk/subarr/blob/main/CHANGELOG.md) for details."
+    )
+    with open(args.body_out, "w", encoding="utf-8") as fh:
+        fh.write(body + "\n")
+
+    print(derive_title(section, args.version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vitest.setup.js
+++ b/scripts/vitest.setup.js
@@ -1,0 +1,18 @@
+// React + ReactDOM are runtime CDN globals (the IIFE bundles leave them
+// undefined-at-build, resolved on window). Our unit tests exercise pure
+// logic, not rendering — but importing a .jsx module would ReferenceError if
+// anything touches React/ReactDOM at module scope. Stub minimal globals so
+// imports are safe without pulling React into devDependencies.
+globalThis.React = globalThis.React || {
+  createElement: () => null,
+  Fragment: Symbol('React.Fragment'),
+  useState: () => [undefined, () => {}],
+  useEffect: () => {},
+  useMemo: (fn) => fn(),
+  useCallback: (fn) => fn,
+  useRef: () => ({ current: null }),
+  createContext: () => ({ Provider: () => null, Consumer: () => null }),
+};
+globalThis.ReactDOM = globalThis.ReactDOM || {
+  createRoot: () => ({ render() {}, unmount() {} }),
+};

--- a/src/subarr/existing_audit.py
+++ b/src/subarr/existing_audit.py
@@ -1,0 +1,128 @@
+"""#216: audit EXISTING external subtitles with the aftercare scorer.
+
+Today the aftercare scorer (#156) only fires on subgen completions via the
+CompletionWatcher. This runner points the SAME scorer at the external sidecar
+SRTs a user already has (Bazarr/scene/provider subs), so subarr can surface
+bad pre-existing subs — sync drift, scene-release ad boilerplate, suspected
+machine translation — and offer regenerate-from-audio. It turns subarr from
+"fill the gaps" into "audit everything you have".
+
+The runner is deliberately dependency-injected (read/probe/evaluate/record are
+passed in) so the orchestration is unit-testable without a filesystem or DB;
+the router wires the real implementations.
+
+Boundaries (issue #216): we never fix sync in place (that's subsyncarr) — the
+answer is regenerate-from-audio — and we never touch Bazarr's provider logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .aftercare import AftercareEvaluation
+
+log = logging.getLogger(__name__)
+
+# Source tag stored on aftercare_results rows from this runner, so the review
+# UI's latest-per-path + filtering work unchanged and these never mix with
+# completion-watcher rows.
+EXISTING_AUDIT_SOURCE = "existing_audit"
+
+# subarr-subgen writes its sidecars with this infix (e.g. Show.subgen.en.srt).
+# A pre-existing external sub never carries it — a cheap first-pass skip.
+_SUBGEN_MARKER = ".subgen."
+
+
+def is_subarr_generated(srt_path: str, generated_paths: set[str]) -> bool:
+    """True if this SRT is subarr's own output rather than a pre-existing
+    external sub. Two signals: the subgen filename marker, or an exact match
+    in the provenance set (paths subarr has transcribed)."""
+    if _SUBGEN_MARKER in srt_path:
+        return True
+    return srt_path in generated_paths
+
+
+def discover_external_srts(roots: Iterable[Path], *, max_depth: int | None = None) -> list[str]:
+    """Walk each library root for .srt sidecars. Skips symlinks (avoid escaping
+    the root / loops) and unreadable subtrees. Returns sorted absolute paths.
+
+    This is the only filesystem walk the audit does — the same rglob the
+    sidecar scanner uses — so the runner downstream stays pure/injectable.
+    """
+    found: set[str] = set()
+    for root in roots:
+        root = Path(root)
+        if not root.is_dir():
+            continue
+        root_depth = len(root.parts)
+        for srt in root.rglob("*.srt"):
+            try:
+                if srt.is_symlink():
+                    continue
+                if max_depth is not None and (len(srt.parts) - root_depth) > max_depth:
+                    continue
+                found.add(str(srt))
+            except OSError as e:  # unreadable entry — skip, don't abort the walk
+                log.debug("existing-audit discover: skipping %s (%s)", srt, e)
+    return sorted(found)
+
+
+@dataclass
+class AuditSummary:
+    total: int = 0  # paths considered
+    scanned: int = 0  # external subs actually scored
+    skipped: int = 0  # subarr-generated, skipped
+    flagged: int = 0  # scored AND flagged by aftercare
+    errors: int = 0  # unreadable / failed mid-file
+
+
+async def run_existing_audit(
+    srt_paths: Iterable[str],
+    *,
+    generated_paths: set[str],
+    read_text: Callable[[str], str],
+    probe_duration: Callable[[str], Awaitable[float | None]],
+    evaluate: Callable[[str, float | None], AftercareEvaluation],
+    record: Callable[..., None],
+    now: float,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> AuditSummary:
+    """Score each external sidecar SRT and store the result.
+
+    For each path: skip subarr's own output; otherwise read it, fetch the
+    media duration (enables the sync-overrun check), score it, and persist
+    under EXISTING_AUDIT_SOURCE. A single bad file is counted and skipped, not
+    fatal — a library walk must finish. `on_progress(done, total)` fires once
+    per path (skips included) so a long walk can report live.
+    """
+    paths = list(srt_paths)
+    summary = AuditSummary(total=len(paths))
+
+    for i, srt_path in enumerate(paths, start=1):
+        try:
+            if is_subarr_generated(srt_path, generated_paths):
+                summary.skipped += 1
+                continue
+            text = read_text(srt_path)
+            duration = await probe_duration(srt_path)
+            evaluation = evaluate(text, duration)
+            record(
+                canonical_path=srt_path,
+                completed_at=now,
+                evaluation=evaluation,
+                source=EXISTING_AUDIT_SOURCE,
+            )
+            summary.scanned += 1
+            if evaluation.flagged:
+                summary.flagged += 1
+        except Exception as e:  # noqa: BLE001 - one bad sub must not abort the walk
+            summary.errors += 1
+            log.warning("existing-audit: skipping %s (%s)", srt_path, e)
+        finally:
+            if on_progress is not None:
+                on_progress(i, len(paths))
+
+    return summary

--- a/src/subarr/static/v1/home-hifi/__tests__/atoms.test.js
+++ b/src/subarr/static/v1/home-hifi/__tests__/atoms.test.js
@@ -1,0 +1,77 @@
+// #201: first frontend unit tests. Pin the pure helpers in atoms.jsx —
+// language normalization is core (the "FR FR" / mislabelled-language bug
+// territory) and ran with zero coverage until now.
+import { describe, it, expect } from 'vitest';
+import { normalizeLang, langName, fmtTime, genSpark } from '../atoms.jsx';
+
+describe('normalizeLang', () => {
+  it('passes through canonical ISO-639-1 codes', () => {
+    expect(normalizeLang('en')).toBe('en');
+    expect(normalizeLang('fr')).toBe('fr');
+    expect(normalizeLang('ja')).toBe('ja');
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(normalizeLang('  EN ')).toBe('en');
+    expect(normalizeLang('Fr')).toBe('fr');
+  });
+
+  it('resolves 3-letter and name aliases to ISO-639-1', () => {
+    expect(normalizeLang('eng')).toBe('en');
+    expect(normalizeLang('english')).toBe('en');
+    expect(normalizeLang('jpn')).toBe('ja');
+    expect(normalizeLang('french')).toBe('fr');
+  });
+
+  it('returns empty string for falsy input (no crash)', () => {
+    expect(normalizeLang('')).toBe('');
+    expect(normalizeLang(null)).toBe('');
+    expect(normalizeLang(undefined)).toBe('');
+  });
+
+  it('passes an unknown 2-letter code through unchanged', () => {
+    expect(normalizeLang('zz')).toBe('zz');
+  });
+});
+
+describe('langName', () => {
+  it('maps codes and aliases to the language name', () => {
+    expect(langName('en')).toBe('English');
+    expect(langName('ja')).toBe('Japanese');
+    expect(langName('jpn')).toBe('Japanese');
+    expect(langName('french')).toBe('French');
+  });
+
+  it('uppercases an unknown value rather than inventing a name', () => {
+    expect(langName('zz')).toBe('ZZ');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(langName('')).toBe('');
+    expect(langName(null)).toBe('');
+  });
+});
+
+describe('fmtTime', () => {
+  it('zero-pads h:m:s', () => {
+    const d = new Date(2026, 5, 16, 9, 5, 3);
+    expect(fmtTime(d)).toBe('09:05:03');
+  });
+
+  it('renders a late time without padding artifacts', () => {
+    const d = new Date(2026, 5, 16, 23, 59, 59);
+    expect(fmtTime(d)).toBe('23:59:59');
+  });
+});
+
+describe('genSpark', () => {
+  it('produces exactly n points, all non-negative', () => {
+    const pts = genSpark(24, 10, 4);
+    expect(pts).toHaveLength(24);
+    expect(pts.every((v) => v >= 0)).toBe(true);
+  });
+
+  it('returns an empty array for zero length', () => {
+    expect(genSpark(0, 10, 4)).toEqual([]);
+  });
+});

--- a/tests/test_changelog_section.py
+++ b/tests/test_changelog_section.py
@@ -1,0 +1,80 @@
+"""#229: release.yml auto-creates the GitHub Release from CHANGELOG.md.
+
+The #203 update nudge reads releases.atom, so the derived title must never be
+empty and must not bleed one version's notes into another's. These tests pin
+the extraction + title-derivation logic the release job depends on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Load scripts/changelog_section.py by path (it isn't an installed module).
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "changelog_section.py"
+_spec = importlib.util.spec_from_file_location("changelog_section", _SCRIPT)
+cs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cs)
+
+
+SAMPLE = """\
+# Changelog
+
+## [1.6.0] - 2026-06-14
+
+Headline: subarr now configures Whisper for your hardware.
+
+### Added
+- **Guided subgen setup (#231).** A detect-guide-apply flow.
+- **No-auth warning banner (#238).** Dismissible.
+
+## [1.5.4] - 2026-06-13
+
+### Fixed
+- **Log injection (CWE-117, #239).** Scrubbed.
+
+## [1.5.0] - 2026-06-11
+Multi-arch images.
+"""
+
+
+class TestExtractSection:
+    def test_extracts_only_the_target_version(self):
+        sec = cs.extract_section(SAMPLE, "1.6.0")
+        assert "Guided subgen setup" in sec
+        assert "No-auth warning banner" in sec
+        # must NOT bleed into the next version's notes
+        assert "Log injection" not in sec
+        assert "[1.5.4]" not in sec
+
+    def test_middle_version_is_bounded_both_sides(self):
+        sec = cs.extract_section(SAMPLE, "1.5.4")
+        assert "Log injection" in sec
+        assert "Guided subgen setup" not in sec  # not the one above
+        assert "Multi-arch" not in sec  # not the one below
+
+    def test_accepts_v_prefix(self):
+        assert cs.extract_section(SAMPLE, "v1.6.0") == cs.extract_section(SAMPLE, "1.6.0")
+
+    def test_unknown_version_returns_empty(self):
+        assert cs.extract_section(SAMPLE, "9.9.9") == ""
+
+
+class TestDeriveTitle:
+    def test_uses_first_bold_phrase_and_strips_issue_ref(self):
+        sec = cs.extract_section(SAMPLE, "1.6.0")
+        assert cs.derive_title(sec, "1.6.0") == "v1.6.0 — Guided subgen setup"
+
+    def test_strips_trailing_punctuation(self):
+        assert cs.derive_title("- **Hotfix:** stuff", "1.5.5") == "v1.5.5 — Hotfix"
+
+    def test_falls_back_to_bare_version_without_bold(self):
+        assert cs.derive_title("just prose, no bold", "1.5.0") == "v1.5.0"
+
+    def test_empty_section_falls_back_to_bare_version(self):
+        assert cs.derive_title("", "1.5.0") == "v1.5.0"
+
+    def test_title_is_never_empty(self):
+        # the #203 contract — whatever we feed it, a usable title comes out
+        for ver in ("1.0.0", "2.3.4", "v9.9.9"):
+            assert cs.derive_title("", ver).strip()

--- a/tests/test_existing_audit.py
+++ b/tests/test_existing_audit.py
@@ -1,0 +1,155 @@
+"""#216 Phase 1: audit EXISTING external subtitles with the aftercare scorer.
+
+These pin the runner's orchestration — skip subarr's own output, score the
+rest, store under the existing_audit source, count progress, survive bad
+files — without touching the filesystem or DB (deps are injected).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from subarr import existing_audit as ea
+from subarr.aftercare import AftercareEvaluation
+
+
+def _ev(flagged: bool, composite: float = 0.9) -> AftercareEvaluation:
+    return AftercareEvaluation(
+        composite=composite, cue_count=10, flagged=flagged, readability=None, signals=None
+    )
+
+
+class TestDiscoverExternalSrts:
+    def test_finds_srts_recursively_skips_non_srt(self, tmp_path):
+        (tmp_path / "Show.en.srt").write_text("x")
+        sub = tmp_path / "Season 1"
+        sub.mkdir()
+        (sub / "Ep.en.srt").write_text("x")
+        (tmp_path / "notes.txt").write_text("x")
+        found = ea.discover_external_srts([tmp_path])
+        assert found == sorted([str(tmp_path / "Show.en.srt"), str(sub / "Ep.en.srt")])
+
+    def test_missing_root_is_skipped_not_fatal(self, tmp_path):
+        (tmp_path / "A.en.srt").write_text("x")
+        found = ea.discover_external_srts([tmp_path, tmp_path / "does-not-exist"])
+        assert found == [str(tmp_path / "A.en.srt")]
+
+    def test_dedups_across_overlapping_roots(self, tmp_path):
+        (tmp_path / "A.en.srt").write_text("x")
+        found = ea.discover_external_srts([tmp_path, tmp_path])
+        assert found == [str(tmp_path / "A.en.srt")]
+
+
+class TestIsSubarrGenerated:
+    def test_subgen_filename_marker_is_ours(self):
+        assert ea.is_subarr_generated("/m/Show.S01E01.subgen.large-v3.en.srt", set())
+
+    def test_path_in_provenance_set_is_ours(self):
+        p = "/m/Show.S01E01.en.srt"
+        assert ea.is_subarr_generated(p, {p})
+
+    def test_plain_external_sub_is_not_ours(self):
+        assert not ea.is_subarr_generated("/m/Show.S01E01.en.srt", set())
+
+
+@pytest.mark.asyncio
+async def test_skips_generated_scores_and_stores_the_rest():
+    paths = [
+        "/m/A.subgen.en.srt",  # ours (marker) -> skip
+        "/m/B.en.srt",  # external, clean
+        "/m/C.en.srt",  # external, flagged
+    ]
+    flags = {"/m/B.en.srt": False, "/m/C.en.srt": True}
+    stored: list[dict] = []
+
+    async def probe(_p):
+        return 1500.0
+
+    # read_text returns the path so the fake evaluator can key the flag off it
+    summary = await ea.run_existing_audit(
+        paths,
+        generated_paths=set(),
+        read_text=lambda p: p,
+        probe_duration=probe,
+        evaluate=lambda text, dur: _ev(flagged=flags[text]),
+        record=lambda **kw: stored.append(kw),
+        now=123.0,
+    )
+    assert summary.total == 3
+    assert summary.skipped == 1  # the .subgen. one
+    assert summary.scanned == 2
+    assert summary.errors == 0
+    assert {s["canonical_path"] for s in stored} == {"/m/B.en.srt", "/m/C.en.srt"}
+    assert all(s["source"] == ea.EXISTING_AUDIT_SOURCE for s in stored)
+    assert all(s["completed_at"] == 123.0 for s in stored)
+
+
+@pytest.mark.asyncio
+async def test_flagged_count_and_duration_passthrough():
+    seen_durations = []
+
+    def evaluate(text, dur):
+        seen_durations.append(dur)
+        return _ev(flagged=True)
+
+    async def probe(_p):
+        return 42.0
+
+    summary = await ea.run_existing_audit(
+        ["/m/B.en.srt"],
+        generated_paths=set(),
+        read_text=lambda p: "cue",
+        probe_duration=probe,
+        evaluate=evaluate,
+        record=lambda **kw: None,
+        now=1.0,
+    )
+    assert summary.flagged == 1
+    assert seen_durations == [42.0]  # ffprobe duration reaches the scorer
+
+
+@pytest.mark.asyncio
+async def test_unreadable_file_counts_as_error_and_continues():
+    stored = []
+
+    def read_text(p):
+        if p == "/m/bad.en.srt":
+            raise OSError("permission denied")
+        return "cue"
+
+    async def probe(_p):
+        return None
+
+    summary = await ea.run_existing_audit(
+        ["/m/bad.en.srt", "/m/good.en.srt"],
+        generated_paths=set(),
+        read_text=read_text,
+        probe_duration=probe,
+        evaluate=lambda t, d: _ev(flagged=False),
+        record=lambda **kw: stored.append(kw),
+        now=1.0,
+    )
+    assert summary.errors == 1
+    assert summary.scanned == 1
+    assert [s["canonical_path"] for s in stored] == ["/m/good.en.srt"]
+
+
+@pytest.mark.asyncio
+async def test_progress_callback_fires_per_processed_file():
+    ticks = []
+
+    async def probe(_p):
+        return None
+
+    await ea.run_existing_audit(
+        ["/m/a.subgen.en.srt", "/m/b.en.srt"],
+        generated_paths=set(),
+        read_text=lambda p: "cue",
+        probe_duration=probe,
+        evaluate=lambda t, d: _ev(flagged=False),
+        record=lambda **kw: None,
+        now=1.0,
+        on_progress=lambda done, total: ticks.append((done, total)),
+    )
+    # one tick per path (including the skipped one), final reaches total
+    assert ticks[-1] == (2, 2)

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,30 @@
+// Frontend unit-test harness (#201). The SPA had zero tests — the only gate
+// was bundle drift — so the #193 (fabricated demo data) / #188 (decorative
+// search box) bug class shipped uncaught. This runs pure frontend logic
+// (formatters, language normalization, filters, payload mappers) in CI.
+//
+// JSX transform MUST mirror scripts/build-frontend.mjs exactly: classic
+// runtime, React.createElement / React.Fragment. React + ReactDOM are CDN
+// globals at runtime (esbuild IIFE leaves them undefined-at-build); the setup
+// file stubs them so importing a .jsx module never ReferenceErrors. These
+// tests exercise pure logic, not rendering, so the node environment is enough.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  // Vitest 4 transforms with oxc, not esbuild. Force the CLASSIC JSX runtime
+  // (React.createElement / React.Fragment) to match build-frontend.mjs —
+  // otherwise oxc defaults to the automatic runtime and injects a
+  // `react/jsx-dev-runtime` import we don't ship (React is a CDN global).
+  oxc: {
+    jsx: {
+      runtime: 'classic',
+      pragma: 'React.createElement',
+      pragmaFrag: 'React.Fragment',
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/subarr/static/v1/**/*.test.{js,jsx}'],
+    setupFiles: ['scripts/vitest.setup.js'],
+  },
+});


### PR DESCRIPTION
Phase 1 of #216 (first feature request from the r/radarr launch). The aftercare scorer only fired on subgen completions; this adds the engine to point the **same** scorer at the external sidecar SRTs a user already has - surfacing sync drift, scene-ad boilerplate, suspected MT in subs they didn't generate.

**This PR is the engine only** - no API/UI yet, so no untrusted-content render surface (the stored-XSS concern from the issue lands with the UI in a later phase).

- `discover_external_srts()` - the single fs walk (rglob `*.srt` per library root, skips symlinks/unreadable subtrees, dedups, sorted)
- `is_subarr_generated()` - skips our own output (`.subgen.` marker or provenance-path match) so only **pre-existing external** subs are audited
- `run_existing_audit()` - dependency-injected orchestrator: scores each SRT with media duration (enables the #218 sync-overrun check), stores under `source='existing_audit'`, counts scanned/skipped/flagged/errors, `on_progress` per file; one bad file is counted+skipped, never fatal

**10 tests** cover discovery, the skip predicate, and the orchestrator (skip/score/store, duration passthrough, error survival, progress) - all injected, no fs/DB.

**Staging:** P2 untrusted cue-text sanitization (stored-XSS gate) -> P3 router trigger + review-page source filter -> P4 one-click regenerate-from-audio. Boundaries held: never fixes sync in place (subsyncarr's job), never touches Bazarr provider logic.