### PR TITLE
feat(aftercare): untrusted cue-text sanitizer (#216 phase 2)

### DIFF
--- a/src/subarr/subtitle_sanitize.py
+++ b/src/subarr/subtitle_sanitize.py
@@ -1,0 +1,48 @@
+"""#216 Phase 2: sanitize untrusted external subtitle text for UI display.
+
+The existing-subtitle audit renders cue text from provider/scene SRTs the user
+did NOT generate. A crafted .srt/.ass can carry HTML/script or ASS override
+(including \\t transforms, \\clip, and drawing) tags — naively injecting that
+into the DOM is a stored-XSS vector. (Our own Whisper output is clean; this is
+specifically for arbitrary third-party subs.)
+
+`sanitize_cue_text` reduces a cue to inert, display-only text: active elements
+(script/style) are dropped whole, all tag delimiters and ASS override blocks
+are stripped so nothing structural can reach the DOM, control characters are
+removed, and whitespace is normalized. React escapes by default — this is the
+belt to that suspenders, and it also strips ASS noise React would happily
+render as literal clutter. Sanitize at this boundary so the API never emits
+raw untrusted markup.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Elements whose CONTENT is never display text — drop tag + body together.
+_ACTIVE_ELEMENT = re.compile(r"<(script|style)\b[^>]*>.*?</\1\s*>", re.IGNORECASE | re.DOTALL)
+# ASS/SSA override blocks: {\an8}, {\pos(..)}, {\t(..)}, {\clip(..)}, drawing, etc.
+_ASS_OVERRIDE = re.compile(r"\{[^}]*\}")
+# ASS soft line break (\N, \n) and hard space (\h).
+_ASS_WHITESPACE = re.compile(r"\\[Nnh]")
+# Any remaining tag-like construct (<b>, <font ...>, stray '<', '>').
+_TAGS = re.compile(r"<[^>]*>")
+_STRAY_ANGLES = re.compile(r"[<>]")
+# C0/C1 control characters (keep \t/\n/\r handled separately via whitespace).
+_CONTROL = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def sanitize_cue_text(raw: str | None) -> str:
+    """Return inert, display-only text for an untrusted subtitle cue."""
+    if not raw:
+        return ""
+    text = str(raw)
+    text = _ACTIVE_ELEMENT.sub(" ", text)  # drop <script>/<style> wholesale
+    text = _ASS_OVERRIDE.sub(" ", text)  # {\...} override blocks
+    text = _ASS_WHITESPACE.sub(" ", text)  # \N \n \h -> space
+    text = _TAGS.sub(" ", text)  # remaining <...> tags
+    text = _STRAY_ANGLES.sub(" ", text)  # any leftover bare < or >
+    text = _CONTROL.sub("", text)  # control chars
+    text = _WHITESPACE.sub(" ", text)  # collapse runs
+    return text.strip()

--- a/tests/test_subtitle_sanitize.py
+++ b/tests/test_subtitle_sanitize.py
@@ -1,0 +1,74 @@
+"""#216 Phase 2: sanitize UNTRUSTED external subtitle text before it can reach
+the UI (stored-XSS gate). The existing-audit feature renders cue text from
+provider/scene SRTs the user did not generate — a crafted .srt/.ass can carry
+HTML/script or ASS override/Lua/drawing tags. These pin that the sanitizer
+yields inert, display-only text.
+"""
+
+from __future__ import annotations
+
+from subarr.subtitle_sanitize import sanitize_cue_text
+
+
+class TestStripsActiveContent:
+    def test_script_element_removed_wholesale(self):
+        out = sanitize_cue_text("<script>alert('xss')</script>Hello")
+        assert "alert" not in out
+        assert "<script" not in out
+        assert out.strip() == "Hello"
+
+    def test_style_element_removed_wholesale(self):
+        out = sanitize_cue_text("<style>body{display:none}</style>Subtitle")
+        assert "display:none" not in out
+        assert out.strip() == "Subtitle"
+
+    def test_img_onerror_payload_neutralized(self):
+        out = sanitize_cue_text('<img src=x onerror="alert(1)">caption')
+        assert "<img" not in out
+        assert "onerror" not in out
+        assert "caption" in out
+
+    def test_no_angle_brackets_survive(self):
+        # whatever residual text remains, no tag delimiters can reach the DOM
+        out = sanitize_cue_text("<b>bold</b> and <i>italic</i>")
+        assert "<" not in out and ">" not in out
+        assert "bold" in out and "italic" in out
+
+
+class TestStripsAssOverrideTags:
+    def test_position_and_alignment_override_removed(self):
+        assert sanitize_cue_text("{\\an8}{\\pos(100,200)}Top line").strip() == "Top line"
+
+    def test_lua_style_transform_override_removed(self):
+        out = sanitize_cue_text("{\\t(\\fscx150)}{\\clip(0,0,1,1)}danger")
+        assert "{" not in out and "}" not in out
+        assert "danger" in out
+
+    def test_ass_linebreaks_become_spaces(self):
+        assert sanitize_cue_text("line one\\Nline two\\hgap").strip() == "line one line two gap"
+
+
+class TestPreservesLegitimateText:
+    def test_plain_text_unchanged(self):
+        assert sanitize_cue_text("Hello, world!") == "Hello, world!"
+
+    def test_apostrophes_and_punctuation_kept(self):
+        assert sanitize_cue_text("It's a trap — really?") == "It's a trap — really?"
+
+    def test_control_chars_removed_but_text_kept(self):
+        assert sanitize_cue_text("clean\x00\x07text") == "cleantext"
+
+    def test_whitespace_collapsed_and_trimmed(self):
+        assert sanitize_cue_text("  too    many   spaces  ") == "too many spaces"
+
+    def test_empty_and_none_safe(self):
+        assert sanitize_cue_text("") == ""
+        assert sanitize_cue_text(None) == ""
+
+
+def test_realistic_scene_ad_with_markup():
+    raw = '<font color="#ff0000">{\\an8}Downloaded from \t<a href="http://spam">OpenSubtitles</a></font>'
+    out = sanitize_cue_text(raw)
+    assert "<" not in out and ">" not in out and "{" not in out
+    assert "Downloaded from" in out
+    assert "OpenSubtitles" in out


### PR DESCRIPTION
Phase 2 of #216 - the stored-XSS gate. The existing-subtitle audit (P1, merged) reads provider/scene SRTs the user didn't generate; when P3 renders cue text in the review UI that's **untrusted content** (HTML/script, ASS `\t`/`\clip`/drawing/Lua tags). The issue's security note calls this out specifically.

`sanitize_cue_text()` yields inert, display-only text: `<script>`/`<style>` dropped whole, all tag delimiters + ASS `{\...}` override blocks stripped, `\N`/`\n`/`\h` -> space, control chars removed, whitespace normalized. Sanitize at this boundary so the API never emits raw untrusted markup; React escaping is the second layer.

**13 tests** incl. a malicious corpus (script/style/`<img onerror>`, ASS transform+clip+drawing, control chars) + preservation of real punctuation + a realistic scene-ad cue. Consumed by the P3 results cue-preview.