### PR TITLE
feat(aftercare): existing-audit service + API (#216 phase 3 backend)

### DIFF
--- a/src/subarr/aftercare_store.py
+++ b/src/subarr/aftercare_store.py
@@ -62,14 +62,23 @@ class AfterCareStore:
             return cur.rowcount
 
     def record(
-        self, *, canonical_path: str, completed_at: float, evaluation: AftercareEvaluation, source: str | None
+        self,
+        *,
+        canonical_path: str,
+        completed_at: float,
+        evaluation: AftercareEvaluation,
+        source: str | None,
+        preview: str | None = None,
     ) -> None:
+        # `preview` (#216) is an already-sanitized snippet of a representative
+        # cue, shown in the review UI to explain why an EXTERNAL sub is flagged.
+        # NULL for our own (clean) Whisper output.
         with self._lock:
             self._conn.execute(
                 "INSERT INTO aftercare_results "
                 "(canonical_path, completed_at, composite, cue_count, flagged, "
-                " readability_json, signals_json, source, reviewed_at, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)",
+                " readability_json, signals_json, source, preview, reviewed_at, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)",
                 (
                     canonical_path,
                     completed_at,
@@ -79,6 +88,7 @@ class AfterCareStore:
                     json.dumps(evaluation.readability) if evaluation.readability else None,
                     json.dumps(evaluation.signals) if evaluation.signals else None,
                     source,
+                    preview,
                     time.time(),
                 ),
             )
@@ -88,10 +98,23 @@ class AfterCareStore:
             row = self._conn.execute(_PENDING_COUNT_SQL).fetchone()
         return int(row[0])
 
-    def list_results(self, *, view: str, limit: int, offset: int) -> list[dict[str, Any]]:
-        sql = _LIST_FLAGGED_SQL if view == "flagged" else _LIST_ALL_SQL
+    def list_results(
+        self, *, view: str, limit: int, offset: int, source: str | None = None
+    ) -> list[dict[str, Any]]:
+        # #216: optional source filter (e.g. 'existing_audit') lets the review
+        # page separate audited external subs from completion-watcher rows.
+        base = _LIST_FLAGGED_SQL if view == "flagged" else _LIST_ALL_SQL
+        if source is not None:
+            # Splice the source predicate before the trailing ORDER BY clause so
+            # the LIMIT/OFFSET params stay last.
+            head, sep, tail = base.partition("ORDER BY")
+            sql = f"{head}AND a.source = ? {sep}{tail}"
+            params: tuple = (source, limit, offset)
+        else:
+            sql = base
+            params = (limit, offset)
         with self._lock:
-            rows = self._conn.execute(sql, (limit, offset)).fetchall()
+            rows = self._conn.execute(sql, params).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
     def get(self, result_id: int) -> dict[str, Any] | None:
@@ -135,6 +158,7 @@ class AfterCareStore:
             "readability": json.loads(r["readability_json"]) if r["readability_json"] else None,
             "signals": json.loads(r["signals_json"]) if r["signals_json"] else None,
             "source": r["source"],
+            "preview": r["preview"],
             "reviewed_at": r["reviewed_at"],
             "created_at": r["created_at"],
         }

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -106,6 +106,7 @@ from .arena import AsrRunner
 from .arena_service import ArenaService
 from .arena_store import ArenaStore
 from .aftercare_store import AfterCareStore
+from .existing_audit_service import ExistingAuditService
 from .scan_runner import ScanRunner
 from .scan_store import ScanStore
 from .crash_store import CrashStore
@@ -372,6 +373,12 @@ async def lifespan(app_: FastAPI):
     # passed in directly (watcher judges each completed job's .srt on the fly).
     app_.state.aftercare = AfterCareStore(settings.db_path)
     app_.state.aftercare.prune()  # #197: 365d, never touches unreviewed flags
+    # #216: library-wide audit of EXISTING external subs, single-flight bg task.
+    app_.state.existing_audit = ExistingAuditService(
+        aftercare_store=app_.state.aftercare,
+        provenance=app_.state.provenance,
+        libraries=settings.libraries,
+    )
 
     def _probe_duration_lookup(canonical: str) -> float | None:
         """#216: the file's ffprobe duration for aftercare's sync-overrun

--- a/src/subarr/existing_audit.py
+++ b/src/subarr/existing_audit.py
@@ -70,6 +70,40 @@ def discover_external_srts(roots: Iterable[Path], *, max_depth: int | None = Non
     return sorted(found)
 
 
+def cue_preview(text: str, *, limit: int = 160) -> str | None:
+    """A short, SANITIZED snippet of the first non-empty cue — shown in the
+    review UI to explain why an external sub is flagged (scene-release ads tend
+    to be the opening cue). Returns None if there's no renderable cue. The
+    snippet is sanitized here so the stored/served value is never raw markup."""
+    from .subtitle_readability import parse_srt
+    from .subtitle_sanitize import sanitize_cue_text
+
+    for cue in parse_srt(text):
+        clean = sanitize_cue_text(cue.text)
+        if clean:
+            return clean[: limit - 1] + "…" if len(clean) > limit else clean
+    return None
+
+
+def resolve_media_for_srt(srt_path: str) -> Path | None:
+    """Find the video an external .srt belongs to: a sibling file whose stem is
+    a prefix of the srt's stem (Show.S01E01.en.srt -> Show.S01E01.mkv). Used to
+    fetch the media duration for the sync-overrun check. None if no match."""
+    from .sidecar_scanner import VIDEO_EXTS
+
+    srt = Path(srt_path)
+    parent = srt.parent
+    if not parent.is_dir():
+        return None
+    srt_stem = srt.stem  # drops only ".srt"
+    best: Path | None = None
+    for sib in parent.iterdir():
+        if sib.suffix.lower() in VIDEO_EXTS and srt_stem.startswith(sib.stem):
+            if best is None or len(sib.stem) > len(best.stem):
+                best = sib  # longest matching stem = most specific video
+    return best
+
+
 @dataclass
 class AuditSummary:
     total: int = 0  # paths considered
@@ -88,6 +122,7 @@ async def run_existing_audit(
     evaluate: Callable[[str, float | None], AftercareEvaluation],
     record: Callable[..., None],
     now: float,
+    make_preview: Callable[[str], str | None] | None = None,
     on_progress: Callable[[int, int], None] | None = None,
 ) -> AuditSummary:
     """Score each external sidecar SRT and store the result.
@@ -114,6 +149,7 @@ async def run_existing_audit(
                 completed_at=now,
                 evaluation=evaluation,
                 source=EXISTING_AUDIT_SOURCE,
+                preview=make_preview(text) if make_preview is not None else None,
             )
             summary.scanned += 1
             if evaluation.flagged:

--- a/src/subarr/existing_audit_service.py
+++ b/src/subarr/existing_audit_service.py
@@ -1,0 +1,117 @@
+"""#216 Phase 3: the background service that runs the existing-subtitle audit.
+
+Wires the pure runner (existing_audit.run_existing_audit) to real deps — read
+the file, probe the sibling video for duration, score with the aftercare
+engine, capture a sanitized preview cue, persist via the aftercare store —
+behind a single-flight background task with pollable progress. A library walk
+plus ffprobe-per-file can take minutes, so this never blocks a request: start
+it, poll status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+from .aftercare import evaluate_subtitle
+from .existing_audit import (
+    cue_preview,
+    discover_external_srts,
+    resolve_media_for_srt,
+    run_existing_audit,
+)
+from .media_probe import ProbeError, probe
+
+log = logging.getLogger(__name__)
+
+
+def _read_srt(path: str) -> str:
+    # Provider/scene subs are frequently latin-1 or mixed; replace undecodable
+    # bytes rather than fail the whole file.
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+async def _probe_duration(srt_path: str) -> float | None:
+    """Media duration for the SRT's sibling video (enables the sync-overrun
+    check). None when there's no sibling video or ffprobe can't read it —
+    duration is optional to the scorer."""
+    media = resolve_media_for_srt(srt_path)
+    if media is None:
+        return None
+    try:
+        return (await probe(media)).duration_s
+    except ProbeError as e:
+        log.debug("existing-audit: no duration for %s (%s)", srt_path, e)
+        return None
+
+
+class ExistingAuditService:
+    """Single-flight runner for the library-wide existing-sub audit."""
+
+    def __init__(self, *, aftercare_store, provenance, libraries, clock=time.time):
+        self._store = aftercare_store
+        self._provenance = provenance
+        self._libraries = libraries  # iterable of Library (has .fs_root)
+        self._clock = clock
+        self._task: asyncio.Task | None = None
+        self._state: dict = {
+            "running": False,
+            "done": 0,
+            "total": 0,
+            "summary": None,
+            "started_at": None,
+            "finished_at": None,
+            "error": None,
+        }
+
+    def status(self) -> dict:
+        return dict(self._state)
+
+    def start(self) -> bool:
+        """Kick off an audit. Returns False if one is already running
+        (single-flight) — the caller surfaces 'already running' to the UI."""
+        if self._state["running"]:
+            return False
+        self._state.update(
+            running=True,
+            done=0,
+            total=0,
+            summary=None,
+            started_at=self._clock(),
+            finished_at=None,
+            error=None,
+        )
+        self._task = asyncio.create_task(self._run(), name="existing-audit")
+        return True
+
+    async def _run(self) -> None:
+        try:
+            roots = [lib.fs_root for lib in self._libraries]
+            srts = discover_external_srts(roots)
+            generated = self._provenance.completed_paths_since(0.0)  # all-time
+
+            def on_progress(done: int, total: int) -> None:
+                self._state["done"] = done
+                self._state["total"] = total
+
+            summary = await run_existing_audit(
+                srts,
+                generated_paths=generated,
+                read_text=_read_srt,
+                probe_duration=_probe_duration,
+                evaluate=lambda text, dur: evaluate_subtitle(text, media_duration_s=dur),
+                record=self._store.record,
+                now=self._clock(),
+                make_preview=cue_preview,
+                on_progress=on_progress,
+            )
+            self._state["summary"] = asdict(summary)
+        except Exception as e:  # noqa: BLE001 - a failed walk must update state, not crash the loop
+            self._state["error"] = str(e)
+            log.exception("existing-audit run failed")
+        finally:
+            self._state["running"] = False
+            self._state["finished_at"] = self._clock()

--- a/src/subarr/migrations/020_aftercare_preview.sql
+++ b/src/subarr/migrations/020_aftercare_preview.sql
@@ -1,0 +1,9 @@
+-- 020_aftercare_preview.sql
+--
+-- #216: the existing-subtitle audit surfaces external (provider/scene) subs in
+-- the review UI. To explain WHY a sub is flagged, we store a short, already-
+-- SANITIZED snippet of a representative cue (e.g. the scene-release ad line).
+-- Captured + sanitized at audit time (subtitle_sanitize) so the column never
+-- holds raw untrusted markup; NULL for completion-watcher rows (our own clean
+-- Whisper output needs no preview).
+ALTER TABLE aftercare_results ADD COLUMN preview TEXT;

--- a/src/subarr/routers/aftercare.py
+++ b/src/subarr/routers/aftercare.py
@@ -23,15 +23,31 @@ async def pending(request: Request) -> dict[str, Any]:
     return {"count": store.pending_count()}
 
 
+@router.post("/audit")
+async def start_audit(request: Request) -> dict[str, Any]:
+    """#216: kick off the library-wide existing-subtitle audit. Single-flight —
+    `started=false` means one is already running (not an error)."""
+    svc = request.app.state.existing_audit
+    started = svc.start()
+    return {"started": started, "status": svc.status()}
+
+
+@router.get("/audit/status")
+async def audit_status(request: Request) -> dict[str, Any]:
+    """#216: progress for the existing-sub audit (running, done/total, summary)."""
+    return request.app.state.existing_audit.status()
+
+
 @router.get("/results")
 async def results(
     request: Request,
     view: str = Query("flagged", pattern="^(flagged|all)$"),
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
+    source: str | None = Query(None, max_length=40),
 ) -> dict[str, Any]:
     store = request.app.state.aftercare
-    items = store.list_results(view=view, limit=limit, offset=offset)
+    items = store.list_results(view=view, limit=limit, offset=offset, source=source)
     # Best-effort enrich each row with the show's language from the in-memory
     # coverage snapshot (per-language is the tuning axis — drives the flag + the
     # #168 loop). No schema cost; read-time lookup against the cached snapshot.

--- a/tests/test_aftercare_store.py
+++ b/tests/test_aftercare_store.py
@@ -27,6 +27,7 @@ def test_migration_creates_aftercare_table(tmp_path):
         "readability_json",
         "signals_json",
         "source",
+        "preview",
         "reviewed_at",
         "created_at",
     } <= cols
@@ -83,3 +84,36 @@ def test_mark_reviewed(tmp_path):
     assert s.mark_reviewed(row["id"]) is True
     assert s.pending_count() == 0
     assert s.mark_reviewed(999999) is False
+
+
+def test_preview_round_trips(tmp_path):
+    # #216: the sanitized cue snippet persists and comes back on read
+    s = _store(tmp_path)
+    s.record(
+        canonical_path="TV/A/e1.en.srt",
+        completed_at=1.0,
+        evaluation=_ev(True),
+        source="existing_audit",
+        preview="Downloaded from spam.com",
+    )
+    row = s.list_results(view="all", limit=50, offset=0)[0]
+    assert row["preview"] == "Downloaded from spam.com"
+
+
+def test_preview_defaults_null_for_generated_rows(tmp_path):
+    s = _store(tmp_path)
+    s.record(canonical_path="TV/A/e1.mkv", completed_at=1.0, evaluation=_ev(False), source="subgenscan")
+    assert s.list_results(view="all", limit=50, offset=0)[0]["preview"] is None
+
+
+def test_list_results_source_filter(tmp_path):
+    # #216: the review page filters audited external subs from watcher rows
+    s = _store(tmp_path)
+    s.record(
+        canonical_path="TV/A/ext.en.srt", completed_at=1.0, evaluation=_ev(True), source="existing_audit"
+    )
+    s.record(canonical_path="TV/A/gen.mkv", completed_at=1.0, evaluation=_ev(True), source="subgenscan")
+    audited = s.list_results(view="all", limit=50, offset=0, source="existing_audit")
+    assert [r["canonical_path"] for r in audited] == ["TV/A/ext.en.srt"]
+    everything = s.list_results(view="all", limit=50, offset=0)
+    assert len(everything) == 2

--- a/tests/test_existing_audit.py
+++ b/tests/test_existing_audit.py
@@ -40,6 +40,38 @@ class TestDiscoverExternalSrts:
         assert found == [str(tmp_path / "A.en.srt")]
 
 
+class TestCuePreview:
+    def test_returns_sanitized_first_cue(self):
+        srt = "1\n00:00:01,000 --> 00:00:03,000\n{\\an8}<i>Downloaded from spam.com</i>\n"
+        assert ea.cue_preview(srt) == "Downloaded from spam.com"
+
+    def test_skips_empty_cues_to_first_renderable(self):
+        srt = "1\n00:00:01,000 --> 00:00:02,000\n{\\an8}\n\n2\n00:00:03,000 --> 00:00:04,000\nReal line\n"
+        assert ea.cue_preview(srt) == "Real line"
+
+    def test_none_when_no_renderable_cue(self):
+        assert ea.cue_preview("not an srt at all") is None
+
+    def test_truncates_long_cue_with_ellipsis(self):
+        body = "x" * 500
+        srt = f"1\n00:00:01,000 --> 00:00:03,000\n{body}\n"
+        out = ea.cue_preview(srt, limit=50)
+        assert len(out) == 50 and out.endswith("…")
+
+
+class TestResolveMediaForSrt:
+    def test_finds_sibling_video_by_stem_prefix(self, tmp_path):
+        (tmp_path / "Show.S01E01.mkv").write_text("v")
+        srt = tmp_path / "Show.S01E01.en.srt"
+        srt.write_text("s")
+        assert ea.resolve_media_for_srt(str(srt)) == tmp_path / "Show.S01E01.mkv"
+
+    def test_none_when_no_sibling_video(self, tmp_path):
+        srt = tmp_path / "Orphan.en.srt"
+        srt.write_text("s")
+        assert ea.resolve_media_for_srt(str(srt)) is None
+
+
 class TestIsSubarrGenerated:
     def test_subgen_filename_marker_is_ours(self):
         assert ea.is_subarr_generated("/m/Show.S01E01.subgen.large-v3.en.srt", set())

--- a/tests/test_existing_audit_service.py
+++ b/tests/test_existing_audit_service.py
@@ -1,0 +1,89 @@
+"""#216 Phase 3: the single-flight background audit service.
+
+Tests drive the service against a tmp library with real SRT files (no video
+siblings, so duration probing no-ops) and fake store/provenance, asserting the
+state machine, single-flight guard, and provenance-skip behaviour.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from subarr.existing_audit import EXISTING_AUDIT_SOURCE
+from subarr.existing_audit_service import ExistingAuditService
+
+
+class _FakeStore:
+    def __init__(self):
+        self.records = []
+
+    def record(self, **kw):
+        self.records.append(kw)
+
+
+class _FakeProvenance:
+    def __init__(self, generated=None):
+        self._gen = set(generated or [])
+
+    def completed_paths_since(self, _since):
+        return self._gen
+
+
+def _lib(path):
+    return types.SimpleNamespace(fs_root=path)
+
+
+def _write_srt(path, body="Real subtitle line"):
+    path.write_text(f"1\n00:00:01,000 --> 00:00:03,000\n{body}\n", encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_start_walks_scores_and_records(tmp_path):
+    _write_srt(tmp_path / "A.en.srt")
+    _write_srt(tmp_path / "B.en.srt")
+    store = _FakeStore()
+    svc = ExistingAuditService(
+        aftercare_store=store, provenance=_FakeProvenance(), libraries=[_lib(tmp_path)], clock=lambda: 1.0
+    )
+
+    assert svc.start() is True
+    await svc._task  # let the background run finish
+
+    st = svc.status()
+    assert st["running"] is False
+    assert st["error"] is None
+    assert st["summary"]["scanned"] == 2
+    assert {r["canonical_path"] for r in store.records} == {
+        str(tmp_path / "A.en.srt"),
+        str(tmp_path / "B.en.srt"),
+    }
+    assert all(r["source"] == EXISTING_AUDIT_SOURCE for r in store.records)
+
+
+@pytest.mark.asyncio
+async def test_single_flight_guard():
+    svc = ExistingAuditService(
+        aftercare_store=_FakeStore(), provenance=_FakeProvenance(), libraries=[], clock=lambda: 1.0
+    )
+    svc._state["running"] = True  # simulate an in-flight run
+    assert svc.start() is False  # second start is rejected
+
+
+@pytest.mark.asyncio
+async def test_skips_subarr_generated_via_provenance(tmp_path):
+    _write_srt(tmp_path / "Ours.en.srt")
+    _write_srt(tmp_path / "External.en.srt")
+    store = _FakeStore()
+    svc = ExistingAuditService(
+        aftercare_store=store,
+        provenance=_FakeProvenance(generated={str(tmp_path / "Ours.en.srt")}),
+        libraries=[_lib(tmp_path)],
+        clock=lambda: 1.0,
+    )
+    svc.start()
+    await svc._task
+
+    assert svc.status()["summary"]["skipped"] == 1
+    assert [r["canonical_path"] for r in store.records] == [str(tmp_path / "External.en.srt")]


### PR DESCRIPTION
Phase 3 backend of #216. Wires the audit engine (P1) + sanitizer (P2) into a runnable backend so the review UI (next PR) can trigger a library-wide audit of existing external subs and show why each is flagged.

- **ExistingAuditService** - single-flight supervised background task, pollable progress. Real deps: read file (latin-1 tolerant) -> resolve sibling video + ffprobe duration (sync-overrun check) -> `evaluate_subtitle` -> sanitized preview cue -> store.
- **engine** - `run_existing_audit` gains `make_preview`; pure helpers `cue_preview` + `resolve_media_for_srt`.
- **store** - `record(preview=)`, `list_results(source=)` filter, preview in row dict. Migration 020 adds the nullable `preview` column.
- **router** - `POST /api/aftercare/audit` (single-flight), `GET /api/aftercare/audit/status`, `source` filter on `/results`.
- **app** - service on `app.state` from aftercare store + provenance + `settings.libraries`.

**Tests:** service state-machine / single-flight / provenance-skip; `cue_preview` + `resolve_media_for_srt`; store preview round-trip + source filter + NULL default. Full suite **999 passed** locally - the `record()` change is backward-compatible (`preview` defaults None), completion-watcher path unaffected.

No UI yet (no untrusted render surface). Next: frontend (`aftercare.jsx`) + P4 regenerate.