### PR TITLE
feat(integrations): per-integration circuit breakers (#235)

### DIFF
--- a/src/subarr/circuit_breaker.py
+++ b/src/subarr/circuit_breaker.py
@@ -1,0 +1,79 @@
+"""#235: a lightweight per-integration circuit breaker.
+
+task_health (#157) tells us *whether* an upstream is broken; this stops us
+*hammering* it. When an integration (Bazarr/Sonarr/Radarr/Plex/Tautulli/Ollama)
+fails N times in a row, the breaker OPENs and short-circuits further calls for
+a cooldown — cutting wasted requests, slow timeouts, and log spam — then lets a
+single probe through (HALF_OPEN) to detect recovery.
+
+In-memory by design: a process restart starts CLOSED (a natural "try again"),
+and task_health persists the visibility. Persisting breaker state across
+restarts (as sublarr does) is a possible follow-up, not needed for the core
+"stop pounding a dead upstream" win.
+
+Trip policy is set by the caller: transport errors + 5xx count as failures
+(upstream down/erroring); a <500 HTTP response means the upstream is reachable
+(record_success), even a 4xx — hammering an auth/404 won't help but it isn't a
+flap, so it must not trip the breaker.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+CLOSED = "closed"
+OPEN = "open"
+HALF_OPEN = "half_open"
+
+
+class CircuitBreaker:
+    def __init__(
+        self,
+        *,
+        fail_threshold: int = 5,
+        cooldown_s: float = 60.0,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._fail_threshold = max(1, fail_threshold)
+        self._cooldown_s = cooldown_s
+        self._clock = clock
+        self._state = CLOSED
+        self._consecutive_failures = 0
+        self._opened_at: float | None = None
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    def allow(self) -> bool:
+        """True if a call may proceed now. When OPEN, the first call after the
+        cooldown transitions to HALF_OPEN and is allowed through as the probe;
+        further calls stay blocked until that probe resolves."""
+        if self._state == OPEN:
+            if self._opened_at is not None and (self._clock() - self._opened_at) >= self._cooldown_s:
+                self._state = HALF_OPEN
+                return True
+            return False
+        # CLOSED or HALF_OPEN (probe in flight) — allow.
+        return True
+
+    def record_success(self) -> None:
+        """A reachable response. Clears failures; a successful probe closes."""
+        self._consecutive_failures = 0
+        self._opened_at = None
+        self._state = CLOSED
+
+    def record_failure(self) -> None:
+        """An upstream failure (transport error / 5xx). Trips OPEN at the
+        threshold; a failed HALF_OPEN probe re-opens with a fresh cooldown."""
+        if self._state == HALF_OPEN:
+            self._open()
+            return
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._fail_threshold:
+            self._open()
+
+    def _open(self) -> None:
+        self._state = OPEN
+        self._opened_at = self._clock()

--- a/src/subarr/integrations/base.py
+++ b/src/subarr/integrations/base.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from ..circuit_breaker import CircuitBreaker
 from . import IntegrationError
 
 log = logging.getLogger(__name__)
@@ -24,7 +25,11 @@ class IntegrationClient:
     name: str = "integration"
 
     def __init__(
-        self, base_url: str, headers: dict[str, str] | None = None, timeout: httpx.Timeout | None = None
+        self,
+        base_url: str,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        breaker: CircuitBreaker | None = None,
     ):
         self._base_url = base_url.rstrip("/") if base_url else ""
         self._configured = bool(base_url)
@@ -33,20 +38,46 @@ class IntegrationClient:
             timeout=timeout or _DEFAULT_TIMEOUT,
             headers=headers or {},
         )
+        # #235: per-integration breaker. A downed/flapping upstream OPENs it and
+        # we short-circuit further calls for a cooldown instead of eating slow
+        # timeouts every poll cycle. Caller can inject a tuned breaker.
+        self._breaker = breaker or CircuitBreaker()
 
     def is_configured(self) -> bool:
         return self._configured
 
+    @property
+    def breaker(self) -> CircuitBreaker:
+        return self._breaker
+
     async def aclose(self) -> None:
         await self._client.aclose()
+
+    def _guard(self) -> None:
+        """#235: refuse the call when the breaker is OPEN (cooldown not yet
+        elapsed). Raises the IntegrationError type callers already handle."""
+        if not self._breaker.allow():
+            raise IntegrationError(f"{self.name}: circuit open — upstream failing, backing off")
+
+    def _record(self, status_code: int) -> None:
+        """A 5xx is an upstream failure (trips the breaker); any <500 response
+        means the upstream is reachable (success), even a 4xx — an auth/404 is
+        not a flap and must not open the circuit."""
+        if status_code >= 500:
+            self._breaker.record_failure()
+        else:
+            self._breaker.record_success()
 
     async def _get(self, path: str, params: dict | None = None) -> Any:
         if not self._configured:
             raise IntegrationError(f"{self.name}: not configured (URL or API key missing)")
+        self._guard()
         try:
             r = await self._client.get(path, params=params)
         except httpx.HTTPError as e:
+            self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
         try:
@@ -57,10 +88,13 @@ class IntegrationClient:
     async def _post(self, path: str, params: dict | None = None, json_body: dict | None = None) -> Any:
         if not self._configured:
             raise IntegrationError(f"{self.name}: not configured")
+        self._guard()
         try:
             r = await self._client.post(path, params=params, json=json_body)
         except httpx.HTTPError as e:
+            self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
         try:
@@ -73,10 +107,13 @@ class IntegrationClient:
         episodeFile resource. Same error-translation contract as _post."""
         if not self._configured:
             raise IntegrationError(f"{self.name}: not configured")
+        self._guard()
         try:
             r = await self._client.put(path, params=params, json=json_body)
         except httpx.HTTPError as e:
+            self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,6 +309,7 @@ def _make_integration_bundle(
 
     Each *_handler is a callable httpx.Request -> httpx.Response. Pass None
     to mark that integration as unconfigured (it'll return is_configured() False)."""
+    from subarr.circuit_breaker import CircuitBreaker
     from subarr.coverage_engine import IntegrationBundle
     from subarr.integrations.bazarr import BazarrClient
     from subarr.integrations.radarr import RadarrClient
@@ -317,6 +318,7 @@ def _make_integration_bundle(
 
     def _wrap(cls, handler, base_url, headers=None):
         c = cls.__new__(cls)
+        c._breaker = CircuitBreaker()  # #235: stub bypasses __init__, set it here
         if handler is None:
             # Mark unconfigured. base/url cleared so is_configured() == False.
             c._base_url = ""

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,88 @@
+"""#235: per-integration circuit breaker so a flapping/hung upstream can't be
+hammered every cycle. CLOSED -> (N consecutive failures) -> OPEN -> (cooldown)
+-> HALF_OPEN probe -> CLOSED on success / OPEN on failure.
+"""
+
+from __future__ import annotations
+
+from subarr.circuit_breaker import CircuitBreaker
+
+
+def _clock():
+    """A controllable monotonic clock for deterministic cooldown tests."""
+    t = {"now": 1000.0}
+    return t, (lambda: t["now"])
+
+
+def test_starts_closed_and_allows():
+    cb = CircuitBreaker(fail_threshold=3, cooldown_s=30)
+    assert cb.state == "closed"
+    assert cb.allow() is True
+
+
+def test_opens_after_threshold_consecutive_failures():
+    t, clock = _clock()
+    cb = CircuitBreaker(fail_threshold=3, cooldown_s=30, clock=clock)
+    cb.record_failure()
+    cb.record_failure()
+    assert cb.state == "closed"  # not yet
+    cb.record_failure()
+    assert cb.state == "open"
+    assert cb.allow() is False  # blocked while open
+
+
+def test_success_resets_failure_count():
+    cb = CircuitBreaker(fail_threshold=3, cooldown_s=30)
+    cb.record_failure()
+    cb.record_failure()
+    cb.record_success()  # reset
+    cb.record_failure()
+    cb.record_failure()
+    assert cb.state == "closed"  # 2 < 3 after the reset
+
+
+def test_open_transitions_to_half_open_after_cooldown():
+    t, clock = _clock()
+    cb = CircuitBreaker(fail_threshold=1, cooldown_s=30, clock=clock)
+    cb.record_failure()
+    assert cb.state == "open"
+    assert cb.allow() is False
+    t["now"] += 31  # cooldown elapses
+    assert cb.allow() is True  # one probe permitted
+    assert cb.state == "half_open"
+
+
+def test_half_open_probe_success_closes():
+    t, clock = _clock()
+    cb = CircuitBreaker(fail_threshold=1, cooldown_s=30, clock=clock)
+    cb.record_failure()
+    t["now"] += 31
+    cb.allow()  # -> half_open
+    cb.record_success()
+    assert cb.state == "closed"
+    assert cb.allow() is True
+
+
+def test_half_open_probe_failure_reopens_and_resets_cooldown():
+    t, clock = _clock()
+    cb = CircuitBreaker(fail_threshold=1, cooldown_s=30, clock=clock)
+    cb.record_failure()
+    t["now"] += 31
+    cb.allow()  # -> half_open
+    cb.record_failure()  # probe failed
+    assert cb.state == "open"
+    assert cb.allow() is False  # cooldown restarts, blocked again immediately
+    t["now"] += 31
+    assert cb.allow() is True  # probes again after a fresh cooldown
+
+
+def test_open_blocks_only_until_cooldown_not_forever():
+    t, clock = _clock()
+    cb = CircuitBreaker(fail_threshold=2, cooldown_s=10, clock=clock)
+    cb.record_failure()
+    cb.record_failure()
+    assert cb.allow() is False
+    t["now"] += 5
+    assert cb.allow() is False  # still cooling
+    t["now"] += 6
+    assert cb.allow() is True  # past cooldown

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -226,7 +226,12 @@ def test_integrations_health_isolates_one_failure(app_with_stub):
     r = app_with_stub.get("/api/integrations/health")
     by_name = {it["name"]: it for it in r.json()["integrations"]}
     assert by_name["bazarr"]["online"] is False
-    assert "500" in by_name["bazarr"].get("error", "")
+    # bazarr's repeated 500s trip its per-client circuit breaker (#235), so the
+    # error is either the raw HTTP 500 or the breaker's "circuit open" backoff —
+    # both mean offline. The point of THIS test is isolation: one failing
+    # integration must not take the others down (each has its own breaker).
+    err = by_name["bazarr"].get("error", "")
+    assert "500" in err or "circuit open" in err
     assert by_name["sonarr"]["online"] is True
 
 

--- a/tests/test_integration_breaker.py
+++ b/tests/test_integration_breaker.py
@@ -1,0 +1,90 @@
+"""#235: IntegrationClient honours its circuit breaker — a failing upstream
+trips it and further calls short-circuit (no wasted request) until it recovers.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from subarr.circuit_breaker import CircuitBreaker
+from subarr.integrations import IntegrationError
+from subarr.integrations.base import IntegrationClient
+
+
+def _client(handler, breaker):
+    c = IntegrationClient("http://up.test", breaker=breaker)
+    c._client = httpx.AsyncClient(base_url="http://up.test", transport=httpx.MockTransport(handler))
+    return c
+
+
+@pytest.mark.asyncio
+async def test_opens_after_threshold_then_short_circuits():
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        raise httpx.ConnectError("down")  # upstream unreachable
+
+    cb = CircuitBreaker(fail_threshold=2, cooldown_s=60, clock=lambda: 0.0)
+    c = _client(handler, cb)
+
+    for _ in range(2):
+        with pytest.raises(IntegrationError):
+            await c._get("/x")
+    assert cb.state == "open"
+    assert calls["n"] == 2  # two real attempts
+
+    # next call is short-circuited — the transport is NOT hit again
+    with pytest.raises(IntegrationError, match="circuit open"):
+        await c._get("/x")
+    assert calls["n"] == 2  # unchanged — no wasted request
+
+
+@pytest.mark.asyncio
+async def test_5xx_trips_but_4xx_does_not():
+    status = {"code": 503}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(status["code"])
+
+    cb = CircuitBreaker(fail_threshold=2, cooldown_s=60, clock=lambda: 0.0)
+    c = _client(handler, cb)
+
+    # two 5xx -> open
+    for _ in range(2):
+        with pytest.raises(IntegrationError):
+            await c._get("/x")
+    assert cb.state == "open"
+
+    # reset with a fresh breaker; 4xx must NOT trip (upstream reachable)
+    cb2 = CircuitBreaker(fail_threshold=2, cooldown_s=60, clock=lambda: 0.0)
+    status["code"] = 404
+    c2 = _client(handler, cb2)
+    for _ in range(5):
+        with pytest.raises(IntegrationError):
+            await c2._get("/x")
+    assert cb2.state == "closed"  # 404s never open the circuit
+
+
+@pytest.mark.asyncio
+async def test_recovers_after_cooldown_probe_succeeds():
+    now = {"t": 0.0}
+    up = {"ok": False}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if not up["ok"]:
+            raise httpx.ConnectError("down")
+        return httpx.Response(200, json={"ok": True})
+
+    cb = CircuitBreaker(fail_threshold=1, cooldown_s=30, clock=lambda: now["t"])
+    c = _client(handler, cb)
+
+    with pytest.raises(IntegrationError):
+        await c._get("/x")
+    assert cb.state == "open"
+
+    now["t"] += 31  # cooldown elapses, upstream back
+    up["ok"] = True
+    assert await c._get("/x") == {"ok": True}  # probe succeeds
+    assert cb.state == "closed"


### PR DESCRIPTION
Closes #235. task_health (#157) shows *whether* an upstream is broken; this stops us *hammering* it. A downed/flapping integration (Bazarr/Sonarr/Radarr/Plex/Tautulli/Ollama) now trips a breaker and further calls short-circuit for a cooldown instead of eating slow timeouts + log spam every poll cycle.

- **circuit_breaker.py** - pure CLOSED/OPEN/HALF_OPEN: open after N consecutive failures, half-open probe after cooldown, success resets. Injectable clock. In-memory (restart = natural reset; cross-restart persistence noted as follow-up).
- **IntegrationClient** - each client owns a breaker (long-lived via the IntegrationBundle singletons, so state persists across cycles). `_get/_post/_put` guard when OPEN and record outcomes: transport errors + 5xx = failure; any **<500** response = reachable success, so a 4xx (auth/404) never trips the circuit. Per-client breakers => one failing integration can't open another's (**isolation reinforced**).

Scope: the IntegrationClient family. subgen (separate `SubgenClient`, already has `SubgenUnavailable` + watchdog) can adopt the same breaker as a fast-follow.

**Tests:** breaker state machine (7) + client integration (trips/short-circuits, 5xx-trips/4xx-doesn't, cooldown recovery). Full suite **1030 passed** - the run surfaced two legit test-side updates (the conftest stub bypasses `__init__` so it sets `_breaker` itself; the coverage isolation test now accepts the breaker's `circuit open` as offline).