### PR TITLE
test(integrations): contract-test fixtures for Bazarr/Sonarr/Radarr (#253)

### DIFF
--- a/tests/fixtures/integrations/bazarr_badges.json
+++ b/tests/fixtures/integrations/bazarr_badges.json
@@ -1,0 +1,8 @@
+{
+  "episodes": 3,
+  "movies": 1,
+  "providers": 5,
+  "status": 0,
+  "sonarr_signalr": "connected",
+  "radarr_signalr": "connected"
+}

--- a/tests/fixtures/integrations/bazarr_episodes_wanted.json
+++ b/tests/fixtures/integrations/bazarr_episodes_wanted.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "seriesTitle": "Example Show",
+      "episodeTitle": "Pilot",
+      "episode_number": "1x01",
+      "sonarrSeriesId": 12,
+      "sonarrEpisodeId": 345,
+      "missing_subtitles": [{ "name": "English", "code2": "en", "code3": "eng", "forced": false, "hi": false }],
+      "sceneName": "Example.Show.S01E01.1080p.WEB.h264-GROUP",
+      "tags": [],
+      "monitored": "True"
+    }
+  ],
+  "total": 1
+}

--- a/tests/fixtures/integrations/bazarr_movies_wanted.json
+++ b/tests/fixtures/integrations/bazarr_movies_wanted.json
@@ -1,0 +1,13 @@
+{
+  "data": [
+    {
+      "title": "Example Movie",
+      "radarrId": 7,
+      "missing_subtitles": [{ "name": "English", "code2": "en", "code3": "eng", "forced": false, "hi": false }],
+      "sceneName": "Example.Movie.2024.1080p.BluRay.x264-GROUP",
+      "tags": [],
+      "monitored": "True"
+    }
+  ],
+  "total": 1
+}

--- a/tests/fixtures/integrations/bazarr_providers_episodes.json
+++ b/tests/fixtures/integrations/bazarr_providers_episodes.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "provider": "opensubtitlescom",
+      "score": 92,
+      "release_info": ["Example.Show.S01E01.1080p.WEB.h264-GROUP"],
+      "forced": false,
+      "hi": false,
+      "uploader": "someuser",
+      "url": "https://www.opensubtitles.com/en/subtitles/example",
+      "matches": ["series", "season", "episode", "resolution"],
+      "dont_matches": []
+    }
+  ]
+}

--- a/tests/fixtures/integrations/radarr_movies.json
+++ b/tests/fixtures/integrations/radarr_movies.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 7,
+    "title": "Example Movie",
+    "year": 2024,
+    "path": "/movies/Example Movie (2024)",
+    "monitored": true,
+    "tags": [],
+    "hasFile": true,
+    "movieFile": { "id": 99, "relativePath": "Example Movie (2024) Bluray-1080p.mkv" }
+  }
+]

--- a/tests/fixtures/integrations/radarr_system_status.json
+++ b/tests/fixtures/integrations/radarr_system_status.json
@@ -1,0 +1,11 @@
+{
+  "appName": "Radarr",
+  "instanceName": "Radarr",
+  "version": "5.14.0.9383",
+  "buildTime": "2024-09-01T00:00:00Z",
+  "isDocker": true,
+  "runtimeName": "dotnet",
+  "osName": "ubuntu",
+  "branch": "master",
+  "authentication": "forms"
+}

--- a/tests/fixtures/integrations/sonarr_series.json
+++ b/tests/fixtures/integrations/sonarr_series.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 12,
+    "title": "Example Show",
+    "path": "/tv/Example Show",
+    "monitored": true,
+    "tags": [],
+    "languageProfileId": 1,
+    "seriesType": "standard",
+    "statistics": { "episodeFileCount": 10, "episodeCount": 10, "sizeOnDisk": 1234567890 }
+  }
+]

--- a/tests/fixtures/integrations/sonarr_system_status.json
+++ b/tests/fixtures/integrations/sonarr_system_status.json
@@ -1,0 +1,11 @@
+{
+  "appName": "Sonarr",
+  "instanceName": "Sonarr",
+  "version": "4.0.10.2680",
+  "buildTime": "2024-09-01T00:00:00Z",
+  "isDocker": true,
+  "runtimeName": "dotnet",
+  "osName": "ubuntu",
+  "branch": "main",
+  "authentication": "forms"
+}

--- a/tests/test_integration_contracts.py
+++ b/tests/test_integration_contracts.py
@@ -1,0 +1,128 @@
+"""#253: contract tests for the core integrations.
+
+subarr is an API CLIENT of Bazarr/Sonarr/Radarr (no fork — so #171's rebase
+detector doesn't apply here). The risk is API-contract drift: an upstream
+version changes a response shape and our parser silently chokes. These pin the
+shapes we actually depend on, using committed fixtures under
+tests/fixtures/integrations/ as a living record of "what upstream returns".
+
+Scope = the load-bearing endpoints (the coverage engine's inputs). They catch
+OUR parser regressions and document the contract; they do NOT detect upstream
+changing its API (that needs changelog-watching / a live canary — see #253).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from subarr.circuit_breaker import CircuitBreaker
+from subarr.integrations.bazarr import BazarrClient
+from subarr.integrations.radarr import RadarrClient
+from subarr.integrations.sonarr import SonarrClient
+
+_FIX = Path(__file__).parent / "fixtures" / "integrations"
+
+
+def _load(name: str) -> object:
+    return json.loads((_FIX / name).read_text(encoding="utf-8"))
+
+
+def _client(cls, payload):
+    """A real client whose transport serves the fixture (no env/network).
+    Built via __new__ so it doesn't depend on settings — we set the few attrs
+    the request path needs (mirrors the conftest stub)."""
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    c = cls.__new__(cls)
+    c._base_url = "http://up.test"
+    c._configured = True
+    c._breaker = CircuitBreaker()
+    c._client = httpx.AsyncClient(base_url="http://up.test", transport=httpx.MockTransport(handler))
+    return c
+
+
+# ── Bazarr ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bazarr_episodes_wanted_contract():
+    c = _client(BazarrClient, _load("bazarr_episodes_wanted.json"))
+    items = await c.episodes_wanted()  # unwraps the {"data": [...]} envelope
+    assert isinstance(items, list) and items, "expected episodes under data[]"
+    ep = items[0]
+    for field in ("sonarrSeriesId", "sonarrEpisodeId", "seriesTitle", "episodeTitle", "episode_number"):
+        assert field in ep, f"Bazarr wanted-episode contract lost field: {field}"
+    assert isinstance(ep["missing_subtitles"], list)
+
+
+@pytest.mark.asyncio
+async def test_bazarr_movies_wanted_contract():
+    c = _client(BazarrClient, _load("bazarr_movies_wanted.json"))
+    items = await c.movies_wanted()
+    assert isinstance(items, list) and items
+    mv = items[0]
+    for field in ("radarrId", "title", "missing_subtitles"):
+        assert field in mv, f"Bazarr wanted-movie contract lost field: {field}"
+
+
+@pytest.mark.asyncio
+async def test_bazarr_badges_contract():
+    c = _client(BazarrClient, _load("bazarr_badges.json"))
+    badges = await c.badges()
+    for field in ("episodes", "movies", "providers"):
+        assert field in badges, f"Bazarr badges contract lost field: {field}"
+
+
+@pytest.mark.asyncio
+async def test_bazarr_provider_candidates_contract():
+    c = _client(BazarrClient, _load("bazarr_providers_episodes.json"))
+    cands = await c.candidate_episode_subtitles(episode_id=345)
+    assert isinstance(cands, list) and cands
+    cand = cands[0]
+    # the fields the Whisper short-circuit decision reads
+    for field in ("provider", "score", "forced", "hi"):
+        assert field in cand, f"Bazarr provider-candidate contract lost field: {field}"
+
+
+# ── Sonarr / Radarr ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sonarr_status_contract():
+    c = _client(SonarrClient, _load("sonarr_system_status.json"))
+    status = await c.status()
+    assert status.get("version"), "Sonarr status must carry a version"
+    assert "appName" in status
+
+
+@pytest.mark.asyncio
+async def test_sonarr_series_contract():
+    c = _client(SonarrClient, _load("sonarr_series.json"))
+    series = await c.series()
+    assert isinstance(series, list) and series
+    s = series[0]
+    for field in ("id", "title", "path", "monitored"):
+        assert field in s, f"Sonarr series contract lost field: {field}"
+
+
+@pytest.mark.asyncio
+async def test_radarr_status_contract():
+    c = _client(RadarrClient, _load("radarr_system_status.json"))
+    status = await c.status()
+    assert status.get("version"), "Radarr status must carry a version"
+
+
+@pytest.mark.asyncio
+async def test_radarr_movies_contract():
+    c = _client(RadarrClient, _load("radarr_movies.json"))
+    movies = await c.movies()
+    assert isinstance(movies, list) and movies
+    m = movies[0]
+    for field in ("id", "title", "path", "monitored"):
+        assert field in m, f"Radarr movie contract lost field: {field}"


### PR DESCRIPTION
Closes #253. subarr is an API *client* of the arr stack (no fork, so #171's rebase detector doesn't apply). The risk is **API-contract drift** - an upstream version changes a response shape and our parser silently chokes. These pin the shapes we actually depend on, with committed fixtures under `tests/fixtures/integrations/` as a living record of what upstream returns.

**Covered (the coverage-engine inputs):** Bazarr `episodes_wanted` / `movies_wanted` / `badges` / provider candidates; Sonarr system-status + series; Radarr system-status + movies. Each test feeds a fixture through a mock transport and asserts the parser unwraps the envelope + the depended-on fields survive (e.g. a Bazarr wanted episode keeps `sonarrSeriesId`/`sonarrEpisodeId`/`seriesTitle`/`episodeTitle`/`episode_number`).

Catches **our** parser regressions + documents the contract. Does **not** detect upstream changing its API (changelog-watching / live canary - noted on the issue). **Test-only, no product code.** Same harness can extend to Plex/Tautulli/Ollama + episodeFile/history later.