### PR TITLE
fix(onboarding): don't force env-configured installs through the wizard (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ breaking config changes.
     session-fixation), generic login errors (no user enumeration),
     `secrets.compare_digest` throughout.
 
+### Fixed
+- **Env-configured installs no longer forced into the onboarding wizard (#262).**
+  The root route only sends you to the first-run wizard when the install is
+  genuinely unconfigured. An install set up via env vars (the common arr-stack
+  pattern) lands on the dashboard instead of a blank wizard after login.
+  Relatedly, the wizard now **pre-fills from live settings** (secrets masked) so
+  an explicit "Re-run setup" reflects current config, and "Test connection"
+  falls back to the stored credential when a masked field is left untouched.
+
 ## [1.6.0] - 2026-06-14
 
 Headline: subarr now configures Whisper for your hardware. No migrations; no

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -64,7 +64,7 @@ from .probe_walker import ProbeWalker
 from .pending_feeder import PendingQueueFeeder
 from .pending_queue import PendingQueueStore
 from .provenance import ProvenanceStore, SOURCE_SUBGENSCAN
-from .onboarding import OnboardingStore
+from .onboarding import OnboardingStore, install_is_configured
 from .routers import (
     admin,
     aftercare as r_aftercare,
@@ -1057,7 +1057,12 @@ if _STATIC_DIR.is_dir():
         if store is not None:
             try:
                 state = store.get()
-                if not state.is_complete:
+                # #262: only force the wizard on a genuine first run. An install
+                # configured via env vars never completes the wizard, so gating
+                # on is_complete alone dragged established users into a blank
+                # wizard after login. Explicit "Re-run setup" links straight to
+                # /onboarding and so is unaffected by this gate.
+                if not state.is_complete and not install_is_configured(settings):
                     return RedirectResponse(url="/onboarding", status_code=302)
             except Exception as e:
                 log.warning("onboarding state lookup failed at /: %r", e)

--- a/src/subarr/onboarding.py
+++ b/src/subarr/onboarding.py
@@ -85,6 +85,79 @@ def _mask_progress(progress: dict[str, Any]) -> dict[str, Any]:
     return {k: (_mask_secret(v) if _is_secret_key(k) else v) for k, v in progress.items()}
 
 
+# ─── Established-install detection + pre-fill (#262) ─────────────────
+# An install configured via env vars (the common arr-stack pattern) never
+# runs the wizard, so `is_complete` stays False forever. Without this, the
+# `/` redirect drags those established users into a blank first-run wizard
+# after login. We treat "has any integration credential" as the signal that
+# this is NOT a first run, and we pre-fill the wizard from live settings so
+# that when it *does* show (genuine first run with partial env, or an explicit
+# Re-run), the fields reflect current config instead of blanks.
+
+# Wizard-field name → Settings attribute. Mirrors _apply_progress_to_settings
+# in routers/onboarding.py (the inverse direction).
+_PREFILL_FIELDS = (
+    "media_root",
+    "arr_path_prefix",
+    "bazarr_url",
+    "bazarr_api_key",
+    "sonarr_url",
+    "sonarr_api_key",
+    "radarr_url",
+    "radarr_api_key",
+    "tautulli_url",
+    "tautulli_api_key",
+    "subgen_url",
+    "ollama_url",
+    "ollama_model",
+    "plex_url",
+    "plex_token",
+)
+
+# Credentials whose presence proves the install is already set up. URLs are
+# excluded — they carry compose-default values even on a fresh install.
+_CONFIGURED_SIGNALS = (
+    "bazarr_api_key",
+    "sonarr_api_key",
+    "radarr_api_key",
+    "tautulli_api_key",
+    "plex_token",
+)
+
+
+def install_is_configured(settings: Any) -> bool:
+    """True when the install already has integration credentials — i.e. it was
+    configured (typically via env vars) and should NOT be forced through the
+    first-run wizard."""
+    return any(bool(getattr(settings, attr, "")) for attr in _CONFIGURED_SIGNALS)
+
+
+def settings_prefill(settings: Any) -> dict[str, Any]:
+    """Wizard-field values derived from the live Settings, for pre-filling the
+    wizard. Omits empty fields (so blank credentials don't paint over nothing).
+    Returns RAW values — the caller masks secrets before they leave the server."""
+    out: dict[str, Any] = {}
+    for attr in _PREFILL_FIELDS:
+        val = getattr(settings, attr, "")
+        if attr == "media_root" and val:
+            val = str(val)  # may be a Path on the real Settings
+        if val:
+            out[attr] = val
+    return out
+
+
+def apply_prefill(state_dict: dict[str, Any], settings: Any) -> dict[str, Any]:
+    """Merge settings-derived defaults UNDER the stored progress in a state dict
+    (as returned by OnboardingState.to_dict), so the wizard pre-fills from live
+    config. Stored progress (the user's wizard edits) always wins. Prefill
+    secrets are masked the same way to_dict() masks stored progress, so raw
+    credentials never reach the client. Does not mutate the input."""
+    masked_prefill = _mask_progress(settings_prefill(settings))
+    out = dict(state_dict)
+    out["progress"] = {**masked_prefill, **(state_dict.get("progress") or {})}
+    return out
+
+
 @dataclass
 class OnboardingState:
     step: int

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -47,13 +47,50 @@ class ProbePathsRequest(BaseModel):
     media_root: str
 
 
+# ─── Masked-credential fallback for Test-connection (#262) ──────────
+
+# Service → Settings attribute holding its API key. Plex is handled separately
+# (it authenticates with a token, carried in the `token` field).
+_TEST_CRED_ATTR = {
+    "bazarr": "bazarr_api_key",
+    "sonarr": "sonarr_api_key",
+    "radarr": "radarr_api_key",
+    "tautulli": "tautulli_api_key",
+}
+
+
+def _resolve_masked_credential(service: str, body: "TestRequest", settings: Any) -> None:
+    """The pre-filled wizard shows masked secrets (••••1234). If the user tests a
+    connection without retyping, the masked placeholder would fail the live
+    probe. Substitute the real value from settings for a masked/blank credential
+    so 'Test connection' works on a pre-filled (re-run / env-configured) wizard.
+    A genuinely retyped value is left untouched. Mutates body in place."""
+    from ..onboarding import _is_masked
+
+    svc = service.lower()
+    if svc == "plex":
+        tok = body.token or body.api_key or ""
+        if (not tok or _is_masked(tok)) and getattr(settings, "plex_token", ""):
+            body.token = settings.plex_token
+        return
+    attr = _TEST_CRED_ATTR.get(svc)
+    if attr and (not body.api_key or _is_masked(body.api_key)) and getattr(settings, attr, ""):
+        body.api_key = getattr(settings, attr)
+
+
 # ─── State endpoints ────────────────────────────────────────────────
 
 
 @router.get("/onboarding/state")
 def get_state(request: Request) -> dict[str, Any]:
+    # #262: pre-fill from live settings (env-configured installs, or an explicit
+    # Re-run) so the wizard reflects current config instead of blank fields.
+    # Stored wizard progress wins; secrets are masked inside apply_prefill.
+    from ..config import settings
+    from ..onboarding import apply_prefill
+
     state = request.app.state.onboarding.get()
-    return state.to_dict()
+    return apply_prefill(state.to_dict(), settings)
 
 
 @router.put("/onboarding/state")
@@ -100,6 +137,11 @@ async def test_connection(service: str, body: TestRequest, request: Request) -> 
     wanted" confirmation chip when green.
     """
     svc = service.lower()
+    # #262: a pre-filled wizard shows masked secrets; substitute the real value
+    # from settings when the user tests without retyping, else the probe fails.
+    from ..config import settings as _live_settings
+
+    _resolve_masked_credential(svc, body, _live_settings)
     handlers = {
         "bazarr": _test_bazarr,
         "sonarr": _test_sonarr,

--- a/tests/test_onboarding_established.py
+++ b/tests/test_onboarding_established.py
@@ -1,0 +1,165 @@
+"""#262: established-install detection + settings pre-fill for the wizard."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from subarr.onboarding import apply_prefill, install_is_configured, settings_prefill
+
+
+def _settings(**over):
+    base = dict(
+        media_root="/media/library",
+        arr_path_prefix="/data/Media/",
+        bazarr_url="http://bazarr:6767",
+        bazarr_api_key="",
+        sonarr_url="http://sonarr:8989",
+        sonarr_api_key="",
+        radarr_url="http://radarr:7878",
+        radarr_api_key="",
+        tautulli_url="http://tautulli:8181",
+        tautulli_api_key="",
+        subgen_url="http://subgen:9000",
+        ollama_url="http://ollama:11434",
+        ollama_model="qwen2.5:7b",
+        plex_url="http://plex:32400",
+        plex_token="",
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+# ─── install_is_configured ──────────────────────────────────────────
+
+
+def test_blank_install_is_not_configured():
+    assert install_is_configured(_settings()) is False
+
+
+def test_bazarr_key_marks_configured():
+    assert install_is_configured(_settings(bazarr_api_key="abc123")) is True
+
+
+def test_any_arr_key_marks_configured():
+    assert install_is_configured(_settings(sonarr_api_key="s")) is True
+    assert install_is_configured(_settings(radarr_api_key="r")) is True
+    assert install_is_configured(_settings(tautulli_api_key="t")) is True
+
+
+def test_plex_token_marks_configured():
+    assert install_is_configured(_settings(plex_token="tok")) is True
+
+
+# ─── settings_prefill ───────────────────────────────────────────────
+
+
+def test_prefill_includes_nonempty_fields():
+    p = settings_prefill(_settings(bazarr_api_key="realkey"))
+    assert p["media_root"] == "/media/library"
+    assert p["bazarr_url"] == "http://bazarr:6767"
+    assert p["bazarr_api_key"] == "realkey"
+
+
+def test_prefill_omits_empty_secret_fields():
+    p = settings_prefill(_settings())  # all api keys blank
+    assert "bazarr_api_key" not in p
+    assert "sonarr_api_key" not in p
+    assert "plex_token" not in p
+    # URLs + media_root still present (they have values)
+    assert "media_root" in p
+    assert "sonarr_url" in p
+
+
+def test_prefill_media_root_is_string():
+    # media_root may arrive as a Path on the real Settings; prefill must stringify.
+    from pathlib import PurePosixPath
+
+    # PurePosixPath keeps forward slashes on any host OS (the real Settings holds
+    # a PosixPath in the Linux container; str() it regardless).
+    p = settings_prefill(_settings(media_root=PurePosixPath("/mnt/media")))
+    assert p["media_root"] == "/mnt/media"
+    assert isinstance(p["media_root"], str)
+
+
+# ─── apply_prefill (state merge) ────────────────────────────────────
+
+
+def test_apply_prefill_fills_missing_fields():
+    state = {"step": 0, "progress": {}}
+    out = apply_prefill(state, _settings(sonarr_api_key="realkey"))
+    # URL pre-filled from settings
+    assert out["progress"]["sonarr_url"] == "http://sonarr:8989"
+    # secret pre-filled but MASKED (never raw to the client)
+    assert out["progress"]["sonarr_api_key"] == "••••lkey"
+
+
+def test_apply_prefill_stored_value_wins():
+    # The user typed a custom URL into the wizard — must not be overwritten.
+    state = {"step": 2, "progress": {"sonarr_url": "http://custom:8989"}}
+    out = apply_prefill(state, _settings(sonarr_url="http://sonarr:8989"))
+    assert out["progress"]["sonarr_url"] == "http://custom:8989"
+
+
+def test_apply_prefill_does_not_mutate_input():
+    state = {"step": 0, "progress": {}}
+    apply_prefill(state, _settings(bazarr_api_key="x"))
+    assert state["progress"] == {}
+
+
+# ─── masked-credential fallback for Test-connection ─────────────────
+
+
+def test_masked_arr_key_falls_back_to_settings():
+    from subarr.routers.onboarding import TestRequest, _resolve_masked_credential
+
+    body = TestRequest(url="http://sonarr:8989", api_key="••••lkey")
+    _resolve_masked_credential("sonarr", body, _settings(sonarr_api_key="realkey"))
+    assert body.api_key == "realkey"
+
+
+def test_blank_arr_key_falls_back_to_settings():
+    from subarr.routers.onboarding import TestRequest, _resolve_masked_credential
+
+    body = TestRequest(url="http://radarr:7878", api_key="")
+    _resolve_masked_credential("radarr", body, _settings(radarr_api_key="rk"))
+    assert body.api_key == "rk"
+
+
+def test_real_typed_key_is_left_untouched():
+    from subarr.routers.onboarding import TestRequest, _resolve_masked_credential
+
+    body = TestRequest(url="http://sonarr:8989", api_key="user-typed-new")
+    _resolve_masked_credential("sonarr", body, _settings(sonarr_api_key="realkey"))
+    assert body.api_key == "user-typed-new"
+
+
+def test_masked_plex_token_falls_back_to_settings():
+    from subarr.routers.onboarding import TestRequest, _resolve_masked_credential
+
+    body = TestRequest(url="http://plex:32400", token="••••oken")
+    _resolve_masked_credential("plex", body, _settings(plex_token="realtoken"))
+    assert body.token == "realtoken"
+
+
+# ─── / redirect gate (the actual bug) ───────────────────────────────
+
+
+def test_root_redirects_unconfigured_install_to_onboarding(app_with_stub, monkeypatch):
+    import subarr.app as app_mod
+
+    monkeypatch.setattr(app_mod, "install_is_configured", lambda s: False)
+    app_with_stub.app.state.onboarding.reset()  # ensure not-complete
+    r = app_with_stub.get("/", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["location"] == "/onboarding"
+
+
+def test_root_redirects_configured_install_to_home(app_with_stub, monkeypatch):
+    # #262: a configured-but-incomplete install must NOT be forced to the wizard.
+    import subarr.app as app_mod
+
+    monkeypatch.setattr(app_mod, "install_is_configured", lambda s: True)
+    app_with_stub.app.state.onboarding.reset()  # not-complete, yet configured
+    r = app_with_stub.get("/", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["location"] == "/home"


### PR DESCRIPTION
Fixes #262.

## Problem
The root `/` route gated the first-run wizard on `onboarding_state.is_complete` alone. Installs configured via **env vars** (the common arr-stack pattern) never run the wizard, so `is_complete` stays false forever. Forced auth (#238) made `_safeNext()` land every post-login load on `/`, so these established users were dragged into a **blank** onboarding wizard on upgrade (blank because `GET /api/onboarding/state` returned only `progress_json`, never the live env settings).

## Fix
- `install_is_configured(settings)` — true if any bazarr/sonarr/radarr/tautulli api-key or plex token is set.
- Gate the `/` redirect on it: wizard only for genuinely unconfigured + incomplete installs. Established → `/home`; explicit "Re-run setup" links straight to `/onboarding`, unaffected.
- **Pre-fill** `GET /api/onboarding/state` from live settings (secrets masked) so the wizard reflects current config when it does show.
- Masked-credential fallback in Test-connection so a pre-filled probe works without retyping.

No DB mutation (routing-gate correctness), no frontend bundle change (pre-fill is a backend merge the wizard already consumes).

## Verification
- New `tests/test_onboarding_established.py` (16): helpers, prefill merge + masking, masked-cred fallback, and `/` redirect for both configured and unconfigured installs.
- Full suite green (1095 passed / 2 skipped).
- Live dev-box (real env): `install_is_configured = True`, all 15 fields pre-fill with secrets masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)