### PR TITLE
fix(security): stop leaking exception text in API responses — Phase D (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ breaking config changes.
 ## [Unreleased]
 
 ### Security
+- **No internal error detail leaks to API clients (#261).** Endpoints no longer
+  return raw exception text; a shared `safe_error()` maps failures to a constant,
+  leak-free message by type/HTTP-status (e.g. "authentication failed", "could
+  not connect", "the upstream service returned a server error") while the full
+  detail goes only to the server log. Operators still see *why* something failed,
+  without exposing paths/hostnames/stack info. Clears the 19 CodeQL
+  `py/stack-trace-exposure` findings.
 - **Forced authentication (#238).** subarr now requires a login by default,
   matching modern Sonarr/Radarr. A fresh install (or the first launch after
   upgrading from a no-auth version) shows a one-time setup screen to create an

--- a/src/subarr/error_detail.py
+++ b/src/subarr/error_detail.py
@@ -1,0 +1,59 @@
+"""#261: leak-free error messages for HTTP responses.
+
+CodeQL `py/stack-trace-exposure` flags any exception text (`str(e)`) reaching an
+HTTP response — an exception message can carry internal paths, hostnames, or
+stack detail. `safe_error` returns a **constant** message chosen by exception
+TYPE / HTTP status, never derived from the exception's own text, so the operator
+still learns the *kind* of failure ("authentication failed", "could not
+connect") while the full detail goes only to the server log.
+
+Usage at a call site:
+    except SomeError as e:
+        log.warning("widget fetch failed: %s", e)   # full detail, server-side
+        raise HTTPException(502, detail=safe_error(e))   # safe, leak-free
+"""
+
+from __future__ import annotations
+
+
+import logging
+
+import httpx
+
+from .docker_client import DockerUnavailable
+from .integrations import IntegrationError
+from .integrations.ollama import OllamaError
+from .subgen_client import SubgenUnavailable
+
+# Our own typed "service is down / misconfigured" errors. Their messages are
+# author-written, but we still don't echo them — type-mapping keeps CodeQL clean
+# and the wording consistent.
+_SERVICE_ERRORS = (IntegrationError, OllamaError, SubgenUnavailable, DockerUnavailable)
+
+log = logging.getLogger(__name__)
+
+
+def safe_error(e: BaseException) -> str:
+    """A constant, leak-free message describing the *kind* of failure. Never
+    contains any text derived from the exception itself. Logs the real exception
+    server-side so the detail isn't lost — call sites can just use the return
+    value as the client-facing `detail`/`error` without adding their own log."""
+    log.warning("handled %s (returning sanitized message): %s", type(e).__name__, e)
+    if isinstance(e, httpx.HTTPStatusError):
+        code = e.response.status_code
+        if code in (401, 403):
+            return "authentication failed — check the API key or token"
+        if code == 404:
+            return "the requested resource was not found"
+        if code == 429:
+            return "the upstream service is rate-limiting requests"
+        if 500 <= code <= 599:
+            return "the upstream service returned a server error"
+        return "the upstream service rejected the request"
+    if isinstance(e, (httpx.ConnectError, httpx.ConnectTimeout)):
+        return "could not connect — check the URL and that the service is running"
+    if isinstance(e, httpx.TimeoutException):
+        return "the request timed out"
+    if isinstance(e, _SERVICE_ERRORS):
+        return "the service is unavailable or misconfigured"
+    return "an unexpected error occurred"

--- a/src/subarr/routers/admin.py
+++ b/src/subarr/routers/admin.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from ..docker_client import DockerUnavailable
+from ..error_detail import safe_error
 from ..integrations import IntegrationError
 
 router = APIRouter(prefix="/api", tags=["admin"])
@@ -62,12 +63,12 @@ async def restart_subgen(request: Request) -> dict:
     try:
         await docker_ops.restart_subgen()
     except DockerUnavailable as e:
-        raise HTTPException(503, detail=str(e))
+        raise HTTPException(503, detail=safe_error(e))
     try:
         info = await docker_ops.container_info()
     except DockerUnavailable as e:
         # restart succeeded; info failed — surface what we know
-        return {"restarted": True, "warning": str(e)}
+        return {"restarted": True, "warning": safe_error(e)}
     return {"restarted": True, "container": info}
 
 
@@ -77,7 +78,7 @@ async def container(request: Request) -> dict:
     try:
         return await docker_ops.container_info()
     except DockerUnavailable as e:
-        raise HTTPException(503, detail=str(e))
+        raise HTTPException(503, detail=safe_error(e))
 
 
 @router.post("/plex/scan")
@@ -90,7 +91,7 @@ async def plex_scan(request: Request) -> dict:
     try:
         return await plex.full_scan()
     except IntegrationError as e:
-        raise HTTPException(502, detail=str(e))
+        raise HTTPException(502, detail=safe_error(e))
 
 
 class PartialScanRequest(BaseModel):
@@ -121,7 +122,7 @@ async def plex_partial_scan(req: PartialScanRequest, request: Request) -> dict:
     try:
         return await plex.partial_scan(p)
     except IntegrationError as e:
-        raise HTTPException(502, detail=str(e))
+        raise HTTPException(502, detail=safe_error(e))
 
 
 @router.get("/plex/sections")
@@ -134,4 +135,4 @@ async def plex_sections(request: Request) -> dict:
     try:
         return {"sections": await plex.sections(refresh=True)}
     except IntegrationError as e:
-        raise HTTPException(502, detail=str(e))
+        raise HTTPException(502, detail=safe_error(e))

--- a/src/subarr/routers/audio_lang.py
+++ b/src/subarr/routers/audio_lang.py
@@ -25,6 +25,7 @@ from ..config import settings
 from ..log_safe import scrub
 from ..paths import PathOutsideRootError, canonical_to_fs
 from ..subgen_client import SubgenUnavailable
+from ..error_detail import safe_error
 
 log = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/audio-lang", tags=["audio-lang"])
@@ -142,7 +143,7 @@ async def _propagate_to_sonarr(
     try:
         langs = await sonarr.languages()
     except IntegrationError as e:
-        return {"attempted": True, "ok": False, "detail": f"sonarr /language fetch failed: {e}"}
+        return {"attempted": True, "ok": False, "detail": f"sonarr /language fetch failed: {safe_error(e)}"}
     name = _iso_to_sonarr_name(lang_code)
     target = next(
         (l for l in langs if (l.get("name") or "").lower() == name.lower()),
@@ -157,7 +158,7 @@ async def _propagate_to_sonarr(
             languages=[{"id": target["id"], "name": target["name"]}],
         )
     except IntegrationError as e:
-        return {"attempted": True, "ok": False, "detail": f"sonarr PUT failed: {e}"}
+        return {"attempted": True, "ok": False, "detail": f"sonarr PUT failed: {safe_error(e)}"}
     log.info(
         "sonarr propagation OK: episodeFile=%s language=%s (id=%s) via user verification on %s",
         ep_file_id,
@@ -204,7 +205,7 @@ async def _trigger_bazarr_sync(bundle) -> dict[str, Any]:
         try:
             tasks = await bazarr.list_tasks()
         except IntegrationError as e:
-            return {"attempted": False, "detail": f"bazarr task list failed: {e}"}
+            return {"attempted": False, "detail": f"bazarr task list failed: {safe_error(e)}"}
         for t in tasks:
             jid = (t.get("job_id") or "").lower()
             name = (t.get("name") or "").lower()
@@ -217,7 +218,7 @@ async def _trigger_bazarr_sync(bundle) -> dict[str, Any]:
     try:
         await bazarr.trigger_task(_bazarr_sync_task_id)
     except IntegrationError as e:
-        return {"attempted": True, "ok": False, "detail": f"bazarr trigger failed: {e}"}
+        return {"attempted": True, "ok": False, "detail": f"bazarr trigger failed: {safe_error(e)}"}
     log.info("bazarr sync triggered: task=%s", _bazarr_sync_task_id)
     return {"attempted": True, "ok": True, "task": _bazarr_sync_task_id}
 
@@ -528,7 +529,7 @@ async def track_mismatch_swap(req: TrackSwapRequest, request: Request) -> dict[s
     try:
         result = await probe(Path(fs))
     except Exception as e:  # noqa: BLE001
-        raise HTTPException(502, detail=f"probe failed: {e}")
+        raise HTTPException(502, detail=f"probe failed: {safe_error(e)}")
     m = detect_default_track_mismatch(result.audio, original_language)
     if m is None:
         return {"ok": True, "swapped": False, "detail": "already correct"}
@@ -538,7 +539,7 @@ async def track_mismatch_swap(req: TrackSwapRequest, request: Request) -> dict[s
     try:
         await swap_default_audio_track(fs, m.native_audio_ordinal, audio_ordinals)
     except TrackSwapError as e:
-        raise HTTPException(500, detail=str(e))
+        raise HTTPException(500, detail=safe_error(e))
 
     # 4. Re-probe + refresh the cache so the row clears immediately.
     try:
@@ -578,7 +579,7 @@ def _resolve_canonical_to_fs(canonical: str) -> str:
     try:
         target = canonical_to_fs(canonical)
     except (PathOutsideRootError, ValueError) as e:
-        raise HTTPException(400, detail=f"invalid path: {e}")
+        raise HTTPException(400, detail=f"invalid path: {safe_error(e)}")
     if not target.is_file():
         raise HTTPException(404, detail=f"not found: {canonical}")
     return str(target)
@@ -768,5 +769,5 @@ async def whisper_detect(req: WhisperDetectRequest, request: Request) -> dict[st
             chunk_length_s=max(5, min(120, int(req.chunk_length_s))),
         )
     except SubgenUnavailable as e:
-        raise HTTPException(502, detail=f"subgen unavailable: {e}")
+        raise HTTPException(502, detail=f"subgen unavailable: {safe_error(e)}")
     return result

--- a/src/subarr/routers/enrichment.py
+++ b/src/subarr/routers/enrichment.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from ..enrichment import enrich_one
 from ..integrations.ollama import OllamaError
+from ..error_detail import safe_error
 from ..subgen_client import SubgenUnavailable
 
 router = APIRouter(prefix="/api/enrichment", tags=["enrichment"])
@@ -58,7 +59,7 @@ async def health(request: Request) -> dict:
     try:
         tags = await ollama.tags()
     except OllamaError as e:
-        return {"online": False, "configured": True, "model": ollama.model, "error": str(e)}
+        return {"online": False, "configured": True, "model": ollama.model, "error": safe_error(e)}
     models = [m.get("name") for m in (tags.get("models") or [])]
     return {
         "online": True,
@@ -83,7 +84,7 @@ async def enrich_lang(req: EnrichOneRequest, request: Request, gate: bool = Quer
             store=request.app.state.enrichment,
         )
     except OllamaError as e:
-        raise HTTPException(503, detail=str(e))
+        raise HTTPException(503, detail=safe_error(e))
     return result.to_dict()
 
 
@@ -120,7 +121,7 @@ async def enrich_lang_bulk(
             )
             results.append(r.to_dict())
         except OllamaError as e:
-            errors.append({"canonical_path": it.canonical_path, "error": str(e)})
+            errors.append({"canonical_path": it.canonical_path, "error": safe_error(e)})
     if free_vram_after:
         await ollama.unload()
     return {"results": results, "errors": errors, "model_unloaded": free_vram_after}

--- a/src/subarr/routers/gpu.py
+++ b/src/subarr/routers/gpu.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import os
 import shutil
+from ..error_detail import safe_error
 from typing import Any
 
 from fastapi import APIRouter
@@ -96,7 +97,7 @@ async def gpu_status() -> dict[str, Any]:
             )
             legacy = True
         except Exception as e2:
-            return {"online": False, "error": str(e2)}
+            return {"online": False, "error": safe_error(e2)}
 
     first = gpu_csv.strip().splitlines()[0] if gpu_csv.strip() else ""
     if not first:

--- a/src/subarr/routers/household.py
+++ b/src/subarr/routers/household.py
@@ -17,6 +17,7 @@ from typing import Any
 from fastapi import APIRouter, Query, Request
 
 from ..integrations import IntegrationError
+from ..error_detail import safe_error
 
 router = APIRouter(prefix="/api/household", tags=["household"])
 log = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ async def list_users(request: Request) -> dict[str, Any]:
         users = await t.get_users()
     except IntegrationError as e:
         log.warning("get_users failed: %s", e)
-        return {"available": False, "users": [], "error": str(e)}
+        return {"available": False, "users": [], "error": safe_error(e)}
     # Filter to non-system users
     cleaned = [
         {
@@ -59,7 +60,7 @@ async def household_profile(
     try:
         users = await t.get_users()
     except IntegrationError as e:
-        return {"available": False, "members": [], "error": str(e)}
+        return {"available": False, "members": [], "error": safe_error(e)}
     members = []
     for u in users:
         uid = u.get("user_id")

--- a/src/subarr/routers/integrations.py
+++ b/src/subarr/routers/integrations.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from ..integrations import IntegrationError
+from ..error_detail import safe_error
 
 router = APIRouter(prefix="/api", tags=["integrations"])
 log = logging.getLogger(__name__)
@@ -266,10 +267,10 @@ async def _probe(name: str, client, summary_kind: str = "version") -> dict[str, 
             "version": status.get("version") if isinstance(status, dict) else None,
         }
     except IntegrationError as e:
-        return {"name": name, "online": False, "configured": True, "error": str(e)}
+        return {"name": name, "online": False, "configured": True, "error": safe_error(e)}
     except Exception as e:  # defensive
         log.warning("%s probe unexpected error: %s", name, e)
-        return {"name": name, "online": False, "configured": True, "error": repr(e)}
+        return {"name": name, "online": False, "configured": True, "error": safe_error(e)}
 
 
 @router.get("/integrations/health")

--- a/src/subarr/routers/logs.py
+++ b/src/subarr/routers/logs.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Query, Request
 from fastapi.responses import StreamingResponse
 
 from ..docker_client import DockerUnavailable
+from ..error_detail import safe_error
 
 router = APIRouter(prefix="/api", tags=["logs"])
 
@@ -26,7 +27,7 @@ async def logs_events(request: Request, tail: int = Query(200, ge=0, le=5000)) -
                 if await request.is_disconnected():
                     return
         except DockerUnavailable as e:
-            yield f"event: error\ndata: {json.dumps(str(e))}\n\n"
+            yield f"event: error\ndata: {json.dumps(safe_error(e))}\n\n"
         except asyncio.CancelledError:
             return
 

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
+from ..error_detail import safe_error
 
 log = logging.getLogger(__name__)
 router = APIRouter(prefix="/api")
@@ -158,7 +159,7 @@ async def test_connection(service: str, body: TestRequest, request: Request) -> 
         return await handler(body)
     except Exception as e:
         log.warning("test_connection %s failed: %s", svc, e)
-        return {"ok": False, "error": str(e), "version": None, "detail": None}
+        return {"ok": False, "error": safe_error(e), "version": None, "detail": None}
 
 
 async def _test_bazarr(body: TestRequest) -> dict[str, Any]:
@@ -387,7 +388,7 @@ async def root_folders(request: Request) -> dict[str, Any]:
                 ],
             }
         except Exception as e:  # noqa: BLE001 — best-effort diagnostics surface
-            out[name] = {"configured": True, "folders": [], "error": str(e)[:200]}
+            out[name] = {"configured": True, "folders": [], "error": safe_error(e)}
     return out
 
 
@@ -522,7 +523,7 @@ def detect_mounts() -> dict[str, Any]:
     except OSError as e:
         return {
             "available": False,
-            "reason": f"could not read {mountinfo_path}: {e}",
+            "reason": f"could not read {mountinfo_path}: {safe_error(e)}",
             "candidates": [],
         }
 
@@ -571,7 +572,7 @@ def probe_paths(body: ProbePathsRequest, request: Request) -> dict[str, Any]:
             if len(samples) >= 5:
                 break
     except PermissionError as e:
-        return {"ok": False, "error": f"permission denied reading {root}: {e}"}
+        return {"ok": False, "error": f"permission denied reading {root}: {safe_error(e)}"}
 
     return {
         "ok": True,
@@ -613,7 +614,7 @@ async def first_walk(request: Request) -> dict[str, Any]:
     except Exception as e:
         # Don't fail the walk if persistence fails — log it, surface it
         # in the response so the wizard can flag.
-        persist_error = str(e)
+        persist_error = safe_error(e)
         log.warning("first-walk: schedule probe_roots persist failed: %s", e)
 
     # 2. Fire the foreground walk for first-paint coverage data.
@@ -624,7 +625,7 @@ async def first_walk(request: Request) -> dict[str, Any]:
             walks.append({"walk_id": w.id, "root": w.root})
         except Exception as e:
             log.warning("first-walk start failed for %s: %s", root, e)
-            walks.append({"root": root, "error": str(e)})
+            walks.append({"root": root, "error": safe_error(e)})
     return {
         "walks": walks,
         "schedule_probe_roots": roots,

--- a/src/subarr/routers/provenance.py
+++ b/src/subarr/routers/provenance.py
@@ -19,6 +19,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 
 from ..integrations import IntegrationError
+from ..error_detail import safe_error
 
 router = APIRouter(prefix="/api", tags=["provenance"])
 log = logging.getLogger(__name__)
@@ -66,7 +67,7 @@ async def by_path(path: str, request: Request) -> dict[str, Any]:
         try:
             bazarr_history = await bundle.bazarr.episodes_history(sonarr_episode_id=sonarr_ep_id)
         except IntegrationError as e:
-            bazarr_error = str(e)
+            bazarr_error = safe_error(e)
     elif bundle.bazarr.is_configured():
         # No sonarr id known — surface a hint in the response shape but
         # don't error.

--- a/src/subarr/routers/subgen_setup.py
+++ b/src/subarr/routers/subgen_setup.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel, field_validator
 
 from ..subgen_client import SubgenUnavailable
+from ..error_detail import safe_error
 from ..subgen_config_gen import (
     detection_passthrough_snippet,
     generate_env_additions,
@@ -223,7 +224,7 @@ async def apply(body: ApplyBody, request: Request) -> dict[str, Any]:
             "reason": "subgen_unreachable",
             "detail": (
                 f"subgen did not answer — the change may or may not have applied; "
-                f"re-run detection once subgen is back ({e})"
+                f"re-run detection once subgen is back ({safe_error(e)})"
             ),
         }
     if status == 200 and resp.get("ok"):

--- a/src/subarr/routers/vision.py
+++ b/src/subarr/routers/vision.py
@@ -26,6 +26,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from ..config import settings
+from ..error_detail import safe_error
 from ..integrations.ollama import OllamaError, _VISION_FAMILIES
 
 router = APIRouter(prefix="/api/vision", tags=["vision"])
@@ -147,7 +148,7 @@ async def vision_pull(req: VisionPullRequest, request: Request) -> StreamingResp
             async for line in ollama.pull_model(req.name):
                 yield (line + "\n").encode("utf-8")
         except OllamaError as e:
-            err = json.dumps({"error": str(e)})
+            err = json.dumps({"error": safe_error(e)})
             yield (err + "\n").encode("utf-8")
 
     return StreamingResponse(gen(), media_type="application/x-ndjson")

--- a/src/subarr/sidecar_scanner.py
+++ b/src/subarr/sidecar_scanner.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import logging
 import re
+from .error_detail import safe_error
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from pathlib import Path
@@ -145,13 +146,13 @@ def scan(root: Path, loose_threshold: float = 0.85, max_depth: int | None = None
             if max_depth is not None and (len(srt_path.parts) - root_depth) > max_depth:
                 continue
         except OSError as e:
-            result.errors.append(f"{srt_path}: {e}")
+            result.errors.append(f"{srt_path}: {safe_error(e)}")
             continue
         result.total_srt += 1
         try:
             mismatch = _classify_one(srt_path, loose_threshold)
         except OSError as e:
-            result.errors.append(f"{srt_path}: {e}")
+            result.errors.append(f"{srt_path}: {safe_error(e)}")
             continue
         if mismatch is None:
             result.exact_matches += 1

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -226,12 +226,11 @@ def test_integrations_health_isolates_one_failure(app_with_stub):
     r = app_with_stub.get("/api/integrations/health")
     by_name = {it["name"]: it for it in r.json()["integrations"]}
     assert by_name["bazarr"]["online"] is False
-    # bazarr's repeated 500s trip its per-client circuit breaker (#235), so the
-    # error is either the raw HTTP 500 or the breaker's "circuit open" backoff —
-    # both mean offline. The point of THIS test is isolation: one failing
-    # integration must not take the others down (each has its own breaker).
-    err = by_name["bazarr"].get("error", "")
-    assert "500" in err or "circuit open" in err
+    # bazarr's repeated 500s trip its per-client circuit breaker (#235). The point
+    # of THIS test is isolation: one failing integration must not take the others
+    # down (each has its own breaker). #261: the offline reason is surfaced but
+    # sanitized — we just assert a reason is present, not its (now leak-free) text.
+    assert by_name["bazarr"].get("error")
     assert by_name["sonarr"]["online"] is True
 
 

--- a/tests/test_error_detail.py
+++ b/tests/test_error_detail.py
@@ -1,0 +1,55 @@
+"""#261: safe_error maps exceptions to constant, leak-free messages."""
+
+from __future__ import annotations
+
+import httpx
+
+from subarr.docker_client import DockerUnavailable
+from subarr.error_detail import safe_error
+from subarr.integrations import IntegrationError
+from subarr.integrations.ollama import OllamaError
+from subarr.subgen_client import SubgenUnavailable
+
+
+def _http_status(code: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("GET", "http://svc.test/api")
+    resp = httpx.Response(code, request=req)
+    return httpx.HTTPStatusError(f"HTTP {code}", request=req, response=resp)
+
+
+def test_auth_status_codes():
+    for code in (401, 403):
+        assert "authentication" in safe_error(_http_status(code)).lower()
+
+
+def test_not_found_rate_limited_server():
+    assert "not found" in safe_error(_http_status(404)).lower()
+    assert "rate" in safe_error(_http_status(429)).lower()
+    assert "server error" in safe_error(_http_status(500)).lower()
+
+
+def test_connect_and_timeout():
+    assert "connect" in safe_error(httpx.ConnectError("boom")).lower()
+    assert "timed out" in safe_error(httpx.TimeoutException("slow")).lower()
+
+
+def test_typed_integration_errors_are_generic():
+    for e in (
+        OllamaError("model /secret/path failed"),
+        IntegrationError("internal stack detail"),
+        SubgenUnavailable("http://subgen:9000 refused at line 42"),
+        DockerUnavailable("/var/run/docker.sock permission denied"),
+    ):
+        msg = safe_error(e)
+        assert "unavailable" in msg.lower() or "misconfigured" in msg.lower()
+
+
+def test_never_leaks_the_raw_message():
+    secret = "/etc/subarr/secret.key line 99 Traceback"
+    msg = safe_error(ValueError(secret))
+    assert secret not in msg
+    assert "unexpected" in msg.lower()
+
+
+def test_returns_plain_string():
+    assert isinstance(safe_error(Exception("x")), str)

--- a/tests/test_integrations_health_probe.py
+++ b/tests/test_integrations_health_probe.py
@@ -49,7 +49,11 @@ async def test_status_failure_marks_offline():
         "bazarr_badges",
     )
     assert out["online"] is False
-    assert "timeout" in out["error"]
+    # #261: the raw exception text must NOT leak to the client; a safe,
+    # constant message is returned instead (real detail goes to the server log).
+    assert out["error"]
+    assert "timeout" not in out["error"]
+    assert "/api/system/status" not in out["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_root_folders.py
+++ b/tests/test_root_folders.py
@@ -90,7 +90,10 @@ def test_root_folders_endpoint_isolates_per_service_errors(app_with_stub):
     body = app_with_stub.get("/api/onboarding/root-folders").json()
     assert body["radarr"]["configured"] is True
     assert body["radarr"]["folders"] == []
-    assert "arr down" in body["radarr"]["error"]
+    # #261: per-service failure still isolates the error, but the raw exception
+    # text is sanitized out of the response (no leak to the client).
+    assert body["radarr"]["error"]
+    assert "arr down" not in body["radarr"]["error"]
     assert body["sonarr"]["configured"] is False  # the other service unaffected
 
 


### PR DESCRIPTION
Phase D — the final item on the forced-auth roadmap. Closes #261.

## Problem
Endpoints returned raw exception text (`str(e)` / `f"...{e}"`) in HTTP responses — CodeQL `py/stack-trace-exposure` (19 findings). An exception message can carry internal paths, hostnames, or stack detail.

## Fix
`error_detail.safe_error(e)` maps a failure to a **constant**, leak-free message by exception **type / HTTP status** (e.g. "authentication failed", "could not connect — check the URL", "the upstream service returned a server error") and **logs the real exception server-side**. The returned string is never derived from the exception, so it clears the CodeQL taint while the operator still learns the *kind* of failure. Reminder: these endpoints are auth-gated now (post-#238), so the audience was already authenticated admins.

Swept **34 response-bound sites across 12 modules** (the 19 flagged + same-pattern siblings, for consistency): admin, audio_lang, enrichment, gpu, household, integrations, logs, onboarding, provenance, subgen_setup, vision, sidecar_scanner.

## Tests
- New `test_error_detail` (6): type/status mapping + "never leaks the raw message".
- Updated 3 tests that had asserted the **old leaked text** (`"timeout" in error`, `"arr down" in error`, `"500" in err`) to assert the sanitized property instead — reason still surfaced, raw text absent.
- **Full suite 1146 passed / 2 skipped.**

CodeQL on this PR is the real proof it clears all 19 `py/stack-trace-exposure` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)