### PR TITLE
fix(telemetry): stop tests/CI pinging the prod endpoint (#202 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ breaking config changes.
 
 ## [Unreleased]
 
+### Fixed
+- **Telemetry no longer transmits under tests/CI (#202 follow-up).** The pinger
+  POSTs on its first tick and the endpoint default is the real prod URL, so every
+  test that booted the app was pinging telemetry.subarr.com — inflating the
+  public install count with our own dev/CI runs. The test suite now hard-disables
+  the endpoint, and the pinger is a no-op when no endpoint is configured.
+
 ### Security
 - **No internal error detail leaks to API clients (#261).** Endpoints no longer
   return raw exception text; a shared `safe_error()` maps failures to a constant,

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -171,6 +171,13 @@ class TelemetryCollector:
     # ─── Lifecycle ─────────────────────────────────────────────────
 
     def start(self) -> None:
+        # No endpoint ⇒ telemetry is disabled (opt-out, or the test/CI env that
+        # sets SUBARR_TELEMETRY_ENDPOINT=""). Don't spawn the pinger at all — its
+        # first tick POSTs immediately, which is how the test suite was polluting
+        # the prod endpoint. Manual `send_now()` still works + records locally.
+        if not self._endpoint:
+            log.info("telemetry disabled (no endpoint) — pinger not started")
+            return
         if self._task is not None and not self._task.done():
             return
         self._stop.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,10 @@ import pytest
 # gate suite-wide so the ~1000 real-app tests aren't all 401'd. Set at import
 # (before any subarr.app import) so the import-time settings singleton sees it.
 os.environ.setdefault("SUBARR_AUTH_DISABLED", "1")
+# #202: hard-disable telemetry transmission across the suite. The endpoint
+# default is the real prod URL and the pinger POSTs on its first tick, so every
+# TestClient boot was pinging telemetry.subarr.com. Empty = "don't transmit".
+os.environ.setdefault("SUBARR_TELEMETRY_ENDPOINT", "")
 
 
 def _make_compose(p: Path) -> None:

--- a/tests/test_telemetry_disabled.py
+++ b/tests/test_telemetry_disabled.py
@@ -1,0 +1,49 @@
+"""#202 follow-up: telemetry must NOT transmit under tests/CI.
+
+The pinger's _loop POSTs immediately on start(), the endpoint default is the
+real prod URL, and conftest never disabled it — so every TestClient boot was
+pinging telemetry.subarr.com (the Windows/AMD64 flood in the prod D1). These
+guard against a regression of that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from subarr.migrate import run_migrations
+from subarr.telemetry import TelemetryCollector
+
+
+def _collector(db_path, endpoint):
+    p = db_path / "t.db"
+    run_migrations(p)
+    return TelemetryCollector(db_path=p, endpoint=endpoint, subarr_version="vTEST")
+
+
+def test_start_is_noop_without_endpoint(tmp_path):
+    # Disabled telemetry (no endpoint) must not spawn the pinger — its first
+    # tick would otherwise POST to whatever endpoint is configured.
+    c = _collector(tmp_path, "")
+    c.start()
+    assert c._task is None
+
+
+@pytest.mark.asyncio
+async def test_start_spawns_pinger_when_endpoint_set(tmp_path, monkeypatch):
+    c = _collector(tmp_path, "https://telemetry.example/ping")
+
+    async def _noop():
+        return (False, None)
+
+    monkeypatch.setattr(c, "send_now", _noop)  # never touch the network in tests
+    c.start()
+    assert c._task is not None
+    await c.stop()
+
+
+def test_test_env_disables_telemetry_endpoint():
+    # Regression guard: conftest hard-disables the baked prod endpoint so the
+    # suite can never ping telemetry.subarr.com again.
+    from subarr.config import settings
+
+    assert settings.telemetry_endpoint == ""


### PR DESCRIPTION
Surfaced while validating the #202 data-dive: our telemetry is heavily self-polluted.

## Root cause
`telemetry.py` `_loop` does `await send_now()` **immediately on start**, `lifespan` starts the collector unconditionally against the **baked prod default** (`https://telemetry.subarr.com/v1/ping`), and conftest never disabled it. So **every test that boots a `TestClient` fired a real ping** — fresh temp `/data` per test → fresh install_id → one ping. CI does it on every PR; local full-suite runs do it hundreds of times.

## Evidence (prod D1)
- **90% of single-ping installs are `os_arch=Windows/AMD64`** — but subarr ships as a **Linux Docker image only**, so those are us running from source / under pytest, not real users.
- Real-user base is ~**570 Linux installs**, not the ~4,930 the raw counts implied. The public **subarr.com/stats install count is inflated**, and the #202 funnel analysis was contaminated.

## Fix
- **conftest:** `SUBARR_TELEMETRY_ENDPOINT=""` suite-wide (empty = "don't transmit"), mirroring the `SUBARR_AUTH_DISABLED` guard.
- **`TelemetryCollector.start()`:** no-op when no endpoint — a disabled collector no longer spawns a pinger whose first tick POSTs. Manual `send_now()` + local recording unchanged.
- **tests:** `start()` no-op without endpoint, spawns with endpoint, + a regression guard that the test env has telemetry disabled.

Full suite **1149 passed / 2 skipped**.

## Not in this PR (follow-ups)
- **D1 cleanup** of the already-polluted rows (destructive — backup-first plan for review).
- **#202** re-analysis on cleaned data once it accrues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)