### PR TITLE
fix: update nudge fires when running version is ahead of latest

### DIFF
--- a/src/subarr/update_checker.py
+++ b/src/subarr/update_checker.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sqlite3
 import time
 import defusedxml.ElementTree as ET  # XXE / billion-laughs hardened (B314)
@@ -131,25 +132,58 @@ def parse_vanilla_version(py_source: str) -> str | None:
     can't see it. Its version is the ``subgen_version = '<v>'`` constant at the
     top of subgen.py — pull it from the raw file. Returns None if absent (the
     constant moved/renamed) so the caller fails soft to 'no release info'."""
-    import re
 
     m = re.search(r"^subgen_version\s*=\s*['\"]([^'\"]+)['\"]", py_source, re.MULTILINE)
     return m.group(1) if m else None
 
 
+def _version_key(tag: str | None) -> tuple[int, ...] | None:
+    """The numeric components of a version tag as an int tuple for ordering,
+    or None when the tag has no digits (an opaque tag we can't order).
+    'v2.0.0' → (2, 0, 0); 'v2026.05.3-r9' → (2026, 5, 3, 9)."""
+    if not tag:
+        return None
+    nums = re.findall(r"\d+", tag)
+    return tuple(int(n) for n in nums) if nums else None
+
+
+def compare_versions(a: str | None, b: str | None) -> int | None:
+    """Order two version tags: -1 if a<b, 0 if equal, 1 if a>b, or None when
+    either has no numeric content (incomparable opaque tags). Shorter tuples
+    are zero-padded so '2.0' == '2.0.0'. The 'v' prefix is irrelevant to the
+    numeric key, so 'v2.0.0' == '2.0.0'."""
+    ka, kb = _version_key(a), _version_key(b)
+    if ka is None or kb is None:
+        return None
+    n = max(len(ka), len(kb))
+    ka = ka + (0,) * (n - len(ka))
+    kb = kb + (0,) * (n - len(kb))
+    return (ka > kb) - (ka < kb)
+
+
 def missed_releases(entries: list[dict[str, Any]], current_version: str | None) -> list[dict[str, Any]]:
-    """The releases an install is missing: every feed entry NEWER than its
-    current version (entries are newest-first; we take until we hit the
-    current tag). Current version older than the feed window → the whole
-    feed is missed. Unknown current → [] (never guess). Bodies stripped —
-    only {tag, title, notes_url, released_at} travel to the UI."""
+    """The releases an install is missing: every feed entry strictly NEWER
+    than its current version (entries are newest-first; we stop at the first
+    entry that is the current version or older). Current older than the feed
+    window → the whole feed is missed. Current NEWER than the whole feed
+    (locally-built, or the window just after we tag a release before the
+    cache refreshes) → [] — never "N releases behind". Unknown current → []
+    (never guess). Bodies stripped — only {tag, title, notes_url,
+    released_at} travel to the UI."""
     if not current_version:
         return []
     cur = current_version.lstrip("v")
     out: list[dict[str, Any]] = []
     for e in entries:
-        tag = (e.get("tag") or "").lstrip("v")
-        if tag and tag == cur:
+        tag = e.get("tag") or ""
+        cmp = compare_versions(tag, current_version)
+        if cmp is not None:
+            # Orderable tags: stop once an entry is the current version or
+            # older. Yields [] when current is ahead of the whole feed.
+            if cmp <= 0:
+                break
+        elif tag.lstrip("v") == cur:
+            # Opaque/un-orderable tag: fall back to exact-match stop.
             break
         out.append(
             {
@@ -212,14 +246,19 @@ class UpdateState:
 
     @property
     def has_update(self) -> bool:
-        """True iff we know both current + latest and they differ.
+        """True only when the running version is strictly OLDER than latest.
 
-        Uses string equality — versions are opaque tags like
-        'v1.0.0' or 'v2026.05.3-r1'. We don't try to semver-compare;
-        any mismatch surfaces a notification and the user decides."""
+        Direction matters: a locally-built install (or the window just after
+        we tag a release, before the 24h cache refreshes) can be NEWER than
+        the latest release the feed knows about — that's 'up to date', not an
+        update. We order by numeric version key; for opaque un-orderable tags
+        (no digits) we fall back to 'any difference is news'."""
         if not self.current_version or not self.latest_version:
             return False
-        return self.current_version.lstrip("v") != self.latest_version.lstrip("v")
+        cmp = compare_versions(self.current_version, self.latest_version)
+        if cmp is None:
+            return self.current_version.lstrip("v") != self.latest_version.lstrip("v")
+        return cmp < 0
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -216,6 +216,27 @@ async def test_strips_v_prefix_for_comparison(db_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_has_update_false_when_current_ahead_of_latest(db_path: Path):
+    """Regression: the running version is NEWER than the latest release the
+    feed knows about (locally-built, or the window right after we tag a
+    release before the cache refreshes). That's 'up to date', never an
+    'update available' nudge — direction matters, not mere inequality."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return _atom_response(req, "v1.6.0")
+
+    c = _checker_with_mock(db_path, handler, current_versions={"subarr": "2.0.0"})
+    await c._poll_all()
+    await c._client.aclose()
+
+    [s] = c.states()
+    assert s.latest_version == "v1.6.0"
+    assert s.current_version == "2.0.0"
+    assert s.has_update is False
+    assert s.missed_releases == []
+
+
+@pytest.mark.asyncio
 async def test_404_records_error_without_crashing(db_path: Path):
     """Private/non-existent repos return 404. Should write a row with
     last_error set, no latest_version, has_update False."""

--- a/tests/test_update_nudge.py
+++ b/tests/test_update_nudge.py
@@ -69,6 +69,33 @@ def test_missed_releases_between_current_and_latest(subarr_env):
     assert missed_releases(entries, None) == []
 
 
+def test_missed_releases_empty_when_current_ahead_of_feed(subarr_env):
+    """Regression: a locally-built / just-released-ahead install (current
+    NEWER than every entry in the cached feed) is NOT 'N releases behind'.
+    The dev box showed 'v1.6.0 is out — you're on 2.0.0 (10 releases behind)'
+    because the take-until-current-tag walk never matched and returned the
+    whole feed. Current > newest feed entry must yield []."""
+    from subarr.update_checker import missed_releases, parse_atom_entries
+
+    entries = parse_atom_entries(_FEED)  # newest is v1.5.2
+    assert missed_releases(entries, "2.0.0") == []
+    assert missed_releases(entries, "v2.0.0") == []
+
+
+def test_compare_versions_orders_and_handles_opaque(subarr_env):
+    from subarr.update_checker import compare_versions
+
+    assert compare_versions("1.6.0", "2.0.0") == -1  # older < newer
+    assert compare_versions("2.0.0", "1.6.0") == 1  # newer > older
+    assert compare_versions("v2.0.0", "2.0.0") == 0  # 'v' prefix + equal
+    assert compare_versions("2.0", "2.0.0") == 0  # zero-pad shorter
+    # date-rev subgen tags are still orderable
+    assert compare_versions("v2026.05.3-r9", "v2026.05.3-r10") == -1
+    # no numeric content → incomparable
+    assert compare_versions("latest", "2.0.0") is None
+    assert compare_versions(None, "2.0.0") is None
+
+
 def test_state_roundtrips_missed_releases(subarr_env, tmp_path):
     from subarr.migrate import run_migrations
     from subarr.update_checker import UpdateChecker


### PR DESCRIPTION
**Symptom** (caught dogfooding the dev box): the dashboard showed *"v1.6.0 is out — you're on 2.0.0 (10 releases behind)"* — nonsensical, since 2.0.0 is **newer** than 1.6.0. The dev box runs locally-built 2.0.0 with a `latest=1.6.0` cached from a poll *before* the v2.0.0 release published.

**Root cause** — two coupled direction-blind bugs in `update_checker.py`:
- `has_update` used string inequality (`current != latest`), deliberately direction-agnostic — so a version *ahead* of latest counted as "update available."
- `missed_releases` walked the feed "until we hit the current tag." When the running version is newer than the whole feed, its tag never appears, so it returned the **entire feed** → "10 releases behind."

This is exactly the cohort #223's "honest nudge for locally-built images" was meant to serve — plus everyone in the window between a tag and its release publishing.

**Fix**
- New `compare_versions(a, b)` → numeric version-key ordering (zero-padded, `v`-prefix agnostic; `None` for opaque un-orderable tags like a digit-less string). Date-rev subgen tags (`v2026.05.3-r9`) remain orderable.
- `has_update` is now true **only when current is strictly older** than latest. Opaque tags fall back to the old "any difference is news."
- `missed_releases` stops at the first entry `<= current`, yielding `[]` when ahead. The "older than feed window" case (all-missed) is preserved.

Frontend nudge already gates on `has_update`, so no UI change.

**Verified**
- New TDD tests: `test_has_update_false_when_current_ahead_of_latest`, `test_missed_releases_empty_when_current_ahead_of_feed`, `test_compare_versions_orders_and_handles_opaque`. All update-checker suites green (35 passed).
- Live on the dev box: ahead → `has_update=False` (no banner), behind → `has_update=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)