### PR TITLE
fix: arena /asr rejects 3-letter language tags — normalize to Whisper ISO 639-1

### DIFF
--- a/src/subarr/arena.py
+++ b/src/subarr/arena.py
@@ -28,9 +28,34 @@ import asyncio
 from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
+from .langs import normalize_lang
 from .paths import canonical_to_fs, canonical_to_subgen_batch
 from .subtitle_readability import parse_srt
 from .tournament_harness import judge_candidates
+
+# Whisper's accepted language codes (2-letter ISO 639-1 + a few specials),
+# the exact set subgen /asr validates against. Arr/ffprobe tags are 3-letter
+# ISO 639-2/B ('ger', 'fre'), which /asr hard-rejects — so we normalize to
+# this set and, for anything that doesn't land in it, send no language at all
+# (Whisper auto-detects) rather than failing the whole sweep on a bad code.
+_WHISPER_LANGS = frozenset(
+    "af am ar as az ba be bg bn bo br bs ca cs cy da de el en es et eu fa fi fo "
+    "fr gl gu ha haw he hi hr ht hu hy id is it ja jw ka kk km kn ko la lb ln lo "
+    "lt lv mg mi mk ml mn mr ms mt my ne nl nn no oc pa pl ps pt ro ru sa sd si "
+    "sk sl sn so sq sr su sv sw ta te tg th tk tl tr tt uk ur uz vi yi yo zh yue".split()
+)
+
+
+def to_whisper_lang(code: str | None) -> str | None:
+    """Coerce an arr/ffprobe language tag to the code subgen /asr accepts.
+
+    Normalizes to ISO 639-1 (e.g. 'ger' → 'de') and returns it only when it
+    lands in Whisper's accepted set; otherwise None, so the caller omits the
+    param and Whisper auto-detects instead of erroring on an invalid code."""
+    if not code:
+        return None
+    norm = normalize_lang(code)
+    return norm if norm in _WHISPER_LANGS else None
 
 
 class ArenaUnsupported(RuntimeError):
@@ -230,7 +255,11 @@ class AsrRunner:
     ):
         self._subgen = subgen
         self._caps = capabilities
-        self._source_language = source_language
+        # Normalize the source language to Whisper's accepted code set up front
+        # (arr tags are 3-letter ISO 639-2/B like 'ger'; /asr needs 'de'). An
+        # un-mappable tag becomes None → Whisper auto-detects rather than the
+        # whole sweep erroring on an invalid code.
+        self._source_language = to_whisper_lang(source_language)
         self._to_fs_path = to_fs_path
         self._to_subgen = to_subgen
         self._sampler = sampler

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -252,6 +252,60 @@ async def test_asr_runner_requests_vanilla_base_when_supported(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_asr_runner_maps_three_letter_lang_to_whisper_iso(tmp_path):
+    """Arr/ffprobe tags are 3-letter ISO 639-2/B ('ger'); subgen /asr only
+    accepts 2-letter ISO 639-1 ('de') and hard-errors on anything else.
+    Regression (live dogfood): source_language='ger' must reach /asr as 'de',
+    not the raw 'ger' that failed the whole sweep."""
+    c0 = tmp_path / "c0.wav"
+    c0.write_bytes(b"RIFF")
+    seen = []
+
+    def handler(req):
+        seen.append(dict(req.url.params))
+        return httpx.Response(
+            200, text="1\n00:00:00,000 --> 00:00:01,000\nx\n", headers={"content-type": "text/plain"}
+        )
+
+    runner = AsrRunner(
+        _client(handler),
+        capabilities=_caps(True),
+        source_language="ger",
+        to_fs_path=lambda p: p,
+        sampler=lambda fs: [{"path": str(c0), "kind": "speech", "ranges": []}],
+    )
+    await runner.prepare("TV/Show/ep.mkv")
+    await runner.run(0, task="transcribe", kwargs={})
+    assert seen[-1].get("language") == "de"
+
+
+@pytest.mark.asyncio
+async def test_asr_runner_omits_unmappable_lang_for_autodetect(tmp_path):
+    """An un-mappable tag ('und') must NOT be forwarded — omit the param so
+    Whisper auto-detects, rather than erroring the sweep on an invalid code."""
+    c0 = tmp_path / "c0.wav"
+    c0.write_bytes(b"RIFF")
+    seen = []
+
+    def handler(req):
+        seen.append(dict(req.url.params))
+        return httpx.Response(
+            200, text="1\n00:00:00,000 --> 00:00:01,000\nx\n", headers={"content-type": "text/plain"}
+        )
+
+    runner = AsrRunner(
+        _client(handler),
+        capabilities=_caps(True),
+        source_language="und",
+        to_fs_path=lambda p: p,
+        sampler=lambda fs: [{"path": str(c0), "kind": "speech", "ranges": []}],
+    )
+    await runner.prepare("TV/Show/ep.mkv")
+    await runner.run(0, task="transcribe", kwargs={})
+    assert "language" not in seen[-1]
+
+
+@pytest.mark.asyncio
 async def test_asr_returns_detected_language_when_requested(tmp_path):
     c0 = tmp_path / "c.wav"
     c0.write_bytes(b"RIFF")


### PR DESCRIPTION
**Caught dogfooding** (running a 6-recipe sweep on a German episode while the normal queue ran):

\`\`\`
subgen /asr error: ASR processing failed: 'ger' is not a valid language code
(accepted: af, am, ar, ... de, ...)
\`\`\`

**Root cause:** arr/ffprobe store audio languages as 3-letter ISO 639-2/B (\`ger\`, \`fre\`, \`jpn\`). Whisper's \`/asr\` only accepts 2-letter ISO 639-1 (\`de\`). \`AsrRunner.run\` passed \`source_language\` straight to \`/asr\` (\`arena.py:274\`), so **the arena failed for essentially every foreign file with a 3-letter tag** — not just this one.

**Fix:** new \`to_whisper_lang()\` — normalize through the existing \`normalize_lang\` helper and validate against Whisper's accepted code set; un-mappable tags (\`und\`, garbage) → \`None\` so Whisper auto-detects rather than erroring the whole sweep. Applied once in \`AsrRunner.__init__\`.

**Verified**
- TDD: \`test_asr_runner_maps_three_letter_lang_to_whisper_iso\` (ger→de reaches /asr), \`test_asr_runner_omits_unmappable_lang_for_autodetect\` (und → param omitted). Full arena suites green (65 passed).
- Live on the dev box: \`ger→de\`, \`fre→fr\`, \`spa→es\`, \`jpn→ja\`, \`und/xx→None\`.

**Architecture note** (the question that surfaced this): the arena uses subgen's \`/asr\` upload channel directly and bypasses the normal pending queue, so a recipe sweep and a queued transcription hit subgen concurrently (subgen's model lock serializes the actual GPU work). Working as designed; flagging for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)