### PR TITLE
fix: arena concurrency hardening (review findings) + pre-merge review policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# subarr — project instructions
+
+## Pre-merge review policy (MANDATORY before every merge)
+
+Every PR gets a review scaled to its blast radius **before** it is merged. No merge until the
+tier-appropriate review passes and every real finding is fixed or filed as an issue.
+
+| Tier | Scope | Required review |
+|------|-------|-----------------|
+| **0 — Trivial** | docs, comments, version bumps, config one-liners, mechanical renames, bundle-only churn | Read the full diff (spec + quality). No subagents. |
+| **1 — Substantive** | new logic, multi-file changes, behaviour changes, any bugfix with real logic | **Multi-lens adversarial review** — 2–3 reviewer subagents, lenses chosen for the change (correctness, edge/boundary cases, + the change's domain risk). Triage every finding (verify against the code — do NOT rubber-stamp), fix reals or file before merge. |
+| **2 — High-stakes** | auth/session, concurrency, data-model/migrations, path/filesystem/security, write-back to an arr, secrets/telemetry, money | Tier-1 **plus a security & failure-mode lens.** Reserve an **ultra** (`/code-review ultra <PR#>`) pass for the milestone/release boundary, not every PR. |
+
+Notes:
+- Reviewers are read-only; the controller triages and applies fixes (keeps lenses isolated).
+- "Verify, don't rubber-stamp": reviewers sometimes contradict each other or flag non-issues —
+  confirm each finding against the actual code before acting (this is how #279's review found 2 real
+  bugs and correctly dismissed several non-issues).
+- Scale the lenses to the change. A concurrency change gets a races lens; a path change gets a
+  traversal/security lens; a parser gets a malformed-input lens.
+
+## Comprehensive review program
+
+A one-time deep sweep of the major/critical subsystems is tracked in memory
+(`reference_subarr-review-program`). Each area gets a scoped multi-lens review like #279, producing a
+triaged findings list. Auth is reserved for a single final ultra pass once the non-ultra areas are clear.
+
+## Solo-repo merge
+
+Branch protection is bypassed with `gh pr merge <NN> --squash --admin --delete-branch` (solo repo).
+The pre-merge review above is the real gate, not branch protection.

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -825,6 +825,10 @@ async def lifespan(app_: FastAPI):
             await app_.state.audio_audit.aclose()
         except (AttributeError, Exception):
             pass
+        try:
+            await app_.state.arena.aclose()  # cancel + await in-flight sweeps before store close
+        except (AttributeError, Exception):
+            pass
         await app_.state.scheduler.stop()
         try:
             app_.state.coverage_cache_task.cancel()
@@ -862,6 +866,10 @@ async def lifespan(app_: FastAPI):
             pass
         app_.state.pending.close()
         app_.state.onboarding.close()
+        try:
+            app_.state.arena_store.close()
+        except (AttributeError, Exception):
+            pass
         try:
             app_.state.aftercare.close()  # #156
         except (AttributeError, Exception):

--- a/src/subarr/arena_service.py
+++ b/src/subarr/arena_service.py
@@ -157,8 +157,17 @@ class ArenaService:
         self._tasks[run.id] = asyncio.create_task(self._run(run), name=f"arena-{run.id}")
 
     async def aclose(self) -> None:
-        for t in list(self._tasks.values()):
+        tasks = list(self._tasks.values())
+        for t in tasks:
             t.cancel()
+        # Await cancellation so a sweep's _run finally (the _inflight decrement +
+        # terminal status write) lands before the store is closed on shutdown,
+        # instead of racing the event loop / SQLite teardown.
+        for t in tasks:
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
 
     # ── SSE ────────────────────────────────────────────────────────────────
     def _emit(self, run_id: str, evt: dict) -> None:
@@ -224,7 +233,7 @@ class ArenaService:
                 self._emit(
                     run.id, {"event": "waiting_for_capacity", "data": {"id": run.id, "ahead": processing}}
                 )
-            await asyncio.sleep(CAPACITY_POLL_INTERVAL_S)
+            await asyncio.sleep(self._capacity_poll_interval_s)
 
     async def _run(self, run: ArenaRun) -> None:
         run_id = run.id

--- a/src/subarr/arena_store.py
+++ b/src/subarr/arena_store.py
@@ -48,7 +48,7 @@ class ArenaRun:
     media_path: str
     variants: list[dict[str, Any]]  # [{label, kwargs}]
     source_language: str | None = None
-    status: str = "pending"  # pending | queued | running | done | error
+    status: str = "pending"  # pending | queued | waiting_for_capacity | running | done | error
     source_text: str | None = None
     outcomes: list[dict[str, Any]] = field(default_factory=list)
     result: dict[str, Any] | None = None  # serialized TournamentResult

--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -302,6 +302,10 @@ async def get_queue(request: Request, history_window_s: int = _DEFAULT_HISTORY_W
                 }
             )
 
+    # Count of arena sweeps actively transcribing (running /asr) — NOT sweeps
+    # parked in waiting_for_capacity (those hold no GPU slot, so the "using a
+    # slot" indicator stays silent until they actually start). A waiting sweep is
+    # surfaced on its own Tuning-Lab card, not here.
     arena = getattr(request.app.state, "arena", None)
     arena_active = arena.inflight_count() if arena is not None else 0
 

--- a/src/subarr/subgen_capacity.py
+++ b/src/subarr/subgen_capacity.py
@@ -9,6 +9,15 @@ feeder and the arena — consult this before committing work.
 N is read live from subgen (capabilities.concurrent_transcriptions); when it is
 unknown (old subgen, or subgen unreachable) the gate is disabled so behaviour is
 exactly as before — no regression, no false stalls.
+
+SOFT GATE (known limitation): the feeder and the arena each read subgen's state
+and decide independently, with no shared lock spanning check-then-commit. A brief
+overshoot to N+1 is possible when both commit in the same window (e.g. the feeder
+submits a /batch job the same tick an arena sweep starts). It self-corrects on the
+next feeder tick (which then sees the higher processing count). A hard, race-free
+guarantee would require enforcement INSIDE subgen (/asr sharing the worker pool's
+semaphore) — deliberately out of scope; this external gate trades a rare,
+self-healing N+1 for zero subgen changes.
 """
 
 from __future__ import annotations

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -334,7 +334,13 @@ class SubgenClient:
                             ignore_forced_subtitles = bool(caps_block.get("ignore_forced_subtitles"))
                             runtime_config = bool(caps_block.get("runtime_config"))
                             _ct = caps_block.get("concurrent_transcriptions")
-                            concurrent_transcriptions = _ct if isinstance(_ct, int) and _ct > 0 else None
+                            # bool is an int subclass — exclude it so a misconfig'd
+                            # `true` doesn't silently parse as N=1 and serialize the feed.
+                            concurrent_transcriptions = (
+                                _ct
+                                if isinstance(_ct, int) and not isinstance(_ct, bool) and _ct > 0
+                                else None
+                            )
                 except ValueError:
                     pass
         except httpx.HTTPError:

--- a/tests/test_arena_service.py
+++ b/tests/test_arena_service.py
@@ -714,6 +714,20 @@ async def test_sweep_waits_for_capacity_then_runs(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aclose_cancels_and_awaits_inflight_sweep(tmp_path):
+    # A sweep parked in waiting_for_capacity (subgen at capacity, N=1) must be
+    # cancelled AND awaited by aclose() — so shutdown is deterministic, not GC-raced.
+    svc, _sub = _cap_svc(tmp_path, processing=[{"path": "/m/x.mkv"}], n=1)
+    run = svc.create("TV/Show/ep.mkv", [ConfigVariant("base", {})])
+    svc.start(run)
+    await asyncio.sleep(0.1)
+    assert svc.get(run.id).status == "waiting_for_capacity"
+    await svc.aclose()
+    assert all(t.done() for t in svc._tasks.values())
+    assert svc.inflight_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_await_capacity_fails_open_after_unreadable_probes(tmp_path):
     # When subgen's /queue raises on every call, the gate must fail OPEN after
     # CAPACITY_PROBE_FAIL_OPEN_AFTER consecutive failures — never stall a sweep

--- a/tests/test_subgen_client.py
+++ b/tests/test_subgen_client.py
@@ -39,6 +39,24 @@ async def test_probe_concurrent_transcriptions_absent_is_none():
 
 
 @pytest.mark.asyncio
+async def test_probe_concurrent_transcriptions_bool_is_none():
+    """A subgen misconfig returning `true`/`false` must NOT parse as N=1/0 —
+    isinstance(True, int) is True in Python, so the bool would sneak through the
+    int guard and silently serialize the feeder. Bools map to None (gate off)."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/queue":
+            return httpx.Response(
+                200,
+                json={"queued": [], "processing": [], "capabilities": {"concurrent_transcriptions": True}},
+            )
+        return httpx.Response(200, json={"version": "Subgen 2026.05.3-r10, ..."})
+
+    caps = await _client(handler).probe_capabilities()
+    assert caps.concurrent_transcriptions is None
+
+
+@pytest.mark.asyncio
 async def test_batch_normalizes_language_params_to_iso6391():
     """Arr tags are 3-letter ISO 639-2 ('fre'/'fra'/'ger'); normalize them to
     Whisper's 2-letter ISO 639-1 at the send boundary so subgen never has to


### PR DESCRIPTION
Findings from the in-session multi-lens review of #279 (all verified against the code; core gate logic, N=None dormancy, and depth-vs-gate interaction came back sound):

- **`capacity_poll_interval_s` ignored on the wait path** — `arena_service.py` now uses the injected interval consistently.
- **`concurrent_transcriptions: true` parsed as N=1** — bool excluded from the int guard (+ test).
- **Arena never shut down cleanly** — `aclose()` now cancels *and awaits* sweeps; lifespan `finally` closes the arena + arena_store (it was the only component missing) (+ test).
- **Docs:** soft-gate N+1 caveat in `subgen_capacity`, `arena_active`=running-not-waiting intent, status-enum comment.

Filed [#283](https://github.com/coaxk/subarr/issues/283) (DELETE doesn't cancel a running/waiting sweep — pre-existing, own fix+test).

Also adds **`CLAUDE.md`** with the mandatory risk-tiered pre-merge review policy (Tier 0/1/2), now the standing gate for every PR.

Suite: 1183 passed, 2 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)