### PR TITLE
fix: integration cheap wins (#290) — breaker logging + radarr movieId fan-out

### DIFF
--- a/src/subarr/circuit_breaker.py
+++ b/src/subarr/circuit_breaker.py
@@ -19,8 +19,11 @@ flap, so it must not trip the breaker.
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
+
+log = logging.getLogger(__name__)
 
 CLOSED = "closed"
 OPEN = "open"
@@ -31,10 +34,12 @@ class CircuitBreaker:
     def __init__(
         self,
         *,
+        name: str = "integration",
         fail_threshold: int = 5,
         cooldown_s: float = 60.0,
         clock: Callable[[], float] = time.monotonic,
     ):
+        self._name = name or "integration"
         self._fail_threshold = max(1, fail_threshold)
         self._cooldown_s = cooldown_s
         self._clock = clock
@@ -60,6 +65,8 @@ class CircuitBreaker:
 
     def record_success(self) -> None:
         """A reachable response. Clears failures; a successful probe closes."""
+        if self._state != CLOSED:
+            log.warning("circuit breaker recovered for %s — back to CLOSED", self._name)
         self._consecutive_failures = 0
         self._opened_at = None
         self._state = CLOSED
@@ -75,5 +82,12 @@ class CircuitBreaker:
             self._open()
 
     def _open(self) -> None:
+        if self._state != OPEN:
+            log.warning(
+                "circuit breaker OPEN for %s after %d consecutive failures — backing off %ss",
+                self._name,
+                self._consecutive_failures,
+                self._cooldown_s,
+            )
         self._state = OPEN
         self._opened_at = self._clock()

--- a/src/subarr/integrations/base.py
+++ b/src/subarr/integrations/base.py
@@ -41,7 +41,7 @@ class IntegrationClient:
         # #235: per-integration breaker. A downed/flapping upstream OPENs it and
         # we short-circuit further calls for a cooldown instead of eating slow
         # timeouts every poll cycle. Caller can inject a tuned breaker.
-        self._breaker = breaker or CircuitBreaker()
+        self._breaker = breaker or CircuitBreaker(name=self.name)
 
     def is_configured(self) -> bool:
         return self._configured

--- a/src/subarr/integrations/radarr.py
+++ b/src/subarr/integrations/radarr.py
@@ -134,8 +134,11 @@ class RadarrClient(IntegrationClient):
 
         results = await asyncio.gather(*(_one(mid) for mid in ids))
         out: list[dict[str, Any]] = []
-        for chunk in results:
+        # gather preserves order → zip each chunk back to the movieId it was
+        # fetched for and stamp it on every file row. (Was a no-op: setdefault
+        # with the row's own possibly-absent movieId left it None on the fan-out.)
+        for mid, chunk in zip(ids, results):
             for r in chunk:
-                r.setdefault("movieId", r.get("movieId"))
-                out.extend([r])
+                r.setdefault("movieId", mid)
+                out.append(r)
         return out

--- a/tests/test_radarr_movie_coverage.py
+++ b/tests/test_radarr_movie_coverage.py
@@ -9,6 +9,7 @@ English coverage, running the SAME funnel as the wanted path.
 from __future__ import annotations
 
 import asyncio
+import pytest
 
 
 def _movie(rid, title):
@@ -125,3 +126,26 @@ def test_skips_movies_without_a_file(subarr_env):
     m["movieFile"] = {}
     out = _run([m], [], {})
     assert out == []
+
+
+@pytest.mark.asyncio
+async def test_all_movie_files_stamps_movieid_from_fanout(subarr_env):
+    """#290: the /moviefile fan-out must stamp the movieId it fetched each chunk
+    for. Radarr file rows can omit movieId; the old setdefault(movieId, row's-own)
+    left it None. Now it's zipped back from the fetched id."""
+    from subarr.integrations.radarr import RadarrClient
+
+    c = RadarrClient()
+
+    async def _movies():
+        return [{"id": 11, "hasFile": True}, {"id": 22, "hasFile": True}]
+
+    async def _files(mid):
+        return [{"path": f"/m/{mid}.mkv"}]  # rows WITHOUT movieId
+
+    c.movies = _movies
+    c.movie_files_for_movie = _files
+    out = await c.all_movie_files_with_mediainfo()
+    by_path = {r["path"]: r for r in out}
+    assert by_path["/m/11.mkv"]["movieId"] == 11
+    assert by_path["/m/22.mkv"]["movieId"] == 22


### PR DESCRIPTION
Two small verified fixes from the integration review.

- **CircuitBreaker logs on open/recover.** It was opening silently — an operator only learned an integration was short-circuited via a health poll. Now it carries a name and logs `circuit breaker OPEN for <name> after N consecutive failures` (+ a recovery line). The base client passes `name=self.name`.
- **radarr `movieId` fan-out stamp.** `all_movie_files_with_mediainfo` did `setdefault('movieId', row's-own-movieId)` — a no-op that left `movieId` None when Radarr omits it from a file row. Now it `zip`s each chunk back to the movieId it was fetched for.

TDD: new radarr fan-out test; breaker + integration suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)