### PR TITLE
fix: re-pend orphaned SUBMITTED jobs after subgen restart (#287)

### DIFF
--- a/src/subarr/pending_feeder.py
+++ b/src/subarr/pending_feeder.py
@@ -97,6 +97,11 @@ class PendingQueueFeeder:
         # → monotonic submit time. Counted toward effective depth so we don't
         # re-fill a slot subgen hasn't reported yet (the over-feed race).
         self._inflight: dict[str, float] = {}
+        # #287: one-shot reconcile on first successful subgen /queue read.
+        # Stays False until a /queue read succeeds; set to True after the first
+        # reconcile runs. Reset to False on start() so a process restart always
+        # re-reconciles once.
+        self._reconciled: bool = False
 
     @property
     def _subgen(self):
@@ -108,6 +113,7 @@ class PendingQueueFeeder:
         if self._task is not None and not self._task.done():
             return
         self._stop.clear()
+        self._reconciled = False  # #287: re-reconcile on every process start
         self._task = asyncio.create_task(self._loop(), name="subarr-queue-feeder")
 
     def kick(self) -> None:
@@ -172,6 +178,23 @@ class PendingQueueFeeder:
             return 0
 
         subgen_paths = _subgen_paths(q)
+
+        # #287: one-shot boot reconcile. On the first tick where subgen's /queue
+        # is readable, re-pend any SUBMITTED rows that subgen no longer knows
+        # about (subgen was restarted and lost its queue). Runs BEFORE normal
+        # feeding so re-pended jobs are immediately eligible this same tick.
+        # The flag is only set after a successful /queue read so a momentarily
+        # unreachable subgen does NOT trigger a spurious re-pend.
+        if not self._reconciled:
+            n_repended = self._store.repend_orphaned_submitted(subgen_paths)
+            if n_repended:
+                log.info(
+                    "queue-feeder boot reconcile: re-pended %d orphaned SUBMITTED job(s) "
+                    "(subgen queue was empty for them after restart)",
+                    n_repended,
+                )
+            self._reconciled = True
+
         now = time.monotonic()
         # Release in-flight reservations that have surfaced in subgen's queue
         # (handed off to _effective_depth) or aged past the grace window.

--- a/src/subarr/pending_queue.py
+++ b/src/subarr/pending_queue.py
@@ -277,6 +277,36 @@ class PendingQueueStore:
             )
             return cur.rowcount > 0
 
+    def repend_orphaned_submitted(self, live_subgen_paths: set[str]) -> int:
+        """#287: re-pend SUBMITTED jobs that subgen no longer knows about.
+
+        For each row with status=SUBMITTED whose subgen-space path
+        (`canonical_to_subgen_batch(canonical_path)`) is NOT in
+        `live_subgen_paths`, flip it back to STATUS_PENDING and clear
+        `submitted_at` so the feeder treats it as a fresh job.
+
+        Call this once at boot (after a successful /queue read) to recover
+        jobs that were SUBMITTED when subgen was restarted and lost its queue.
+        Returns the number of rows re-pended.
+        """
+        from .paths import canonical_to_subgen_batch
+
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, canonical_path FROM pending_queue WHERE status = ?",
+                (STATUS_SUBMITTED,),
+            ).fetchall()
+            count = 0
+            for job_id, canonical_path in rows:
+                sg_path = canonical_to_subgen_batch(canonical_path)
+                if sg_path not in live_subgen_paths:
+                    self._conn.execute(
+                        "UPDATE pending_queue SET status = ?, submitted_at = NULL WHERE id = ?",
+                        (STATUS_PENDING, job_id),
+                    )
+                    count += 1
+            return count
+
     def clear(self, status: str | None = None) -> int:
         with self._lock:
             if status is None:

--- a/tests/test_pending_feeder.py
+++ b/tests/test_pending_feeder.py
@@ -313,3 +313,119 @@ async def test_inflight_counted_in_capacity_gate_across_ticks(store):
     n2 = await feeder.tick()
     assert n2 == 0, f"expected 0 submitted second tick (gate should block), got {n2}"
     assert len(rec.calls) == 1  # only the first job was ever submitted
+
+
+# ── boot reconciliation of orphaned SUBMITTED rows (#287) ───────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_repends_submitted_not_in_subgen(store):
+    """A SUBMITTED job whose sg_path is absent from subgen's /queue is
+    re-pended on the first successful reconcile tick so it gets re-fed."""
+    job = store.enqueue("TV/lost.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    # subgen's queue is empty — it lost the job after a restart
+    subgen = FakeSubgen(queued=[], processing=[])
+    rec = SubmitRecorder()
+    feeder = _feeder(store, subgen, rec, target=2)
+
+    # First tick triggers the one-shot reconcile, then normal feeding
+    await feeder.tick()
+
+    refreshed = store.get(job.id)
+    # The job was re-pended by reconcile, then immediately re-submitted by the feeder
+    assert refreshed.status == STATUS_SUBMITTED
+    assert rec.calls == ["TV/lost.mkv"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_keeps_submitted_still_in_subgen(store):
+    """A SUBMITTED job whose sg_path IS in subgen's /queue stays SUBMITTED
+    — it hasn't been lost, just not yet completed."""
+    from subarr.paths import canonical_to_subgen_batch
+
+    job = store.enqueue("TV/safe.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    sg_path = canonical_to_subgen_batch("TV/safe.mkv")
+    # subgen still has the job
+    subgen = FakeSubgen(queued=[{"path": sg_path}])
+    rec = SubmitRecorder()
+    feeder = _feeder(store, subgen, rec, target=2)
+
+    await feeder.tick()
+
+    # job stays SUBMITTED (adopted), nothing re-submitted via submit_job
+    assert store.get(job.id).status == STATUS_SUBMITTED
+    assert rec.calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skipped_when_subgen_unreachable(store):
+    """If subgen.queue() raises on the first tick, no reconcile happens
+    (don't re-pend everything when subgen is just momentarily down)."""
+    job = store.enqueue("TV/a.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    subgen = FakeSubgen(raise_exc=SubgenUnavailable("down"))
+    rec = SubmitRecorder()
+    feeder = _feeder(store, subgen, rec, target=2)
+
+    n = await feeder.tick()
+
+    assert n == 0
+    # The job must remain SUBMITTED — we didn't get a live view so we can't
+    # know subgen dropped it
+    assert store.get(job.id).status == STATUS_SUBMITTED
+    assert rec.calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_runs_once_per_process_start(store):
+    """The one-shot reconcile flag means it only fires once, even across
+    multiple ticks. Subsequent ticks don't repeat the reconcile logic."""
+    job = store.enqueue("TV/a.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    # subgen starts empty (lost the job), then on 2nd tick also empty
+    subgen = FakeSubgen(queued=[], processing=[])
+    rec = SubmitRecorder()
+    feeder = _feeder(store, subgen, rec, target=2)
+
+    # tick 1: reconcile fires, re-pends + re-submits
+    await feeder.tick()
+    assert rec.calls == ["TV/a.mkv"]
+    first_call_count = len(rec.calls)
+
+    # tick 2: reconcile must NOT fire again (one-shot)
+    await feeder.tick()
+    # No additional reconcile-triggered re-feed (any new calls would be
+    # normal feeder feeding, which would only happen if there were more pending)
+    assert len(rec.calls) == first_call_count
+
+
+@pytest.mark.asyncio
+async def test_reconcile_retries_if_subgen_was_down_first(store):
+    """If subgen.queue() fails on tick 1, the reconcile flag is NOT set, so
+    tick 2 (with a reachable subgen) successfully reconciles."""
+    job = store.enqueue("TV/b.mkv", source="gaps")
+    store.mark_submitted(job.id)
+
+    call_count = {"n": 0}
+
+    class FlakeySubgen:
+        async def queue(self):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise SubgenUnavailable("down on first call")
+            # Second call succeeds with empty queue (job was lost)
+            return {"queued": [], "processing": [], "queued_count": 0, "processing_count": 0}
+
+    rec = SubmitRecorder()
+    feeder = _feeder(store, FlakeySubgen(), rec, target=2)
+
+    # tick 1: subgen down → soft skip, reconcile not performed
+    n1 = await feeder.tick()
+    assert n1 == 0
+    assert store.get(job.id).status == STATUS_SUBMITTED  # untouched
+
+    # tick 2: subgen reachable → reconcile fires, re-pends + re-submits
+    await feeder.tick()
+    assert rec.calls == ["TV/b.mkv"]

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -166,3 +166,71 @@ def test_move_requires_target(store):
 def test_reorder_unknown_id_raises(store):
     with pytest.raises(KeyError):
         store.promote("nope")
+
+
+# ── repend_orphaned_submitted (#287) ────────────────────────────────
+
+
+def test_repend_orphaned_submitted_basic(store):
+    """Job whose sg_path is NOT in live_subgen_paths gets re-pended; job whose
+    sg_path IS still in live set stays SUBMITTED. Returns count of re-pended."""
+    from subarr.paths import canonical_to_subgen_batch
+
+    j1 = store.enqueue("TV/S01/e01.mkv", source="gaps")
+    j2 = store.enqueue("TV/S01/e02.mkv", source="gaps")
+    store.mark_submitted(j1.id)
+    store.mark_submitted(j2.id)
+
+    sg1 = canonical_to_subgen_batch("TV/S01/e01.mkv")
+    # j1 is still in subgen; j2 is orphaned (not in the live set)
+    n = store.repend_orphaned_submitted({sg1})
+    assert n == 1
+
+    j1_after = store.get(j1.id)
+    j2_after = store.get(j2.id)
+    assert j1_after.status == STATUS_SUBMITTED  # kept
+    assert j2_after.status == STATUS_PENDING  # re-pended
+    assert j2_after.submitted_at is None  # cleared
+
+
+def test_repend_orphaned_submitted_all_live(store):
+    """When every SUBMITTED job is in the live set, nothing is re-pended."""
+    from subarr.paths import canonical_to_subgen_batch
+
+    j = store.enqueue("TV/a.mkv", source="gaps")
+    store.mark_submitted(j.id)
+    sg = canonical_to_subgen_batch("TV/a.mkv")
+    n = store.repend_orphaned_submitted({sg})
+    assert n == 0
+    assert store.get(j.id).status == STATUS_SUBMITTED
+
+
+def test_repend_orphaned_submitted_empty_live(store):
+    """Empty live set means every SUBMITTED row is orphaned and re-pended."""
+    j1 = store.enqueue("TV/a.mkv", source="gaps")
+    j2 = store.enqueue("TV/b.mkv", source="gaps")
+    store.mark_submitted(j1.id)
+    store.mark_submitted(j2.id)
+    n = store.repend_orphaned_submitted(set())
+    assert n == 2
+    for jid in (j1.id, j2.id):
+        j = store.get(jid)
+        assert j.status == STATUS_PENDING
+        assert j.submitted_at is None
+
+
+def test_repend_orphaned_submitted_skips_pending_and_done(store):
+    """Only SUBMITTED rows are candidates; PENDING and DONE are untouched."""
+
+    p = store.enqueue("TV/pending.mkv", source="gaps")
+    s = store.enqueue("TV/submitted.mkv", source="gaps")
+    store.mark_submitted(s.id)
+    # mark the first one done
+    store.set_status(p.id, STATUS_DONE)
+    # Neither the done nor pending path is in the live set
+    n = store.repend_orphaned_submitted(set())
+    assert n == 1  # only the submitted one
+    assert store.get(p.id).status == STATUS_DONE
+    # PENDING job was never submitted so it would not be touched regardless,
+    # but here it's STATUS_DONE — confirm unchanged
+    assert store.get(s.id).status == STATUS_PENDING


### PR DESCRIPTION
**Left open for your review** (per the async plan).

From queue review #287. **The bug:** if subgen restarts and loses its queue, subarr's SUBMITTED rows are stuck SUBMITTED forever — `active_paths()` treats them as in-flight so the feeder never re-enqueues them, and nothing re-pends them. They never complete.

**Fix:** a one-shot boot reconcile in the feeder. On the **first tick with a readable subgen `/queue`**, `repend_orphaned_submitted(live_paths)` flips any SUBMITTED row whose subgen-space path isn't in subgen's live queue back to PENDING (so it gets re-fed).

Why it's safe (failure-mode reviewed):
- Gated on a **successful** `/queue` read — a momentarily-unreachable subgen early-returns before the reconcile, so no spurious mass re-pend; it retries next tick until one read succeeds.
- A **subarr-only restart** (subgen still holding the jobs) → those paths ARE in the live set → they stay SUBMITTED. Only genuinely-lost jobs re-pend.
- Re-pend (not error): the file still needs a sub; it re-feeds through the normal path, and the existing **adopt-as-submitted** dedup re-adopts anything subgen actually still has.
- Runs once per process (`_reconciled` flag, reset in `start()`), before normal feeding so re-pends are eligible the same tick.

TDD: +4 store tests, +5 feeder tests (incl. subgen-unreachable → no reconcile + retry). 42 queue/feeder tests + 117 broader pass; ruff clean.

**Still open (separate follow-up, not in this PR):** the provenance double-row / aftercare-double-fire part of #287 — scoped out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)