### PR TITLE
fix: arena DELETE cancels the running/waiting sweep + guards resurrection (#283)

### DIFF
--- a/src/subarr/arena_service.py
+++ b/src/subarr/arena_service.py
@@ -110,6 +110,11 @@ class ArenaService:
         self._caps_provider = caps_provider
         self._capacity_poll_interval_s = capacity_poll_interval_s
         self._inflight = 0  # arena /asr transcriptions currently running (0/1)
+        # run_ids that have been explicitly deleted while their task was still
+        # live. _persist() checks this set so a late on_clip/on_step/terminal
+        # save does NOT resurrect the row. Entries are discarded in _run's
+        # finally block once the task fully unwinds.
+        self._deleted: set[str] = set()
 
     # ── store (persisted) ────────────────────────────────────────────────────
     def create(
@@ -145,7 +150,28 @@ class ArenaService:
         return self._store.aggregate_global_leaderboard(min_languages=min_languages)
 
     def delete(self, run_id: str) -> bool:
+        # Mark deleted BEFORE cancelling so any CancelledError handler that
+        # runs synchronously on the next event-loop tick calls _persist() and
+        # sees the guard before attempting a write.
+        self._deleted.add(run_id)
+        t = self._tasks.get(run_id)
+        if t is not None:
+            t.cancel()
         return self._store.delete(run_id)
+
+    # ── internal save helper ─────────────────────────────────────────────────
+    def _persist(self, run: ArenaRun) -> None:
+        """Write-through to the store unless this run has been deleted.
+
+        Every state-transition save inside the run lifecycle goes through here
+        so that deleting a run while its task is live is a true stop: the row
+        is removed by delete() and _persist() is a no-op from that point on,
+        preventing resurrection via CancelledError handlers, on_clip callbacks,
+        or any other in-flight save.
+        """
+        if run.id in self._deleted:
+            return
+        self._store.save(run)
 
     def inflight_count(self) -> int:
         """Arena /asr transcriptions currently running — the feeder counts this
@@ -229,7 +255,7 @@ class ArenaService:
             if not emitted:
                 emitted = True
                 run.status = "waiting_for_capacity"
-                self._store.save(run)
+                self._persist(run)
                 self._emit(
                     run.id, {"event": "waiting_for_capacity", "data": {"id": run.id, "ahead": processing}}
                 )
@@ -241,13 +267,13 @@ class ArenaService:
         # their heavy QE work in parallel and saturating the box.
         run.status = "queued"
         run.outcomes = {"clips": [], "done": 0, "total": 0}  # progress scaffold
-        self._store.save(run)
+        self._persist(run)
         self._emit(run_id, {"event": "queued", "data": {"id": run.id}})
         try:
             async with self._sema:
                 await self._await_capacity(run)
                 run.status = "running"
-                self._store.save(run)
+                self._persist(run)
                 self._inflight += 1
                 try:
                     self._emit(
@@ -263,13 +289,18 @@ class ArenaService:
         except asyncio.CancelledError:
             run.status = "error"
             run.error = "cancelled"
-            self._store.save(run)
+            self._persist(run)
             raise
         except Exception as e:
             run.status = "error"
             run.error = str(e)
-            self._store.save(run)
+            self._persist(run)
             self._emit(run_id, {"event": "error", "data": {"error": str(e)}})
+        finally:
+            # Clean up regardless of outcome: discard from _deleted (so the set
+            # doesn't grow unbounded) and remove from _tasks.
+            self._deleted.discard(run_id)
+            self._tasks.pop(run_id, None)
 
     async def _execute(self, run: ArenaRun) -> None:
         run_id = run.id
@@ -284,12 +315,12 @@ class ArenaService:
             for j in range(idx):
                 per_clip["clips"][j]["status"] = "done"
             per_clip["clips"][idx] = {"kind": kind, "status": "running"}
-            self._store.save(run)
+            self._persist(run)
             self._emit(run_id, {"event": "clip", "data": {"idx": idx, "kind": kind, "total": total}})
 
         def on_step() -> None:
             per_clip["done"] += 1
-            self._store.save(run)
+            self._persist(run)
             self._emit(run_id, {"event": "step", "data": {"done": per_clip["done"]}})
 
         result = await run_arena(run.media_path, variants, runner=runner, on_clip=on_clip, on_step=on_step)
@@ -347,5 +378,5 @@ class ArenaService:
         serialized["audio_track_languages"] = track_langs
         run.result = serialized
         run.status = "done"
-        self._store.save(run)
+        self._persist(run)
         self._emit(run_id, {"event": "done", "data": run.to_dict()})

--- a/tests/test_arena_service.py
+++ b/tests/test_arena_service.py
@@ -804,3 +804,121 @@ async def test_n2_allows_one_concurrent_then_blocks(tmp_path):
     sub._count = 0
     await asyncio.wait_for(svc._tasks[run2.id], timeout=3)
     assert svc.get(run2.id).status in ("done", "error")
+
+
+# ── delete + cancel (issue #283) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_waiting_sweep_cancels_task_and_no_resurrection(tmp_path):
+    # Delete a WAITING sweep (subgen at capacity, task parked in _await_capacity):
+    # the task must be cancelled AND the run must NOT reappear in the store once
+    # capacity is freed and the task unwinds.
+    s = ArenaStore(tmp_path / "arena.db")
+    s._conn.executescript(_ARENA_SQL)
+    sub = _FakeSubgen([{"path": "/m/x.mkv"}])  # at capacity
+    svc = ArenaService(
+        s,
+        build_runner=lambda run: _NoopRunner(),
+        subgen_provider=lambda: sub,
+        caps_provider=lambda: type("C", (), {"concurrent_transcriptions": 1})(),
+        capacity_poll_interval_s=0.02,
+    )
+    run = svc.create("/ep.mkv", [ConfigVariant("base", {})])
+    svc.start(run)
+    # Wait until the run is parked waiting_for_capacity
+    for _ in range(50):
+        if svc.get(run.id).status == "waiting_for_capacity":
+            break
+        await asyncio.sleep(0.02)
+    assert svc.get(run.id).status == "waiting_for_capacity"
+
+    # Delete it (fire-and-forget cancel)
+    result = svc.delete(run.id)
+    assert result is True
+    assert svc.get(run.id) is None  # immediately gone from store
+
+    # Free capacity — the task will wake up but must NOT resurrect the row
+    sub._processing = []
+    task = svc._tasks.get(run.id)
+    if task is not None:
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    await asyncio.sleep(0.1)  # let any stray callbacks drain
+    assert svc.get(run.id) is None  # must still be gone — no resurrection
+
+
+@pytest.mark.asyncio
+async def test_delete_persists_noop_for_deleted_run(store):
+    # After delete(run_id), any subsequent _persist call for that run_id
+    # must be a no-op — the row must stay deleted.
+    svc = _service(store, [])
+    run = svc.create("/m.mkv", [ConfigVariant("a", {})])
+    assert svc.delete(run.id) is True
+    assert svc.get(run.id) is None
+
+    # Directly invoke _persist — simulates what a late on_clip/on_step would do
+    svc._persist(run)
+    assert svc.get(run.id) is None  # row must NOT be resurrected
+
+
+@pytest.mark.asyncio
+async def test_delete_no_live_task_still_deletes_row(store):
+    # delete() on a run that never had a live task (or whose task already
+    # finished) must still remove the persisted row — back-compat.
+    svc = _service(store, [])
+    run = svc.create("/m.mkv", [ConfigVariant("a", {})])
+    assert run.id not in svc._tasks  # no task started
+    assert svc.delete(run.id) is True
+    assert svc.get(run.id) is None
+
+
+@pytest.mark.asyncio
+async def test_inflight_returns_to_zero_after_delete(tmp_path):
+    # Delete a RUNNING sweep (past _await_capacity, inside _execute) must still
+    # correctly decrement _inflight back to 0.
+    s = ArenaStore(tmp_path / "arena.db")
+    s._conn.executescript(_ARENA_SQL)
+
+    execute_started = asyncio.Event()
+    delete_done = asyncio.Event()
+
+    class BlockingRunner:
+        def __init__(self, run):
+            pass
+
+        async def preflight(self):
+            pass
+
+        async def prepare(self, media_path):
+            execute_started.set()
+            await delete_done.wait()  # hold inside _execute
+            return []
+
+        async def cleanup(self):
+            pass
+
+    svc = ArenaService(s, build_runner=lambda run: BlockingRunner(run))
+    run = svc.create("/m.mkv", [ConfigVariant("a", {})])
+    svc.start(run)
+
+    # Wait until the task is inside _execute (inflight incremented)
+    await asyncio.wait_for(execute_started.wait(), timeout=3)
+    assert svc.inflight_count() == 1
+
+    # Delete it — cancel is fire-and-forget
+    svc.delete(run.id)
+    delete_done.set()  # unblock prepare so the task can unwind
+
+    task = svc._tasks.get(run.id)
+    if task is not None:
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    await asyncio.sleep(0.1)
+    assert svc.inflight_count() == 0


### PR DESCRIPTION
**Left open for your review.**

From review #283. **The bug:** `ArenaService.delete()` only deleted the DB row — it didn't cancel the running asyncio task. So deleting a RUNNING or (worse) WAITING_FOR_CAPACITY sweep left the task alive, and its next lifecycle `save()` did an INSERT-OR-REPLACE that **resurrected the deleted row** (a waiting sweep would wake when capacity freed and run to completion as a ghost).

**Fix:**
- `delete(run_id)` now marks the run in a `_deleted` set **before** cancelling the task, then cancels `self._tasks[run_id]`, then deletes the row.
- A single `_persist(run)` helper guards every lifecycle save (`if run.id in _deleted: return`) — so once deleted, no `on_clip`/`on_step`/terminal/CancelledError save can resurrect it. (The initial `create()` insert stays direct.)
- `_run`'s outer `finally` discards `_deleted` + pops `_tasks` so both sets stay O(active runs).
- `_inflight` balance preserved (increment/decrement stay in the inner try/finally; cancellation while queued/waiting never enters it).

Failure-mode reviewed: cancel-while-waiting, cancel-while-running, delete-with-no-live-task, and `_inflight`→0 after delete all covered.

TDD: +4 tests incl. the core resurrection regression (delete a waiting sweep, free capacity, assert it does NOT reappear). 40 arena tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)