### PR TITLE
fix: Plex connection pooling + circuit breaker; align base _post/_put contract (#290)

### DIFF
--- a/src/subarr/integrations/base.py
+++ b/src/subarr/integrations/base.py
@@ -97,10 +97,13 @@ class IntegrationClient:
         self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
+        text = r.text
+        if not text.strip():
+            return None  # legitimate empty body (e.g. 204) — no content
         try:
             return r.json()
-        except ValueError:
-            return None
+        except ValueError as e:
+            raise IntegrationError(f"{self.name} {path}: non-json response") from e
 
     async def _put(self, path: str, params: dict | None = None, json_body: dict | None = None) -> Any:
         """PUT — used by v1.1.1 audio-lang propagation to Sonarr's
@@ -116,7 +119,10 @@ class IntegrationClient:
         self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
+        text = r.text
+        if not text.strip():
+            return None  # legitimate empty body (e.g. 204) — no content
         try:
             return r.json()
-        except ValueError:
-            return None
+        except ValueError as e:
+            raise IntegrationError(f"{self.name} {path}: non-json response") from e

--- a/src/subarr/integrations/plex.py
+++ b/src/subarr/integrations/plex.py
@@ -26,6 +26,10 @@ Plex endpoint shape:
 We discover the right section id at runtime by listing /library/sections
 and matching the path against each section's <Location> entries. Cached
 per-process; if Plex sections change subarr restart picks them up.
+
+#290: PlexClient now holds a PERSISTENT httpx.AsyncClient (connection
+pooling — no fresh TCP/TLS per call) and a CircuitBreaker (short-circuit
+on dead/flapping Plex instead of eating many serial 10 s timeouts).
 """
 
 from __future__ import annotations
@@ -41,14 +45,19 @@ import defusedxml.ElementTree as ET  # noqa: N814
 
 import httpx
 
+from ..circuit_breaker import CircuitBreaker
 from . import IntegrationError
+from .base import _DEFAULT_TIMEOUT
 
 log = logging.getLogger(__name__)
 
 
 class PlexClient:
     """Minimal Plex client. Not modelled on IntegrationClient because Plex
-    returns XML (not JSON) and uses query-string auth rather than headers."""
+    returns XML (not JSON) and uses query-string auth rather than headers.
+
+    #290: holds a persistent httpx.AsyncClient for connection pooling and a
+    CircuitBreaker to short-circuit calls when Plex is down/flapping."""
 
     name = "plex"
 
@@ -59,6 +68,7 @@ class PlexClient:
         default_section: str = "all",
         path_prefix: str = "",
         media_root: str = "",
+        breaker: CircuitBreaker | None = None,
     ):
         self._base_url = (base_url or "").rstrip("/")
         self._token = token or ""
@@ -69,6 +79,16 @@ class PlexClient:
         # path to identical container paths.
         self._path_prefix = (path_prefix or "").rstrip("/")
         self._media_root = (media_root or "").rstrip("/")
+        # #290: persistent client — one TCP/TLS connection pool per process
+        # instead of a fresh handshake on every Plex call.
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+        # #290: per-instance breaker. 5xx + transport errors trip it; a 4xx
+        # means Plex is reachable (auth/bad-request) and must NOT open the
+        # circuit. Caller can inject a tuned breaker (e.g. in tests).
+        self._breaker = breaker or CircuitBreaker(name=self.name)
         # Discovered section list — list[dict(id, paths=[str,...])].
         # Lazily fetched on first partial_scan(); refreshed only on restart.
         self._sections: list[dict] | None = None
@@ -93,22 +113,49 @@ class PlexClient:
         # Unknown root — return as-is and let Plex's section matcher decide.
         return subarr_path
 
+    # ── #290: central transport helper ───────────────────────────────────────
+
+    async def _request(self, path: str, params: dict) -> httpx.Response:
+        """GET a Plex endpoint via the persistent client, with circuit-breaker
+        guard. All four call sites funnel through here so breaker policy is
+        applied uniformly.
+
+        Policy (mirrors IntegrationClient):
+        - 5xx + transport errors → record_failure (may open the breaker).
+        - <500 HTTP (incl. 4xx) → record_success (upstream is reachable).
+        - 4xx raises IntegrationError but does NOT open the breaker.
+        """
+        if not self._breaker.allow():
+            raise IntegrationError(f"{self.name}: circuit open — Plex failing, backing off")
+        try:
+            r = await self._client.get(path, params=params)
+        except httpx.HTTPError as e:
+            self._breaker.record_failure()
+            raise IntegrationError(f"{self.name} {path}: {e}") from e
+        if r.status_code >= 500:
+            self._breaker.record_failure()
+        else:
+            self._breaker.record_success()
+        if r.status_code >= 400:
+            raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
+        return r
+
+    # ── XML helper (used by status + audio-hint paths) ────────────────────────
+
+    async def _get_xml(self, path: str, extra_params: dict | None = None):
+        """GET a Plex endpoint and return the parsed XML root."""
+        r = await self._request(path, {"X-Plex-Token": self._token, **(extra_params or {})})
+        try:
+            return ET.fromstring(r.text)
+        except ET.ParseError as e:
+            raise IntegrationError(f"plex {path}: bad XML ({e})") from e
+
+    # ── Section discovery ─────────────────────────────────────────────────────
+
     async def _list_sections(self) -> list[dict]:
         """Fetch + parse /library/sections. Returns list of
         {'id': str, 'title': str, 'paths': [str,...]}."""
-        url = f"{self._base_url}/library/sections"
-        params = {"X-Plex-Token": self._token}
-        try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                r = await client.get(url, params=params)
-        except httpx.HTTPError as e:
-            raise IntegrationError(f"plex sections: {e}") from e
-        if r.status_code >= 400:
-            raise IntegrationError(f"plex sections HTTP {r.status_code}: {r.text[:200]}")
-        try:
-            root = ET.fromstring(r.text)
-        except ET.ParseError as e:
-            raise IntegrationError(f"plex sections: bad XML ({e})") from e
+        root = await self._get_xml("/library/sections")
         out = []
         for directory in root.iter("Directory"):
             sid = directory.get("key")
@@ -152,21 +199,18 @@ class PlexClient:
                         best_len = len(loc_str)
         return best
 
+    # ── Public scan methods ───────────────────────────────────────────────────
+
     async def full_scan(self, section_id: Optional[str] = None) -> dict:
         """Trigger a full scan against the configured (or supplied) section.
         Used by /api/plex/scan as the public 'rescan everything' button."""
         if not self.is_configured():
             raise IntegrationError("plex not configured")
         sid = section_id or self._default_section
-        url = f"{self._base_url}/library/sections/{sid}/refresh"
-        params = {"X-Plex-Token": self._token}
-        try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                r = await client.get(url, params=params)
-        except httpx.HTTPError as e:
-            raise IntegrationError(f"plex full_scan: {e}") from e
-        if r.status_code >= 400:
-            raise IntegrationError(f"plex full_scan HTTP {r.status_code}: {r.text[:200]}")
+        r = await self._request(
+            f"/library/sections/{sid}/refresh",
+            {"X-Plex-Token": self._token},
+        )
         return {"triggered": True, "section": sid, "scope": "full", "plex_status": r.status_code}
 
     async def partial_scan(self, subarr_file_path: str) -> dict:
@@ -196,15 +240,10 @@ class PlexClient:
                 f"plex partial_scan: no section matched path {scan_dir!r}; "
                 f"set PLEX_SECTION to the numeric id or check PLEX_PATH_PREFIX"
             )
-        url = f"{self._base_url}/library/sections/{sid}/refresh"
-        params = {"X-Plex-Token": self._token, "path": scan_dir}
-        try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                r = await client.get(url, params=params)
-        except httpx.HTTPError as e:
-            raise IntegrationError(f"plex partial_scan: {e}") from e
-        if r.status_code >= 400:
-            raise IntegrationError(f"plex partial_scan HTTP {r.status_code}: {r.text[:200]}")
+        r = await self._request(
+            f"/library/sections/{sid}/refresh",
+            {"X-Plex-Token": self._token, "path": scan_dir},
+        )
         log.info("plex partial_scan: section=%s path=%s", sid, scan_dir)
         return {
             "triggered": True,
@@ -224,22 +263,7 @@ class PlexClient:
             "machine_id": root.get("machineIdentifier"),
         }
 
-    # ── #12: per-show selected audio language ───────────────────────────
-
-    async def _get_xml(self, path: str, extra_params: dict | None = None):
-        """GET a Plex endpoint and return the parsed XML root."""
-        params = {"X-Plex-Token": self._token, **(extra_params or {})}
-        try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                r = await client.get(f"{self._base_url}{path}", params=params)
-        except httpx.HTTPError as e:
-            raise IntegrationError(f"plex {path}: {e}") from e
-        if r.status_code >= 400:
-            raise IntegrationError(f"plex {path} HTTP {r.status_code}")
-        try:
-            return ET.fromstring(r.text)
-        except ET.ParseError as e:
-            raise IntegrationError(f"plex {path}: bad XML ({e})") from e
+    # ── #12: per-show selected audio language ───────────────────────────────
 
     async def _ensure_show_index(self) -> None:
         """Build title_lc → show ratingKey across all show-type sections.
@@ -311,5 +335,5 @@ class PlexClient:
         return {tl: self._audio_hint_cache[tl] for tl in wanted if self._audio_hint_cache.get(tl)}
 
     async def aclose(self) -> None:
-        # Stateless — each call opens its own client. Nothing to close.
-        return None
+        """#290: close the persistent httpx client (releases the connection pool)."""
+        await self._client.aclose()

--- a/tests/test_admin_gpu.py
+++ b/tests/test_admin_gpu.py
@@ -133,39 +133,30 @@ def _plex_handler(req: httpx.Request) -> httpx.Response:
 
 
 @pytest.mark.subgen(handler=_plex_handler)
-def test_plex_scan_calls_correct_url(app_with_stub, monkeypatch):
+def test_plex_scan_calls_correct_url(app_with_stub):
     """v1.1.1 refactor: /api/plex/scan now delegates to PlexClient.full_scan().
-    We swap in a configured client for the duration of the test and intercept
-    the httpx.AsyncClient that PlexClient instantiates per call."""
+    #290: PlexClient now holds a persistent httpx client, so we inject a
+    MockTransport directly into plex._client rather than patching the
+    httpx.AsyncClient class globally."""
     from subarr.integrations.plex import PlexClient
+
+    calls = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls.append(req)
+        return httpx.Response(200, content=b"")
 
     # Inject a configured Plex client into app state (conftest stub leaves
     # it unconfigured by default so other tests get 503 properly).
     plex = PlexClient(base_url="http://plex.test:32400", token="test-token", default_section="all")
+    # Swap the persistent client's transport to the mock — no global patching.
+    plex._client = httpx.AsyncClient(
+        base_url="http://plex.test:32400",
+        transport=httpx.MockTransport(handler),
+    )
     app_with_stub.app.state.integrations.plex = plex
 
-    calls = []
-    _RealAsyncClient = httpx.AsyncClient
-
-    class _FakeAsyncClient:
-        def __init__(self, *a, **kw):
-            self._kw = kw
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return None
-
-        async def get(self, url, params=None):
-            calls.append((url, dict(params or {})))
-            return httpx.Response(200, content=b"")
-
-    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
-    try:
-        r = app_with_stub.post("/api/plex/scan")
-    finally:
-        monkeypatch.setattr("httpx.AsyncClient", _RealAsyncClient)
+    r = app_with_stub.post("/api/plex/scan")
 
     assert r.status_code == 200
     body = r.json()
@@ -173,9 +164,9 @@ def test_plex_scan_calls_correct_url(app_with_stub, monkeypatch):
     assert body["section"] == "all"
     assert body["scope"] == "full"
     assert len(calls) == 1
-    url, params = calls[0]
-    assert url.endswith("/library/sections/all/refresh")
-    assert params == {"X-Plex-Token": "test-token"}
+    req = calls[0]
+    assert req.url.path == "/library/sections/all/refresh"
+    assert req.url.params["X-Plex-Token"] == "test-token"
 
 
 def test_plex_scan_503_when_token_missing(app_with_stub):

--- a/tests/test_base_post_put_contract.py
+++ b/tests/test_base_post_put_contract.py
@@ -1,0 +1,137 @@
+"""#290: Fix 2 — base IntegrationClient _post/_put non-JSON body contract.
+
+Before this fix:
+  - empty body (204/200 with no content) → None  (correct)
+  - non-empty non-JSON body (e.g. HTML error page on a 200) → None  (WRONG — silent data loss)
+  - JSON body → dict  (correct)
+
+After this fix:
+  - empty body → None
+  - non-empty non-JSON body → raises IntegrationError
+  - JSON body → dict
+"""
+
+from __future__ import annotations
+
+import pytest
+import httpx
+
+from subarr.integrations import IntegrationError
+from subarr.integrations.base import IntegrationClient
+
+
+def _client(handler) -> IntegrationClient:
+    """Build an IntegrationClient whose transport is a MockTransport."""
+    c = IntegrationClient("http://up.test")
+    c._client = httpx.AsyncClient(
+        base_url="http://up.test",
+        transport=httpx.MockTransport(handler),
+    )
+    return c
+
+
+# ── _post contract ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_empty_body_returns_none():
+    """A 200 with an empty body (or whitespace only) must return None.
+    Arr endpoints commonly return empty 200/204 for successful mutations."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    c = _client(handler)
+    result = await c._post("/api/v3/something")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_post_whitespace_body_returns_none():
+    """Whitespace-only body (e.g. bare newline) counts as empty — return None."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"\n  \t\n")
+
+    c = _client(handler)
+    result = await c._post("/api/v3/something")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_post_json_body_returns_dict():
+    """A 200 with a valid JSON body returns the decoded dict."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": 42, "status": "ok"})
+
+    c = _client(handler)
+    result = await c._post("/api/v3/something")
+    assert result == {"id": 42, "status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_post_non_empty_non_json_raises_integration_error():
+    """A non-empty non-JSON body on a 200 must raise IntegrationError.
+    This catches HTML error pages that sneak through as 200 OK."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>Proxy error</html>")
+
+    c = _client(handler)
+    with pytest.raises(IntegrationError, match="non-json response"):
+        await c._post("/api/v3/something")
+
+
+# ── _put contract (mirrors _post) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_put_empty_body_returns_none():
+    """PUT with an empty 200 body returns None (same contract as _post)."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    c = _client(handler)
+    result = await c._put("/api/v3/episodeFile/99")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_put_json_body_returns_dict():
+    """PUT with a JSON body returns the decoded dict."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": 99, "languages": [{"name": "Danish"}]})
+
+    c = _client(handler)
+    result = await c._put("/api/v3/episodeFile/99")
+    assert result == {"id": 99, "languages": [{"name": "Danish"}]}
+
+
+@pytest.mark.asyncio
+async def test_put_non_empty_non_json_raises_integration_error():
+    """PUT with a non-empty non-JSON 200 body raises IntegrationError."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"plain text error")
+
+    c = _client(handler)
+    with pytest.raises(IntegrationError, match="non-json response"):
+        await c._put("/api/v3/episodeFile/99")
+
+
+# ── regression: existing callers that rely on None-for-empty-body ────────────
+
+
+@pytest.mark.asyncio
+async def test_post_204_no_content_returns_none():
+    """HTTP 204 No Content has an empty body by definition — must be None."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(204, content=b"")
+
+    c = _client(handler)
+    result = await c._post("/api/v3/command")
+    assert result is None

--- a/tests/test_plex_partial_scan.py
+++ b/tests/test_plex_partial_scan.py
@@ -1,9 +1,14 @@
-"""Tests for the Plex partial-scan client (v1.1.1).
+"""Tests for the Plex partial-scan client (v1.1.1 + #290 pool/breaker).
 
-Covers the three things that determine whether the Apple-TV loop closes:
+Covers:
 1. Path translation when subarr + Plex see different mount paths.
 2. Section auto-discovery (longest-prefix match on Plex Location.path).
 3. Partial-scan request shape (correct URL + path query parameter).
+4. (#290) Persistent client — same object across calls (no per-call client).
+5. (#290) Circuit breaker opens after consecutive 5xx; next call is
+   short-circuited (transport NOT hit again).
+6. (#290) 4xx does NOT open the breaker (record_success path).
+7. (#290) aclose() really closes the underlying client.
 """
 
 from __future__ import annotations
@@ -11,6 +16,7 @@ from __future__ import annotations
 import pytest
 import httpx
 
+from subarr.circuit_breaker import CircuitBreaker
 from subarr.integrations import IntegrationError
 from subarr.integrations.plex import PlexClient
 
@@ -27,50 +33,28 @@ SECTIONS_XML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def _client(handler) -> PlexClient:
-    """Build a PlexClient with an httpx mock transport pinned to handler.
+def _client(handler, breaker=None) -> PlexClient:
+    """Build a PlexClient whose internal httpx client uses a MockTransport.
 
-    PlexClient creates its own AsyncClient per request, so we monkey-patch
-    httpx.AsyncClient via a factory below."""
-    return PlexClient(
+    #290: PlexClient now holds a persistent self._client. We build the real
+    PlexClient then swap its _client with a mocked one — the same pattern
+    used by test_integration_breaker.py for IntegrationClient."""
+    c = PlexClient(
         base_url="http://plex.test:32400",
         token="testtoken",
         default_section="all",
         path_prefix="/data/Media",
         media_root="/media/library",
+        breaker=breaker,
     )
+    c._client = httpx.AsyncClient(
+        base_url="http://plex.test:32400",
+        transport=httpx.MockTransport(handler),
+    )
+    return c
 
 
-@pytest.fixture
-def patched_httpx(monkeypatch):
-    """Patches httpx.AsyncClient so PlexClient sees a MockTransport routed
-    to whatever request handler the test sets via the returned setter."""
-    state = {"handler": None}
-    # Capture the REAL AsyncClient before we patch the name, so the stub
-    # can instantiate one without triggering infinite recursion.
-    _RealAsyncClient = httpx.AsyncClient
-
-    class _StubAsyncClient:
-        def __init__(self, *a, **kw):
-            self._real = _RealAsyncClient(
-                transport=httpx.MockTransport(state["handler"]),
-                timeout=kw.get("timeout", 5.0),
-            )
-
-        async def __aenter__(self):
-            return self._real
-
-        async def __aexit__(self, *a):
-            await self._real.aclose()
-
-        async def get(self, *a, **kw):
-            return await self._real.get(*a, **kw)
-
-        async def aclose(self):
-            await self._real.aclose()
-
-    monkeypatch.setattr("httpx.AsyncClient", _StubAsyncClient)
-    return state
+# ── path-translation tests (no HTTP, no async) ───────────────────────────────
 
 
 def test_translate_path_when_prefix_differs():
@@ -108,8 +92,17 @@ def test_translate_path_passthrough_when_no_root_match():
     assert c.translate_path("/somewhere/else/file.srt") == "/somewhere/else/file.srt"
 
 
+def test_is_configured_requires_url_and_token():
+    assert PlexClient("", "t", "all").is_configured() is False
+    assert PlexClient("http://p:32400", "", "all").is_configured() is False
+    assert PlexClient("http://p:32400", "t", "all").is_configured() is True
+
+
+# ── scan / section-discovery tests ───────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_partial_scan_discovers_section_and_fires(patched_httpx):
+async def test_partial_scan_discovers_section_and_fires():
     """Happy path: PLEX_SECTION='all' so the client lists sections, matches
     the file path against Location entries, and fires a refresh against the
     matching numeric section id with ?path=<dir>."""
@@ -123,7 +116,6 @@ async def test_partial_scan_discovers_section_and_fires(patched_httpx):
             return httpx.Response(200, text="")
         return httpx.Response(404)
 
-    patched_httpx["handler"] = handler
     c = _client(handler)
     result = await c.partial_scan("/media/library/TV/Foo/S01E01.srt")
 
@@ -141,7 +133,7 @@ async def test_partial_scan_discovers_section_and_fires(patched_httpx):
 
 
 @pytest.mark.asyncio
-async def test_partial_scan_uses_numeric_section_without_discovery(patched_httpx):
+async def test_partial_scan_uses_numeric_section_without_discovery():
     """If PLEX_SECTION is numeric, skip section listing — just fire."""
     captured = []
 
@@ -152,7 +144,6 @@ async def test_partial_scan_uses_numeric_section_without_discovery(patched_httpx
             return httpx.Response(500, text="should not be called")
         return httpx.Response(200, text="")
 
-    patched_httpx["handler"] = handler
     c = PlexClient(
         base_url="http://plex.test:32400",
         token="t",
@@ -160,21 +151,22 @@ async def test_partial_scan_uses_numeric_section_without_discovery(patched_httpx
         path_prefix="/data/Media",
         media_root="/media/library",
     )
+    c._client = httpx.AsyncClient(
+        base_url="http://plex.test:32400",
+        transport=httpx.MockTransport(handler),
+    )
     result = await c.partial_scan("/media/library/TV/X.srt")
     assert result["section"] == "7"
     assert all(r.url.path != "/library/sections" for r in captured)
 
 
 @pytest.mark.asyncio
-async def test_partial_scan_raises_when_no_section_matches(patched_httpx):
-    """Path outside every Plex Location → IntegrationError, not silent no-op.
-    Caller (completion_watcher) catches + logs; we don't want to drop the
-    failure on the floor inside the client."""
+async def test_partial_scan_raises_when_no_section_matches():
+    """Path outside every Plex Location → IntegrationError, not silent no-op."""
 
     def handler(req):
         return httpx.Response(200, text=SECTIONS_XML)
 
-    patched_httpx["handler"] = handler
     c = PlexClient(
         base_url="http://plex.test:32400",
         token="t",
@@ -182,11 +174,125 @@ async def test_partial_scan_raises_when_no_section_matches(patched_httpx):
         path_prefix="/data/Media",
         media_root="/media/library",
     )
+    c._client = httpx.AsyncClient(
+        base_url="http://plex.test:32400",
+        transport=httpx.MockTransport(handler),
+    )
     with pytest.raises(IntegrationError, match="no section matched"):
         await c.partial_scan("/media/library/Music/x.srt")
 
 
-def test_is_configured_requires_url_and_token():
-    assert PlexClient("", "t", "all").is_configured() is False
-    assert PlexClient("http://p:32400", "", "all").is_configured() is False
-    assert PlexClient("http://p:32400", "t", "all").is_configured() is True
+# ── #290: pooling + breaker tests ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persistent_client_same_object_across_calls():
+    """#290: _client must be the SAME object across multiple calls — no per-call
+    client construction (which would defeat connection pooling)."""
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if req.url.path == "/library/sections":
+            return httpx.Response(200, text=SECTIONS_XML)
+        return httpx.Response(200, text="")
+
+    c = _client(handler)
+    client_before = c._client
+
+    await c.partial_scan("/media/library/TV/Foo/S01E01.srt")
+    # Flush the section cache so the second call re-hits the transport.
+    c._sections = None
+    await c.partial_scan("/media/library/TV/Foo/S01E02.srt")
+
+    assert c._client is client_before, "_client was replaced between calls — pooling broken"
+    assert calls["n"] >= 2  # at least two real requests went through
+
+
+@pytest.mark.asyncio
+async def test_breaker_opens_on_5xx_and_short_circuits():
+    """#290: after fail_threshold consecutive 5xx the breaker opens and the
+    next call raises 'circuit open' WITHOUT touching the transport."""
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(503, text="down")
+
+    cb = CircuitBreaker(name="plex", fail_threshold=3, cooldown_s=60, clock=lambda: 0.0)
+    c = _client(handler, breaker=cb)
+
+    # Drive three 5xx to trip the breaker.
+    for _ in range(3):
+        with pytest.raises(IntegrationError):
+            await c._request("/library/sections", {"X-Plex-Token": "t"})
+
+    assert cb.state == "open"
+    n_after_trip = calls["n"]
+
+    # Next call must be short-circuited — transport NOT hit.
+    with pytest.raises(IntegrationError, match="circuit open"):
+        await c._request("/library/sections", {"X-Plex-Token": "t"})
+
+    assert calls["n"] == n_after_trip, "transport was hit after breaker opened — short-circuit broken"
+
+
+@pytest.mark.asyncio
+async def test_transport_error_trips_breaker():
+    """#290: a transport-level error (ConnectError) also counts as a failure."""
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        raise httpx.ConnectError("refused")
+
+    cb = CircuitBreaker(name="plex", fail_threshold=2, cooldown_s=60, clock=lambda: 0.0)
+    c = _client(handler, breaker=cb)
+
+    for _ in range(2):
+        with pytest.raises(IntegrationError):
+            await c._request("/identity", {"X-Plex-Token": "t"})
+
+    assert cb.state == "open"
+    n_after = calls["n"]
+
+    with pytest.raises(IntegrationError, match="circuit open"):
+        await c._request("/identity", {"X-Plex-Token": "t"})
+
+    assert calls["n"] == n_after
+
+
+@pytest.mark.asyncio
+async def test_4xx_does_not_open_breaker():
+    """#290: 4xx means Plex is reachable (bad auth/request) — must NOT trip
+    the breaker even after many consecutive 4xx responses."""
+    calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(401, text="Unauthorized")
+
+    cb = CircuitBreaker(name="plex", fail_threshold=3, cooldown_s=60, clock=lambda: 0.0)
+    c = _client(handler, breaker=cb)
+
+    # Fire five 401s — well over the threshold.
+    for _ in range(5):
+        with pytest.raises(IntegrationError):
+            await c._request("/library/sections", {"X-Plex-Token": "bad"})
+
+    assert cb.state == "closed", "401s must not open the circuit breaker"
+    assert calls["n"] == 5  # every call reached the transport
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_underlying_client():
+    """#290: aclose() must delegate to the httpx client so the connection pool
+    is actually released (not a no-op as the old stateless implementation was)."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="")
+
+    c = _client(handler)
+    assert not c._client.is_closed, "client should be open before aclose()"
+    await c.aclose()
+    assert c._client.is_closed, "client must be closed after aclose()"


### PR DESCRIPTION
Closes the two IMPORTANT items left in #290 (the cheap slice — breaker logging + radarr movieId — already shipped in #295).

### PlexClient: pooling + breaker
`PlexClient` opened a **fresh `httpx.AsyncClient` per call** at four sites (`_list_sections`, `full_scan`, `partial_scan`, `_get_xml`) — new TCP/TLS each time, **no circuit breaker**. A dead/flapping Plex during a coverage build = many serial 10s timeouts. `aclose()` was a no-op (false lifecycle assurance).

- Persistent `self._client` (base_url-bound, shares `_DEFAULT_TIMEOUT` with the arr base) + per-instance `CircuitBreaker`.
- All four sites funnel through one `_request()` choke-point mirroring the base's policy: **5xx + transport errors trip the breaker; a 4xx is reachable-but-rejected → records success, does not open**. When open, calls short-circuit fast with `IntegrationError` (call sites already catch it → graceful).
- `_list_sections` collapsed onto `_get_xml` (DRY); every public return shape + log line preserved exactly.
- `aclose()` now really closes the pool. (Already wired via `IntegrationBundle.aclose()` → app lifespan; no app.py change needed.)

Can't subclass `IntegrationClient` (Plex is XML + query-string auth), so this is self-contained — **zero churn to the arr clients' transport** (lower blast radius).

### base `_post`/`_put` contract alignment
They returned `None` on *any* non-JSON body while `_get` raises — a non-empty non-JSON 200 silently became `None` → `TypeError` downstream. Now: **empty/whitespace body → `None`** (legitimate 204/empty-200), **non-empty non-JSON → `IntegrationError`** (matches `_get`).

### Tests
TDD: pooling (persistent client identity), breaker-opens-then-short-circuits-without-network, 4xx-doesn't-open, `aclose` really closes; +`test_base_post_put_contract.py` (empty→None, non-JSON→raise, JSON→dict). 114 plex/integration/base/circuit tests pass; ruff clean. (One pre-existing test rewritten from global-`httpx.AsyncClient`-patch to `MockTransport` injection since the client is no longer re-instantiated per call.)

**Deferred NITs** (filed in #290, not this PR): breaker has no asyncio lock on OPEN→HALF_OPEN; single HALF_OPEN success closes (2-3 probes sturdier); bare `["id"]` in `all_*_files_with_mediainfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)