### PR TITLE
fix: dedup open provenance rows → no aftercare double-fire (#287)

### DIFF
--- a/src/subarr/provenance.py
+++ b/src/subarr/provenance.py
@@ -100,6 +100,19 @@ class ProvenanceStore:
         subgen_version: str | None = None,
     ) -> int:
         with self._lock:
+            # #287: dedup OPEN rows. A re-search of a still-in-flight path
+            # (completed_at IS NULL) must reuse the open ledger row — two open
+            # rows would both poll to completion and fire _run_aftercare twice
+            # for one transcription. Single-process safe under self._lock; a
+            # DB-level partial-UNIQUE backstop is the separate multi-process nit.
+            existing = self._conn.execute(
+                "SELECT id FROM subs_generated "
+                "WHERE canonical_path = ? AND completed_at IS NULL "
+                "ORDER BY id LIMIT 1",
+                (canonical_path,),
+            ).fetchone()
+            if existing is not None:
+                return existing[0]
             cur = self._conn.execute(
                 "INSERT INTO subs_generated "
                 "(canonical_path, series_id, sonarr_episode_id, radarr_movie_id, "
@@ -133,8 +146,11 @@ class ProvenanceStore:
     def mark_completed(self, ledger_id: int, when: float | None = None) -> None:
         ts = when if when is not None else time.time()
         with self._lock:
+            # #287: stamp the FIRST completion only — a later re-poll of the
+            # same path must not overwrite the original completed_at (mirrors
+            # complete_by_canonical's `completed_at IS NULL` idempotency).
             self._conn.execute(
-                "UPDATE subs_generated SET completed_at = ? WHERE id = ?",
+                "UPDATE subs_generated SET completed_at = ? WHERE id = ? AND completed_at IS NULL",
                 (ts, ledger_id),
             )
 

--- a/tests/test_provenance_dedup.py
+++ b/tests/test_provenance_dedup.py
@@ -1,0 +1,53 @@
+"""#287 NIT: provenance.record() must dedup OPEN (pending) rows so a re-search
+of an in-flight path doesn't create a second ledger row — two open rows both
+poll to completion and fire _run_aftercare twice for one transcription.
+
+Also: mark_completed stamps the FIRST completion only (idempotent re-poll).
+"""
+
+from __future__ import annotations
+
+
+def _store(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.provenance import ProvenanceStore
+
+    db = tmp_path / "p.db"
+    run_migrations(db)
+    return ProvenanceStore(db)
+
+
+def test_record_dedups_open_pending_row(tmp_path):
+    store = _store(tmp_path)
+    first = store.record(canonical_path="/m/A.mkv", scan_id="s1")
+    # re-search the same still-in-flight path → reuse the open row, no insert
+    second = store.record(canonical_path="/m/A.mkv", scan_id="s2")
+    assert second == first
+    assert len(store.pending()) == 1  # exactly one open ledger row
+
+
+def test_record_inserts_new_row_after_completion(tmp_path):
+    store = _store(tmp_path)
+    first = store.record(canonical_path="/m/A.mkv", scan_id="s1")
+    store.mark_completed(first)
+    # path completed; a fresh transcription of the same path is a NEW row
+    second = store.record(canonical_path="/m/A.mkv", scan_id="s2")
+    assert second != first
+    assert len(store.pending()) == 1  # only the new one is open
+
+
+def test_record_distinct_paths_independent(tmp_path):
+    store = _store(tmp_path)
+    a = store.record(canonical_path="/m/A.mkv", scan_id="s1")
+    b = store.record(canonical_path="/m/B.mkv", scan_id="s1")
+    assert a != b
+    assert len(store.pending()) == 2
+
+
+def test_mark_completed_keeps_first_stamp(tmp_path):
+    store = _store(tmp_path)
+    lid = store.record(canonical_path="/m/A.mkv", scan_id="s1")
+    store.mark_completed(lid, when=1000.0)
+    store.mark_completed(lid, when=2000.0)  # a later re-poll must NOT overwrite
+    row = store.query_by_path("/m/A.mkv")[0]
+    assert row.completed_at == 1000.0


### PR DESCRIPTION
Closes the **provenance double-row** half of #287 (the queue restart-reconciliation half shipped in #297).

**The bug:** `provenance.record()` did an unconditional INSERT. A re-search of a path whose transcription is still in flight (`completed_at IS NULL`) created a **second open ledger row** — the completion watcher then polls *both*, so `_run_aftercare` fires **twice** for one transcription (inflating aftercare + the ledger).

**Fix:**
- `record()` now reuses the existing open row for a canonical_path (returns its id) instead of inserting a duplicate. Single-process safe under `self._lock`; callers discard the id so reuse is transparent. (The DB-level partial-UNIQUE backstop is the separate multi-process NIT, left deferred — subarr is single-process by design.)
- `mark_completed()` now stamps the **first** completion only (`WHERE completed_at IS NULL`) — a later re-poll can't overwrite the original timestamp. Mirrors `complete_by_canonical`'s existing idempotency.

TDD: +4 tests (dedup open row, new row after completion, distinct paths independent, first-stamp wins). 126 provenance/aftercare/completion/scheduler/queue tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)