### PR TITLE
fix: DB durability hardening — migration race, NFS warning, WAL re-issue (#291 Slice A)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -322,6 +322,18 @@ async def lifespan(app_: FastAPI):
     # all verifications/intents lost + a fresh telemetry id). Verdict cached
     # for the telemetry data_persistent signal. None = unknown (not a container).
     app_.state.data_persistent = check_data_persistence(settings.db_path, app_.state.task_health)
+    # #291: advisory warning — WAL over NFS/SMB risks corruption; log only,
+    # not a hard failure (the setup may be fine, e.g. NFS with local locking).
+    from .data_persistence import data_dir_network_fs
+
+    _net_fs = data_dir_network_fs(settings.db_path)
+    if _net_fs is not None:
+        log.warning(
+            "NFS/network-FS WARNING: /data is on a %s filesystem. "
+            "SQLite WAL mode over network filesystems risks corruption. "
+            "Recommend mounting a local-disk volume at /data.",
+            _net_fs,
+        )
     # #204: exactly one subarr process per database. The handle must live on
     # app.state — the flock dies with it. Second worker / second container on
     # the same /data → red Health task + loud log (we warn, never brick boot).

--- a/src/subarr/crash_store.py
+++ b/src/subarr/crash_store.py
@@ -65,7 +65,10 @@ class CrashStore:
         self._lock = threading.Lock()
 
     def _connect(self) -> sqlite3.Connection:
-        return sqlite3.connect(str(self._path), isolation_level=None)
+        # #291: WAL is persistent but re-issue so this store is boot-order-independent.
+        conn = sqlite3.connect(str(self._path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
 
     def record(self, exc: BaseException, when: float | None = None) -> None:
         """Best-effort insert; never raises (a crash recorder that crashes

--- a/src/subarr/data_persistence.py
+++ b/src/subarr/data_persistence.py
@@ -19,11 +19,70 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 TASK_NAME = "data-persistence"
+
+# Filesystem types where WAL mode is a known corruption vector.
+_NETWORK_FS_TYPES = {"nfs", "nfs4", "cifs", "smb3", "smbfs", "fuse.glusterfs", "fuse.rclone"}
+
+
+def mount_fstype_for(target_path: str, mountinfo_text: str) -> str | None:
+    """Pure helper: parse /proc/self/mountinfo and return the fstype for the
+    mount entry whose mount-point is the longest prefix of target_path.
+
+    mountinfo line format (space-separated fields):
+        <mount-id> <parent-id> <major:minor> <root> <mount-point> <mount-options>
+        [optional-fields] ' - ' <fstype> <source> <super-options>
+
+    Returns the fstype string, or None if no matching entry is found.
+    """
+    best_prefix = ""
+    best_fstype: str | None = None
+    for line in mountinfo_text.splitlines():
+        # Split on the ' - ' separator that divides per-mount fields from fs info.
+        parts = line.split(" - ", 1)
+        if len(parts) != 2:
+            continue
+        left, right = parts
+        left_fields = left.split()
+        if len(left_fields) < 5:
+            continue
+        mount_point = left_fields[4]
+        # Normalise: ensure mount_point ends with / so startswith works cleanly.
+        mp = mount_point if mount_point.endswith("/") else mount_point + "/"
+        tp = target_path if target_path.endswith("/") else target_path + "/"
+        if tp.startswith(mp) and len(mp) > len(best_prefix):
+            fstype = right.split()[0] if right.split() else None
+            if fstype:
+                best_prefix = mp
+                best_fstype = fstype
+    return best_fstype
+
+
+def data_dir_network_fs(db_path: Path) -> str | None:
+    """Return the fstype if db_path's parent is on a network filesystem known
+    to be unsafe for WAL mode, else None.
+
+    Container-gated (like data_dir_is_ephemeral): returns None when not inside
+    a Docker container, not on Linux, or on any error — never warns on dev hosts.
+    """
+    try:
+        if not os.path.exists("/.dockerenv"):
+            return None
+        if sys.platform != "linux":
+            return None
+        data_dir = str(Path(db_path).parent)
+        mountinfo_text = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
+        fstype = mount_fstype_for(data_dir, mountinfo_text)
+        if fstype in _NETWORK_FS_TYPES:
+            return fstype
+        return None
+    except Exception:
+        return None
 
 
 def data_dir_is_ephemeral(db_path: Path) -> bool | None:

--- a/src/subarr/db_integrity.py
+++ b/src/subarr/db_integrity.py
@@ -24,7 +24,9 @@ TASK_NAME = "db-integrity"
 
 # Re-checked at most daily by the caller's discretion; the boot check is the
 # one that matters (covers unclean shutdowns, the main corruption window).
-EXPECTED_INTERVAL_S = 7 * 86400.0
+# #291: daily, not weekly — an always-on container's pill shouldn't read
+# "stale" for a week between boots.
+EXPECTED_INTERVAL_S = 1 * 86400.0
 
 
 class DatabaseCorruptionError(Exception):

--- a/src/subarr/migrate.py
+++ b/src/subarr/migrate.py
@@ -70,7 +70,12 @@ class MigrationRunner:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
         try:
-            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                "PRAGMA busy_timeout=5000"
+            )  # #291: a concurrent migrator (dev --reload) WAITS for the lock instead of erroring "database is locked"
+            conn.execute(
+                "PRAGMA journal_mode=WAL"
+            )  # #291 NIT: we rely on WAL's default synchronous=NORMAL — do NOT set synchronous=OFF (permits corruption on power loss)
             conn.execute("PRAGMA foreign_keys=ON")
             self._ensure_version_table(conn)
             applied_now: list[Migration] = []
@@ -202,10 +207,21 @@ class MigrationRunner:
                         )
                         continue
                     raise
-            conn.execute(
-                "INSERT INTO schema_versions (version, name, applied_at) VALUES (?, ?, ?)",
-                (m.version, m.name, time.time()),
-            )
+            try:
+                conn.execute(
+                    "INSERT INTO schema_versions (version, name, applied_at) VALUES (?, ?, ?)",
+                    (m.version, m.name, time.time()),
+                )
+            except sqlite3.IntegrityError:
+                # #291: a concurrent migrator (two processes booting together,
+                # e.g. dev --reload) recorded this version between our
+                # applied-versions read and now. The migration body is
+                # idempotent (CREATE IF NOT EXISTS / ADD COLUMN duplicate-guard),
+                # so roll back our duplicate work and treat it as applied — no
+                # crash, no corruption.
+                conn.execute("ROLLBACK")
+                log.info("migration %s already recorded by a concurrent process; skipping", m.name)
+                return
             conn.execute("COMMIT")
         except Exception:
             try:

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -209,6 +209,7 @@ class TelemetryCollector:
 
     def state(self) -> TelemetryState:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             row = conn.execute(
                 "SELECT install_id, opted_in, last_ping_at, "
@@ -231,6 +232,7 @@ class TelemetryCollector:
 
     def set_opt_in(self, opted_in: bool) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             conn.execute(
                 "UPDATE telemetry_state SET opted_in = ? WHERE id = 1",
@@ -333,6 +335,7 @@ class TelemetryCollector:
 
     def _ensure_row(self) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             existing = conn.execute("SELECT 1 FROM telemetry_state WHERE id = 1").fetchone()
             if not existing:
@@ -347,6 +350,7 @@ class TelemetryCollector:
 
     def _record_attempt(self, payload_json: str, error: str | None, transmit: bool) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             # #11: stamp last_error_at when error is set; clear it on
             # successful sends so the panel can show "healthy now" the

--- a/src/subarr/update_checker.py
+++ b/src/subarr/update_checker.py
@@ -328,6 +328,7 @@ class UpdateChecker:
     def states(self) -> list[UpdateState]:
         """All cached product states, sorted by product name."""
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             rows = conn.execute(
                 "SELECT product, repo, current_version, latest_version, "
@@ -500,6 +501,7 @@ class UpdateChecker:
         missed: list[dict[str, Any]] | None = None,
     ) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             conn.execute(
                 "INSERT INTO update_checks "
@@ -536,6 +538,7 @@ class UpdateChecker:
     def _write_error(self, product: str, repo: str, error: str) -> None:
         """Update last_error WITHOUT clearing prior successful poll data."""
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
         try:
             existing = conn.execute(
                 "SELECT 1 FROM update_checks WHERE product = ?",

--- a/tests/test_db_durability.py
+++ b/tests/test_db_durability.py
@@ -1,0 +1,85 @@
+"""#291 durability hardening:
+- migrate.py tolerates a concurrent-boot schema_versions collision (dev
+  --reload) instead of crashing.
+- data_persistence.mount_fstype_for resolves a path to its mount fstype so
+  WAL-over-network-FS can be warned.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from subarr.data_persistence import mount_fstype_for
+from subarr.migrate import MigrationRunner
+
+
+# ── migrate concurrent-boot collision ────────────────────────────────────────
+
+
+def test_apply_one_benign_on_concurrent_version_collision(tmp_path):
+    """Two processes booting together both read applied-versions before either
+    commits; the 2nd's version INSERT collides. It must roll back its duplicate
+    work and continue — no crash, no corruption."""
+    db = tmp_path / "m.db"
+    mig_dir = tmp_path / "migs"
+    mig_dir.mkdir()
+    (mig_dir / "001_x.sql").write_text("CREATE TABLE IF NOT EXISTS t (id INTEGER);")
+    runner = MigrationRunner(db, mig_dir)
+
+    conn = sqlite3.connect(str(db), isolation_level=None)
+    conn.execute("PRAGMA busy_timeout=5000")
+    runner._ensure_version_table(conn)
+    # Simulate a concurrent migrator that recorded v1 between our read and apply.
+    conn.execute("INSERT INTO schema_versions (version, name, applied_at) VALUES (1, '001_x', 0)")
+    mig = runner.discover()[0]
+
+    # Must NOT raise despite the duplicate version INSERT inside _apply_one.
+    runner._apply_one(conn, mig)
+
+    # State stays consistent: exactly one v1 row.
+    assert conn.execute("SELECT count(*) FROM schema_versions WHERE version = 1").fetchone()[0] == 1
+    conn.close()
+
+
+def test_run_is_idempotent_and_records_busy_timeout_path(tmp_path):
+    """A normal run applies, and a second run is a clean no-op (regression
+    guard around the busy_timeout/PRAGMA additions)."""
+    db = tmp_path / "m.db"
+    mig_dir = tmp_path / "migs"
+    mig_dir.mkdir()
+    (mig_dir / "001_x.sql").write_text("CREATE TABLE IF NOT EXISTS t (id INTEGER);")
+    runner = MigrationRunner(db, mig_dir)
+
+    first = runner.run()
+    assert [m.version for m in first] == [1]
+    second = runner.run()
+    assert second == []  # already up to date
+
+
+# ── mount fstype parser ──────────────────────────────────────────────────────
+
+_EXT4 = "24 30 0:22 / / rw,relatime shared:1 - ext4 /dev/root rw"
+_NFS = "36 24 0:33 / /data rw,relatime shared:2 - nfs4 server:/export rw"
+_CIFS = "40 24 0:40 / /data rw - cifs //nas/share rw"
+
+
+def test_mount_fstype_local_disk():
+    assert mount_fstype_for("/data", _EXT4 + "\n" + "37 24 0:35 / /data - ext4 /dev/sdb1 rw") == "ext4"
+
+
+def test_mount_fstype_nfs():
+    assert mount_fstype_for("/data", _EXT4 + "\n" + _NFS) == "nfs4"
+
+
+def test_mount_fstype_cifs():
+    assert mount_fstype_for("/data", _EXT4 + "\n" + _CIFS) == "cifs"
+
+
+def test_mount_fstype_longest_prefix_wins():
+    # /data on nfs nested under / on ext4 → the deeper mount wins.
+    mi = "\n".join([_EXT4, _NFS])
+    assert mount_fstype_for("/data/subarr/subarr.db", mi) == "nfs4"
+
+
+def test_mount_fstype_no_match_returns_none():
+    assert mount_fstype_for("/data", "garbage line with no separator") is None


### PR DESCRIPTION
First of two #291 slices (backend durability hardening). The migration runner itself was already **SOLID** — this is hardening around it. The integrity_check + VACUUM INTO backup endpoint + red-pill UI are **Slice B** (next PR).

### Migration runner — concurrent-boot race (dev `--reload`)
Two processes booting together both read applied-versions before either commits → the 2nd hit a UNIQUE collision on `schema_versions` and crashed (self-healed next boot, no corruption, but ugly). Fix preserves **atomic-per-migration** (no risky outer transaction):
- `PRAGMA busy_timeout=5000` so a concurrent migrator **waits** for the lock instead of erroring "database is locked".
- The `schema_versions` INSERT collision is caught as **benign** — migration bodies are idempotent (`CREATE IF NOT EXISTS` / ADD-COLUMN guard), so we roll back the duplicate work and treat it as applied. The catch is scoped to *only* the version INSERT; migration-body errors still abort + roll back.
- Documented reliance on WAL's `synchronous=NORMAL` (so nobody "optimizes" it to OFF).

### NFS/SMB warning
The ephemeral check compares `st_dev` vs `/`, so a network bind-mount reads as "persistent" — but WAL over a network FS is a corruption vector. Added a pure `mount_fstype_for()` parser + `data_dir_network_fs()` (container-gated) → an advisory `log.warning` (not a red pill — the setup *might* be fine).

### WAL re-issue on reconnect stores
`telemetry`/`update_checker`/`crash_store` reconnect per call without re-issuing `journal_mode=WAL` — belt-and-suspenders since the migrator sets WAL first, but now each store is boot-order-independent.

### Integrity staleness 7d → 1d
An always-on container shouldn't read "stale" for a week.

### Verified, no change
`audio_lang_audit` full-wipe is the **re-derivable scan audit**; irreplaceable user verifications live in the separate `audio_lang_verifications` table (untouched). Confirms the reviewer's hypothesis.

TDD: +7 tests (concurrent-boot collision is benign, run idempotency, mount-fstype parser across ext4/nfs4/cifs/nested/no-match). 92 migrate/persistence/telemetry/update/crash/integrity tests pass; ruff clean.

**Deferred** (separate auth-sensitive NIT): `auth_store` `isolation_level` divergence — left for an auth-focused change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)