### PR TITLE
fix: coverage-cache health pill no longer false-flags stale every cycle (#303)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -342,7 +342,10 @@ async def lifespan(app_: FastAPI):
     # (as "never run yet"), not only after their first cycle. Each loop's first
     # record_success/failure carries its real cadence and corrects these.
     for _tname, _tiv in (
-        ("coverage-cache", 300),
+        (
+            "coverage-cache",
+            600,
+        ),  # 2x refresh interval — covers sleep + 60-90s build (see background_refresh_loop)
         ("dashboard-cache", 30),
         ("scheduler", 60),
         ("completion-watcher", 30),

--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -462,6 +462,12 @@ async def background_refresh_loop(
     the user's probe_roots config.
     """
     get_bundle = bundle_provider or (lambda: bundle)
+    # The health staleness threshold must cover the SLEEP *plus* the refresh
+    # build time: refresh() takes 60-90s on large libraries, so successes land
+    # interval_s + build_time apart. A flat interval_s threshold marks the pill
+    # stale for the duration of every refresh (false alarm). 2x interval_s
+    # tolerates a full slow cycle; only a genuinely stuck loop trips it.
+    health_interval_s = interval_s * 2
     # Initial refresh on boot if nothing cached yet — fills the snapshot
     # so the first /api/coverage request after a fresh deploy doesn't
     # block for 90s.
@@ -488,10 +494,10 @@ async def background_refresh_loop(
                 caps_provider=caps_provider,
             )
             if health:
-                health.record_success("coverage-cache", expected_interval_s=interval_s)
+                health.record_success("coverage-cache", expected_interval_s=health_interval_s)
         except asyncio.CancelledError:
             raise
         except Exception as e:
             if health:
-                health.record_failure("coverage-cache", e, expected_interval_s=interval_s)
+                health.record_failure("coverage-cache", e, expected_interval_s=health_interval_s)
             log.warning("coverage cache: background refresh failed: %s", e)

--- a/tests/test_coverage_cache_health.py
+++ b/tests/test_coverage_cache_health.py
@@ -1,0 +1,53 @@
+"""Regression: the coverage-cache health staleness threshold must cover the
+SLEEP plus the refresh build time. A flat interval_s marked the pill stale for
+the ~60-90s of every refresh (false 'coverage cache' warning, dogfood 2026-06-20).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from subarr.coverage_cache import background_refresh_loop
+
+
+class _FakeCache:
+    def get_cached(self):
+        return {"cached": True}  # non-None → skip the boot warm path
+
+    async def refresh(self, *a, **k):
+        return None
+
+
+class _FakeHealth:
+    def __init__(self):
+        self.successes = []
+
+    def record_success(self, name, expected_interval_s=None):
+        self.successes.append((name, expected_interval_s))
+
+    def record_failure(self, name, err, expected_interval_s=None):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_health_threshold_covers_refresh_duration():
+    health = _FakeHealth()
+    task = asyncio.create_task(background_refresh_loop(cache=_FakeCache(), interval_s=1, health=health))
+    for _ in range(50):  # wait for the first post-sleep refresh to record success
+        if health.successes:
+            break
+        await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert health.successes, "loop never recorded a success"
+    name, expected_interval_s = health.successes[0]
+    assert name == "coverage-cache"
+    # threshold = 2x interval so a 60-90s refresh on top of the sleep never
+    # false-flags the pill stale.
+    assert expected_interval_s == 2


### PR DESCRIPTION
Closes #303. Dogfood-found on :9923.

The coverage cache refreshes fine (~65s, 744 items, no errors) but the Health pill kept going stale because the staleness threshold (300s) was *smaller* than the real success cadence (`sleep(300) + refresh(~65s)` = ~365s+). The threshold didn't account for the refresh duration sitting on top of the sleep.

Fix: health threshold = `2 * interval_s` (tolerates a full slow cycle; only a genuinely stuck loop trips it). Boot seed in app.py matched (300→600).

TDD: +1 test asserting the loop records success with `expected_interval_s == 2 * interval_s`. ruff clean, import OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)