### PR TITLE
fix: prune orphan update-checker product rows (stale vanilla subgen row)

### DIFF
--- a/src/subarr/update_checker.py
+++ b/src/subarr/update_checker.py
@@ -362,18 +362,18 @@ class UpdateChecker:
         after the box switched to the subarr-subgen fork, or vice versa)
         would render on the Updates page forever. Pruning to the live product
         set keeps the page honest. Returns the count of orphan rows removed."""
-        keep = tuple(self._products.keys())
-        if not keep:
-            return 0
-        placeholders = ",".join("?" * len(keep))
+        keep = set(self._products.keys())
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
         conn.execute("PRAGMA journal_mode=WAL")
         try:
-            cur = conn.execute(
-                f"DELETE FROM update_checks WHERE product NOT IN ({placeholders})",
-                keep,
-            )
-            return cur.rowcount or 0
+            # Resolve orphans in Python and delete each by exact product = ? —
+            # fully parameterized, no dynamic IN-clause SQL. The tracked set is
+            # tiny (2-3 products), so the per-row deletes are negligible.
+            rows = conn.execute("SELECT DISTINCT product FROM update_checks").fetchall()
+            orphans = [r[0] for r in rows if r[0] not in keep]
+            for product in orphans:
+                conn.execute("DELETE FROM update_checks WHERE product = ?", (product,))
+            return len(orphans)
         finally:
             conn.close()
 

--- a/src/subarr/update_checker.py
+++ b/src/subarr/update_checker.py
@@ -354,6 +354,29 @@ class UpdateChecker:
             for r in rows
         ]
 
+    def _prune_untracked(self) -> int:
+        """Drop persisted state for products we no longer track.
+
+        states() returns every row in update_checks, so a product tracked
+        under a previous config (e.g. the vanilla 'subgen' row left behind
+        after the box switched to the subarr-subgen fork, or vice versa)
+        would render on the Updates page forever. Pruning to the live product
+        set keeps the page honest. Returns the count of orphan rows removed."""
+        keep = tuple(self._products.keys())
+        if not keep:
+            return 0
+        placeholders = ",".join("?" * len(keep))
+        conn = sqlite3.connect(str(self._db_path), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            cur = conn.execute(
+                f"DELETE FROM update_checks WHERE product NOT IN ({placeholders})",
+                keep,
+            )
+            return cur.rowcount or 0
+        finally:
+            conn.close()
+
     async def refresh_now(self) -> list[UpdateState]:
         """Force a poll across all products (admin endpoint)."""
         await self._poll_all()
@@ -392,6 +415,7 @@ class UpdateChecker:
                 log.exception("update poll tick failed: %s", e)
 
     async def _poll_all(self) -> None:
+        self._prune_untracked()  # drop orphan rows for products no longer tracked
         if self._client is None:
             self._client = httpx.AsyncClient(
                 # github.com (the web host), NOT api.github.com — the Atom

--- a/tests/test_update_checker_prune.py
+++ b/tests/test_update_checker_prune.py
@@ -1,0 +1,55 @@
+"""Orphan-prune: update_checks rows for products no longer tracked must be
+dropped, else states() renders a ghost on the Updates page — e.g. the vanilla
+'subgen' row lingering after the box switched to the subarr-subgen fork.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _seed(db, product):
+    conn = sqlite3.connect(str(db), isolation_level=None)
+    conn.execute(
+        "INSERT INTO update_checks (product, repo, current_version, latest_version, "
+        "latest_released_at, release_notes_url, is_breaking, checked_at, last_error, missed_json) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (product, f"x/{product}", "1", "1", None, None, 0, 0.0, None, None),
+    )
+    conn.close()
+
+
+def test_prune_untracked_drops_orphan_products(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.update_checker import UpdateChecker
+
+    db = tmp_path / "u.db"
+    run_migrations(db)
+    _seed(db, "subarr-subgen")
+    _seed(db, "subgen")  # orphan: not tracked when running the fork
+
+    uc = UpdateChecker(
+        db_path=db,
+        products={"subarr": "coaxk/subarr", "subarr-subgen": "coaxk/subarr-subgen"},
+    )
+    removed = uc._prune_untracked()
+
+    assert removed == 1
+    names = {s.product for s in uc.states()}
+    assert names == {"subarr-subgen"}  # orphan 'subgen' gone, tracked row kept
+
+
+def test_prune_untracked_noop_when_all_tracked(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.update_checker import UpdateChecker
+
+    db = tmp_path / "u.db"
+    run_migrations(db)
+    _seed(db, "subarr-subgen")
+
+    uc = UpdateChecker(
+        db_path=db,
+        products={"subarr": "coaxk/subarr", "subarr-subgen": "coaxk/subarr-subgen"},
+    )
+    assert uc._prune_untracked() == 0
+    assert {s.product for s in uc.states()} == {"subarr-subgen"}


### PR DESCRIPTION
Dogfood-found on :9923. The Updates page showed a third row — a vanilla **`subgen`** entry ("installed release unknown → 2026.06.4") — for a box that runs the **subarr-subgen fork** and shouldn't track vanilla at all.

**Root cause:** `update_checker.states()` does `SELECT ... FROM update_checks ORDER BY product` with no filter, and nothing ever pruned products that left the tracked set. The fork/vanilla product set is decided at boot (app.py:681) — switching modes (or an older build) leaves an orphan row that renders forever.

**Fix:** `_poll_all` now calls `_prune_untracked()` first — `DELETE FROM update_checks WHERE product NOT IN (<live products>)` (parameterized). Self-healing each poll; covers fork→vanilla and vanilla→fork.

TDD: +2 tests (orphan dropped + tracked kept; no-op when all tracked). ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)