### PR TITLE
perf: /api/queue skips the ~2s docker logs read when idle

### DIFF
--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -245,12 +245,18 @@ async def get_queue(request: Request, history_window_s: int = _DEFAULT_HISTORY_W
     live["processing_count"] = len(live["processing"])
     live["queued_count"] = len(live["queued"])
 
-    progress_map = await docker_ops.recent_progress(tail=80)
-    if progress_map and isinstance(live.get("processing"), list):
-        for task in live["processing"]:
-            prog = match_progress(task.get("path", ""), progress_map)
-            if prog is not None:
-                task["progress"] = prog
+    # Only pull subgen's progress logs when something is actually transcribing.
+    # recent_progress() is a docker logs read (slow over the socket proxy) — with
+    # nothing processing there's no progress to merge, so skip the cost. This is
+    # the common idle case; fetching it unconditionally made every /api/queue
+    # poll pay ~2s for nothing (dogfood 2026-06-20).
+    if live["processing"]:
+        progress_map = await docker_ops.recent_progress(tail=80)
+        if progress_map:
+            for task in live["processing"]:
+                prog = match_progress(task.get("path", ""), progress_map)
+                if prog is not None:
+                    task["progress"] = prog
 
     # HISTORY (subarr scan_store). Flatten scans → per-path rows so each
     # row in the UI is a single submission outcome, not a scan-with-N-paths.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -59,6 +59,38 @@ def test_queue_busy(app_with_stub):
     assert body["processing"][0]["type"] == "transcribe"
 
 
+def test_queue_idle_skips_docker_progress_read(app_with_stub):
+    """Perf (dogfood 2026-06-20): with nothing processing, /api/queue must NOT
+    do the slow docker logs read (recent_progress) — there's no progress to
+    merge into an empty list, and the read was costing ~2s per poll when idle."""
+    calls = []
+
+    async def _spy(*a, **k):
+        calls.append((a, k))
+        return {}
+
+    app_with_stub.app.state.docker.recent_progress = _spy
+    r = app_with_stub.get("/api/queue")
+    assert r.status_code == 200
+    assert r.json()["processing"] == []
+    assert calls == []  # docker logs read skipped when idle
+
+
+@pytest.mark.subgen(handler=_busy_handler)
+def test_queue_busy_still_reads_progress(app_with_stub):
+    """When something IS processing, recent_progress is fetched to merge live %."""
+    calls = []
+
+    async def _spy(*a, **k):
+        calls.append((a, k))
+        return {}
+
+    app_with_stub.app.state.docker.recent_progress = _spy
+    r = app_with_stub.get("/api/queue")
+    assert r.status_code == 200
+    assert len(calls) == 1  # fetched once because a job is processing
+
+
 def _arena_mixed_handler(req: httpx.Request) -> httpx.Response:
     # subgen /queue with one real library job (/media/...) and one tuning-lab
     # arena sweep, which runs via /asr UPLOAD mode → a subgen temp upload path


### PR DESCRIPTION
Diagnosed from a dogfood report (UI "noticeably slower") + DevTools Network traces showing `/api/queue` consistently ~2s.

**Root cause:** `get_queue()` called `docker_ops.recent_progress(tail=80)` **unconditionally**, then only merged the result `if live["processing"]`. `recent_progress` is a Docker `logs` read over the socket proxy (~2s). With **0 jobs transcribing** (the common idle state) it fetched progress logs only to merge them into an *empty* list — so every `/api/queue` poll wasted ~2s. The queue page + sidebar poll this repeatedly, and on busy pages (Coverage) the concurrent calls piled up behind it.

**Fix:** only do the Docker read when `live["processing"]` is non-empty. Idle polls now skip it entirely.

TDD: +2 tests (idle → `recent_progress` NOT called; busy → called once). 10 queue tests pass; ruff check + format + bandit clean.

Note: this is the clear, high-confidence win. If any residual sluggishness remains after deploy, I'll add a slow-request timing log to catch anything else with hard numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)