### PR TITLE
fix: quiet httpx/httpcore info-log spam from health polls (r/sonarr)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -122,6 +122,12 @@ from .single_process import check_single_process
 from .subgen_client import SubgenClient
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+# r/sonarr feedback: httpx/httpcore log EVERY request at INFO, so the health/
+# queue polls to subgen/sonarr/radarr/bazarr/tautulli/plex flood the info log
+# with "200 OK" lines and bury real signal. Pin them to WARNING — routine
+# request success is debug-level detail, not an info event.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 

--- a/tests/test_logging_hygiene.py
+++ b/tests/test_logging_hygiene.py
@@ -1,0 +1,18 @@
+"""Log hygiene: the HTTP client must not flood the info log.
+
+r/sonarr feedback (furian11): the info log was a wall of "200 OK" lines because
+httpx logs every request at INFO, and Subarr polls subgen/sonarr/radarr/bazarr/
+tautulli/plex on a loop. Those routine successes belong below INFO so the info
+log stays signal (errors + real events), not health-poll noise.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def test_httpx_request_logging_pinned_below_info():
+    import subarr.app  # noqa: F401 — importing runs the module-level logging setup
+
+    assert logging.getLogger("httpx").level == logging.WARNING
+    assert logging.getLogger("httpcore").level == logging.WARNING


### PR DESCRIPTION
r/sonarr feedback (furian11): the info log is a wall of "200 OK" lines from Subarr connecting to subgen/sonarr/radarr/bazarr/tautulli/plex, drowning real errors.

Root cause: `httpx` (and its engine `httpcore`) log **every** request at INFO. Subarr health/queue-polls those six services on a loop, so on the default INFO root that's a flood. In a 60s sample on my box, 95 of ~103 INFO lines were httpx.

Fix: pin `httpx` + `httpcore` loggers to WARNING in the logging setup (`app.py`). Routine request success is debug-level detail, not an info event. Subarr's own INFO logs (bazarr upload OK, plex partial-scan, etc. — genuine events) are unaffected.

Verified live on the dev box: httpx INFO lines dropped from ~48 per 15s to **0**, while real event logs still print. Guard test asserts both loggers stay at WARNING.