### PR TITLE
chore: auto-rebuild SPA bundles via pre-commit hook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 *.bundle.js text eol=lf
 *.bundle.js.map text eol=lf
 src/subarr/static/v1/**/*.html text eol=lf
+
+# Git hooks are POSIX sh — pin to LF so a CRLF shebang (#!/bin/sh\r) can't
+# break execution on Linux/macOS (incl. CI clones).
+.githooks/* text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Auto-rebuild the v1 SPA bundles when a frontend source is staged, so a
+# stale bundle can never reach CI's frontend drift gate
+# (.github/workflows/frontend.yml). The esbuild build is ~50ms — see
+# scripts/build-frontend.mjs. Wired up via core.hooksPath (.githooks),
+# set by scripts/setup-hooks.mjs on `npm install`.
+#
+# Escape hatch (use only if the bundles are already current and Node is
+# unavailable):  SKIP_FRONTEND_BUILD=1 git commit ...
+set -e
+
+[ "${SKIP_FRONTEND_BUILD:-}" = "1" ] && exit 0
+
+# Only act when a staged change can affect bundle output: JSX/JS sources
+# under the SPA tree (including the injected session-guard.js) or the build
+# script itself. Generated bundles are never hand-edited, so editing them
+# directly won't trigger a rebuild — but a source edit always will.
+staged=$(git diff --cached --name-only --diff-filter=ACMR)
+needs_build=$(printf '%s\n' "$staged" \
+  | grep -E '^(src/subarr/static/v1/.*\.(jsx|js)|scripts/build-frontend\.mjs)$' || true)
+[ -z "$needs_build" ] && exit 0
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "pre-commit: frontend source staged but 'npm' is not on PATH." >&2
+  echo "  Install Node and retry, rebuild elsewhere and re-stage the bundles," >&2
+  echo "  or bypass with:  SKIP_FRONTEND_BUILD=1 git commit ..." >&2
+  exit 1
+fi
+
+echo "pre-commit: frontend source staged -> rebuilding SPA bundles..."
+npm run build:frontend >/dev/null
+
+# Re-stage the regenerated outputs so the commit is self-consistent and the
+# CI drift gate stays green. Stage only generated artifacts (.bundle.js +
+# .map) — never the .jsx sources, so partial-staged commits keep their
+# intended source diff. The .html pages are hand-authored sources, not build
+# outputs, so they are deliberately left to the developer.
+git add -- src/subarr/static/v1/home-hifi/*.bundle.js \
+           src/subarr/static/v1/home-hifi/*.bundle.js.map
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Build-time tooling for the subarr static SPA bundles. Not published.",
   "type": "module",
   "scripts": {
+    "prepare": "node scripts/setup-hooks.mjs",
     "build:frontend": "node scripts/build-frontend.mjs",
     "dev:frontend": "node scripts/build-frontend.mjs --watch",
     "check:frontend": "node scripts/build-frontend.mjs && git diff --exit-code -- 'src/subarr/static/v1/home-hifi/*.bundle.js' 'src/subarr/static/v1/home-hifi/*.html'",

--- a/scripts/setup-hooks.mjs
+++ b/scripts/setup-hooks.mjs
@@ -1,0 +1,16 @@
+// Point git at the tracked hooks directory (.githooks) so the frontend
+// auto-rebuild pre-commit hook activates after `npm install`. This is the
+// husky-free way to ship a versioned hook: the hook lives in-repo and
+// core.hooksPath makes git use it.
+//
+// No-ops (instead of failing the install) outside a git checkout — e.g. when
+// the package is unpacked from a tarball or vendored without .git — so it
+// never breaks a consumer's `npm install`.
+import { execFileSync } from 'node:child_process';
+
+try {
+  execFileSync('git', ['rev-parse', '--git-dir'], { stdio: 'ignore' });
+  execFileSync('git', ['config', 'core.hooksPath', '.githooks'], { stdio: 'ignore' });
+} catch {
+  // Not a git checkout, or git unavailable — nothing to wire up.
+}


### PR DESCRIPTION
## What & why

The frontend bundle-drift gate (`.github/workflows/frontend.yml`) is healthy and was never broken. The recurring "arena.bundle.js drift" was **process, not platform**: during fast sprints a shared `.jsx` (e.g. `chrome.jsx`, imported by most pages including arena) gets edited, the dependent bundles go stale, the bundle is pushed unbuilt, CI *correctly* fails, and each was fixed with a rebuild round-trip — tempting an `--admin` bypass.

### Evidence the gate is fine (no esbuild platform divergence)
- esbuild is `0.28.1` everywhere (package.json / lockfile / installed / binary) — no version skew. Node 20-vs-22 is irrelevant; esbuild is a Go binary.
- A fresh local **Windows** `build:frontend` on `main` produces **zero `.bundle.js`/`.html` drift** vs committed — i.e. Windows build == committed == Linux-CI build. Only `.map` files differ (platform `sourcesContent`), which the gate already excludes by design.
- `frontend` check is green on `main` and every PR's final commit; each fail→pass pair changed **only bundle files**, no `.jsx`.

## The fix — close the loop at the dev boundary
- **`.githooks/pre-commit`**: when a staged change touches a frontend source (`*.jsx`/`*.js` under the SPA tree, or `scripts/build-frontend.mjs`), run `build:frontend` (~50ms) and re-stage the generated `*.bundle.js`/`*.map`. Only artifacts are re-staged (never `.jsx` sources), so partial-commits keep their intended diff. Blocks if Node is missing; `SKIP_FRONTEND_BUILD=1` escape hatch.
- **`scripts/setup-hooks.mjs`** + `package.json` `"prepare"`: wire `core.hooksPath` to `.githooks` on `npm install`; no-ops outside a git checkout (won't break tarball/pip installs).
- **`.gitattributes`**: pin `.githooks/*` to LF so the `sh` shebang survives Linux/CI clones.

## Verification
- Functional test: edited `session-guard.js` (injected into all bundles), staged only it → hook rebuilt and the commit auto-contained 14 `.bundle.js` + 14 `.map`. Scratch commit discarded.
- No-frontend commit → hook no-ops.
- Local gates green: `check:frontend` PASS, `test:frontend` 38/38.

No app code changed — tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)