### PR TITLE
fix(queue): resolve orphaned SUBMITTED rows + surface file-removed outcomes (#336)

### DIFF
--- a/src/subarr/pending_feeder.py
+++ b/src/subarr/pending_feeder.py
@@ -42,6 +42,11 @@ DEFAULT_TARGET_DEPTH = 2
 # very short job that completed before it ever showed up).
 INFLIGHT_GRACE_S = 30.0
 
+# #336: how long a SUBMITTED row that subgen no longer reports must have been
+# submitted before we resolve (drop) it as orphaned. 2x the inflight grace so a
+# job subgen is merely slow to surface isn't dropped prematurely.
+ORPHAN_GRACE_S = 60.0
+
 
 def _subgen_paths(q: dict) -> set[str]:
     """The set of subgen-space paths currently queued/processing (same shape
@@ -97,11 +102,6 @@ class PendingQueueFeeder:
         # → monotonic submit time. Counted toward effective depth so we don't
         # re-fill a slot subgen hasn't reported yet (the over-feed race).
         self._inflight: dict[str, float] = {}
-        # #287: one-shot reconcile on first successful subgen /queue read.
-        # Stays False until a /queue read succeeds; set to True after the first
-        # reconcile runs. Reset to False on start() so a process restart always
-        # re-reconciles once.
-        self._reconciled: bool = False
 
     @property
     def _subgen(self):
@@ -113,7 +113,6 @@ class PendingQueueFeeder:
         if self._task is not None and not self._task.done():
             return
         self._stop.clear()
-        self._reconciled = False  # #287: re-reconcile on every process start
         self._task = asyncio.create_task(self._loop(), name="subarr-queue-feeder")
 
     def kick(self) -> None:
@@ -179,21 +178,18 @@ class PendingQueueFeeder:
 
         subgen_paths = _subgen_paths(q)
 
-        # #287: one-shot boot reconcile. On the first tick where subgen's /queue
-        # is readable, re-pend any SUBMITTED rows that subgen no longer knows
-        # about (subgen was restarted and lost its queue). Runs BEFORE normal
-        # feeding so re-pended jobs are immediately eligible this same tick.
-        # The flag is only set after a successful /queue read so a momentarily
-        # unreachable subgen does NOT trigger a spurious re-pend.
-        if not self._reconciled:
-            n_repended = self._store.repend_orphaned_submitted(subgen_paths)
-            if n_repended:
-                log.info(
-                    "queue-feeder boot reconcile: re-pended %d orphaned SUBMITTED job(s) "
-                    "(subgen queue was empty for them after restart)",
-                    n_repended,
-                )
-            self._reconciled = True
+        # #336: every tick, RESOLVE (drop) SUBMITTED rows that subgen no longer
+        # has and that are past the surface grace. A submitted job leaves subgen's
+        # queue when it's transcribed, SKIPPED (sub already exists / file gone), or
+        # lost on restart — in every case the scan already recorded the outcome, so
+        # the pending row has done its job and should be dropped. This replaces the
+        # old #287 boot-only RE-PEND, which flipped orphans back to PENDING and
+        # re-submitted already-done files forever — the zombie churn that piled up
+        # orphaned SUBMITTED rows and starved the feeder's effective depth. A
+        # genuinely-lost transcription re-surfaces as a coverage gap on the next walk.
+        n_resolved = self._store.resolve_orphaned_submitted(subgen_paths, older_than_s=ORPHAN_GRACE_S)
+        if n_resolved:
+            log.info("queue-feeder: resolved %d orphaned SUBMITTED job(s) subgen no longer has", n_resolved)
 
         now = time.monotonic()
         # Release in-flight reservations that have surfaced in subgen's queue

--- a/src/subarr/pending_queue.py
+++ b/src/subarr/pending_queue.py
@@ -292,35 +292,35 @@ class PendingQueueStore:
             )
             return cur.rowcount > 0
 
-    def repend_orphaned_submitted(self, live_subgen_paths: set[str]) -> int:
-        """#287: re-pend SUBMITTED jobs that subgen no longer knows about.
+    def resolve_orphaned_submitted(self, live_subgen_paths: set[str], *, older_than_s: float) -> int:
+        """#336: REMOVE SUBMITTED jobs that subgen no longer reports and that were
+        submitted longer ago than `older_than_s` (past the surface-in-/queue grace).
 
-        For each row with status=SUBMITTED whose subgen-space path
-        (`canonical_to_subgen_batch(canonical_path)`) is NOT in
-        `live_subgen_paths`, flip it back to STATUS_PENDING and clear
-        `submitted_at` so the feeder treats it as a fresh job.
-
-        Call this once at boot (after a successful /queue read) to recover
-        jobs that were SUBMITTED when subgen was restarted and lost its queue.
-        Returns the number of rows re-pended.
-        """
+        A submitted job leaves subgen's queue when it's transcribed, SKIPPED (sub
+        already exists / 404 file gone), or lost on a subgen restart — in every
+        case the scan already recorded the outcome in history, so the pending row
+        has done its job and is dropped. This replaces an earlier reconcile that
+        RE-PENDED orphans (flipped them back to PENDING), which re-submitted
+        already-done files forever — the zombie churn that piled up orphaned
+        SUBMITTED rows and starved the feeder's effective depth. A genuinely lost
+        transcription re-surfaces as a coverage gap on the next walk. Returns the
+        number removed."""
         from .paths import canonical_to_subgen_batch
 
+        cutoff = time.time() - older_than_s
         with self._lock:
             rows = self._conn.execute(
-                "SELECT id, canonical_path FROM pending_queue WHERE status = ?",
+                "SELECT id, canonical_path, submitted_at FROM pending_queue WHERE status = ?",
                 (STATUS_SUBMITTED,),
             ).fetchall()
-            count = 0
-            for job_id, canonical_path in rows:
-                sg_path = canonical_to_subgen_batch(canonical_path)
-                if sg_path not in live_subgen_paths:
-                    self._conn.execute(
-                        "UPDATE pending_queue SET status = ?, submitted_at = NULL WHERE id = ?",
-                        (STATUS_PENDING, job_id),
-                    )
-                    count += 1
-            return count
+            removed = 0
+            for job_id, canonical_path, submitted_at in rows:
+                if submitted_at is not None and submitted_at > cutoff:
+                    continue  # within grace — subgen may not have surfaced it yet
+                if canonical_to_subgen_batch(canonical_path) not in live_subgen_paths:
+                    self._conn.execute("DELETE FROM pending_queue WHERE id = ?", (job_id,))
+                    removed += 1
+            return removed
 
     def clear(self, status: str | None = None) -> int:
         with self._lock:

--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -33,6 +33,7 @@ from ..config import settings
 from ..log_safe import scrub
 from ..paths import PathOutsideRootError, canonical_to_fs
 from ..scan_store import (
+    PATH_STATUS_EMPTY,
     PATH_STATUS_ERROR,
     PATH_STATUS_OK,
     PATH_STATUS_ORPHANED,
@@ -190,6 +191,15 @@ def _path_outcome_chip(
             "category": "orphaned",
             "label": "lost on restart",
             "detail": error or "subgen restarted before transcription completed",
+        }
+    if status == PATH_STATUS_EMPTY:
+        # subgen returned 404 / walked == 0 — the file is no longer on disk
+        # (deleted or moved after it was queued). An expected terminal outcome,
+        # not an error; surface it as a skip so it doesn't vanish silently.
+        return {
+            "category": "skipped",
+            "label": "file removed",
+            "detail": "file is no longer on disk — nothing to transcribe, dropped from the queue",
         }
     return {"category": "pending", "label": status, "detail": ""}
 

--- a/tests/test_pending_feeder.py
+++ b/tests/test_pending_feeder.py
@@ -5,6 +5,7 @@ shared-queue back-off + dedup, submit-failure isolation, priority order.
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 
 import pytest
@@ -319,23 +320,22 @@ async def test_inflight_counted_in_capacity_gate_across_ticks(store):
 
 
 @pytest.mark.asyncio
-async def test_reconcile_repends_submitted_not_in_subgen(store):
-    """A SUBMITTED job whose sg_path is absent from subgen's /queue is
-    re-pended on the first successful reconcile tick so it gets re-fed."""
+async def test_reconcile_resolves_orphaned_submitted(store):
+    """#336: a SUBMITTED job subgen no longer reports (past the grace) is
+    RESOLVED (removed) — not re-pended. It re-surfaces as a coverage gap if still
+    needed, instead of being re-submitted to subgen forever (the zombie churn)."""
     job = store.enqueue("TV/lost.mkv", source="gaps")
     store.mark_submitted(job.id)
-    # subgen's queue is empty — it lost the job after a restart
-    subgen = FakeSubgen(queued=[], processing=[])
+    # age it past ORPHAN_GRACE_S so it's eligible for resolution
+    store._conn.execute("UPDATE pending_queue SET submitted_at = ? WHERE id = ?", (time.time() - 120, job.id))
+    subgen = FakeSubgen(queued=[], processing=[])  # subgen no longer has it
     rec = SubmitRecorder()
     feeder = _feeder(store, subgen, rec, target=2)
 
-    # First tick triggers the one-shot reconcile, then normal feeding
     await feeder.tick()
 
-    refreshed = store.get(job.id)
-    # The job was re-pended by reconcile, then immediately re-submitted by the feeder
-    assert refreshed.status == STATUS_SUBMITTED
-    assert rec.calls == ["TV/lost.mkv"]
+    assert store.get(job.id) is None  # removed, not re-pended
+    assert rec.calls == []  # nothing left to re-feed
 
 
 @pytest.mark.asyncio
@@ -379,34 +379,31 @@ async def test_reconcile_skipped_when_subgen_unreachable(store):
 
 
 @pytest.mark.asyncio
-async def test_reconcile_runs_once_per_process_start(store):
-    """The one-shot reconcile flag means it only fires once, even across
-    multiple ticks. Subsequent ticks don't repeat the reconcile logic."""
-    job = store.enqueue("TV/a.mkv", source="gaps")
-    store.mark_submitted(job.id)
-    # subgen starts empty (lost the job), then on 2nd tick also empty
+async def test_resolve_runs_every_tick_not_just_boot(store):
+    """#336: orphan resolution runs EVERY tick, not once at boot — a job that
+    orphans AFTER the first tick is still resolved on a later tick."""
     subgen = FakeSubgen(queued=[], processing=[])
     rec = SubmitRecorder()
     feeder = _feeder(store, subgen, rec, target=2)
 
-    # tick 1: reconcile fires, re-pends + re-submits
-    await feeder.tick()
-    assert rec.calls == ["TV/a.mkv"]
-    first_call_count = len(rec.calls)
+    await feeder.tick()  # first tick: nothing to resolve
 
-    # tick 2: reconcile must NOT fire again (one-shot)
-    await feeder.tick()
-    # No additional reconcile-triggered re-feed (any new calls would be
-    # normal feeder feeding, which would only happen if there were more pending)
-    assert len(rec.calls) == first_call_count
+    # now a job is submitted, orphaned (subgen still empty), and aged past grace
+    job = store.enqueue("TV/late.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    store._conn.execute("UPDATE pending_queue SET submitted_at = ? WHERE id = ?", (time.time() - 120, job.id))
+
+    await feeder.tick()  # a later tick must still resolve it
+    assert store.get(job.id) is None
 
 
 @pytest.mark.asyncio
-async def test_reconcile_retries_if_subgen_was_down_first(store):
-    """If subgen.queue() fails on tick 1, the reconcile flag is NOT set, so
-    tick 2 (with a reachable subgen) successfully reconciles."""
+async def test_resolve_deferred_until_subgen_readable(store):
+    """#336: if subgen.queue() fails, resolution is skipped that tick (we can't
+    confirm the job is gone); the next reachable tick resolves it."""
     job = store.enqueue("TV/b.mkv", source="gaps")
     store.mark_submitted(job.id)
+    store._conn.execute("UPDATE pending_queue SET submitted_at = ? WHERE id = ?", (time.time() - 120, job.id))
 
     call_count = {"n": 0}
 
@@ -415,17 +412,17 @@ async def test_reconcile_retries_if_subgen_was_down_first(store):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 raise SubgenUnavailable("down on first call")
-            # Second call succeeds with empty queue (job was lost)
+            # Second call succeeds with empty queue (job is gone)
             return {"queued": [], "processing": [], "queued_count": 0, "processing_count": 0}
 
     rec = SubmitRecorder()
     feeder = _feeder(store, FlakeySubgen(), rec, target=2)
 
-    # tick 1: subgen down → soft skip, reconcile not performed
+    # tick 1: subgen down → soft skip, job untouched
     n1 = await feeder.tick()
     assert n1 == 0
-    assert store.get(job.id).status == STATUS_SUBMITTED  # untouched
+    assert store.get(job.id).status == STATUS_SUBMITTED
 
-    # tick 2: subgen reachable → reconcile fires, re-pends + re-submits
+    # tick 2: subgen reachable → resolve removes the orphan
     await feeder.tick()
-    assert rec.calls == ["TV/b.mkv"]
+    assert store.get(job.id) is None

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -168,72 +168,8 @@ def test_reorder_unknown_id_raises(store):
         store.promote("nope")
 
 
-# ── repend_orphaned_submitted (#287) ────────────────────────────────
-
-
-def test_repend_orphaned_submitted_basic(store):
-    """Job whose sg_path is NOT in live_subgen_paths gets re-pended; job whose
-    sg_path IS still in live set stays SUBMITTED. Returns count of re-pended."""
-    from subarr.paths import canonical_to_subgen_batch
-
-    j1 = store.enqueue("TV/S01/e01.mkv", source="gaps")
-    j2 = store.enqueue("TV/S01/e02.mkv", source="gaps")
-    store.mark_submitted(j1.id)
-    store.mark_submitted(j2.id)
-
-    sg1 = canonical_to_subgen_batch("TV/S01/e01.mkv")
-    # j1 is still in subgen; j2 is orphaned (not in the live set)
-    n = store.repend_orphaned_submitted({sg1})
-    assert n == 1
-
-    j1_after = store.get(j1.id)
-    j2_after = store.get(j2.id)
-    assert j1_after.status == STATUS_SUBMITTED  # kept
-    assert j2_after.status == STATUS_PENDING  # re-pended
-    assert j2_after.submitted_at is None  # cleared
-
-
-def test_repend_orphaned_submitted_all_live(store):
-    """When every SUBMITTED job is in the live set, nothing is re-pended."""
-    from subarr.paths import canonical_to_subgen_batch
-
-    j = store.enqueue("TV/a.mkv", source="gaps")
-    store.mark_submitted(j.id)
-    sg = canonical_to_subgen_batch("TV/a.mkv")
-    n = store.repend_orphaned_submitted({sg})
-    assert n == 0
-    assert store.get(j.id).status == STATUS_SUBMITTED
-
-
-def test_repend_orphaned_submitted_empty_live(store):
-    """Empty live set means every SUBMITTED row is orphaned and re-pended."""
-    j1 = store.enqueue("TV/a.mkv", source="gaps")
-    j2 = store.enqueue("TV/b.mkv", source="gaps")
-    store.mark_submitted(j1.id)
-    store.mark_submitted(j2.id)
-    n = store.repend_orphaned_submitted(set())
-    assert n == 2
-    for jid in (j1.id, j2.id):
-        j = store.get(jid)
-        assert j.status == STATUS_PENDING
-        assert j.submitted_at is None
-
-
-def test_repend_orphaned_submitted_skips_pending_and_done(store):
-    """Only SUBMITTED rows are candidates; PENDING and DONE are untouched."""
-
-    p = store.enqueue("TV/pending.mkv", source="gaps")
-    s = store.enqueue("TV/submitted.mkv", source="gaps")
-    store.mark_submitted(s.id)
-    # mark the first one done
-    store.set_status(p.id, STATUS_DONE)
-    # Neither the done nor pending path is in the live set
-    n = store.repend_orphaned_submitted(set())
-    assert n == 1  # only the submitted one
-    assert store.get(p.id).status == STATUS_DONE
-    # PENDING job was never submitted so it would not be touched regardless,
-    # but here it's STATUS_DONE — confirm unchanged
-    assert store.get(s.id).status == STATUS_PENDING
+# ── resolve_orphaned_submitted (#336) — see the dedicated tests appended below
+# (the earlier #287 repend_orphaned_submitted was superseded and removed) ──────
 
 
 def test_move_step_walks_to_top(store):
@@ -268,3 +204,42 @@ def test_move_step_down_walks_to_bottom_then_noop(store):
     assert [j.id for j in store.list(status="pending")][-1] == top
     store.move_step(top, up=False)  # at bottom → no-op
     assert [j.id for j in store.list(status="pending")][-1] == top
+
+
+def test_resolve_orphaned_submitted_removes_past_grace(store):
+    """#336: a SUBMITTED row subgen no longer reports, aged past the grace, is
+    REMOVED (not re-pended) so already-done files stop churning the feeder."""
+    import time
+
+    job = store.enqueue("TV/gone.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    store._conn.execute("UPDATE pending_queue SET submitted_at = ? WHERE id = ?", (time.time() - 120, job.id))
+    removed = store.resolve_orphaned_submitted(set(), older_than_s=60.0)
+    assert removed == 1
+    assert store.get(job.id) is None
+
+
+def test_resolve_orphaned_submitted_keeps_within_grace(store):
+    """A just-submitted row (within grace) is left alone — subgen may not have
+    surfaced it in /queue yet."""
+    job = store.enqueue("TV/fresh.mkv", source="gaps")
+    store.mark_submitted(job.id)  # submitted_at = now
+    removed = store.resolve_orphaned_submitted(set(), older_than_s=60.0)
+    assert removed == 0
+    assert store.get(job.id).status == STATUS_SUBMITTED
+
+
+def test_resolve_orphaned_submitted_keeps_if_in_subgen(store):
+    """A SUBMITTED row whose path IS in subgen's live queue is kept even past
+    grace — it's actively processing, not orphaned."""
+    import time
+
+    from subarr.paths import canonical_to_subgen_batch
+
+    job = store.enqueue("TV/active.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    store._conn.execute("UPDATE pending_queue SET submitted_at = ? WHERE id = ?", (time.time() - 120, job.id))
+    live = {canonical_to_subgen_batch("TV/active.mkv")}
+    removed = store.resolve_orphaned_submitted(live, older_than_s=60.0)
+    assert removed == 0
+    assert store.get(job.id).status == STATUS_SUBMITTED

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -236,3 +236,15 @@ def test_queue_history_is_cached_within_ttl(app_with_stub, monkeypatch):
     assert app_with_stub.get("/api/queue").status_code == 200
     assert app_with_stub.get("/api/queue").status_code == 200
     assert calls["n"] == 1  # built once; second call served the cache
+
+
+def test_empty_status_surfaces_as_file_removed():
+    """#336: subgen 404 / walked==0 (file gone from disk) must NOT vanish into
+    the hidden 'pending' fallback — it surfaces as a visible 'file removed' skip."""
+    import subarr.routers.queue as q
+    from subarr.scan_store import PATH_STATUS_EMPTY
+
+    chip = q._path_outcome_chip(PATH_STATUS_EMPTY, None, None)
+    assert chip["category"] == "skipped"
+    assert chip["label"] == "file removed"
+    assert "no longer on disk" in chip["detail"]


### PR DESCRIPTION
## What & why

Dogfooding surfaced a 40+ job pending backlog that would not drain. Root-caused to two queue-hygiene bugs. Live evidence: **28 of 30 `pending` and all 18 `submitted`** rows already had a generated sub — re-queued already-done files piling up as zombies (the stale rows were cleared out-of-band).

### (b) Orphaned `submitted` rows were re-pended, not resolved
The feeder reconciled orphaned `submitted` rows by **re-pending** them (boot-only, #287). When subgen *skips* a file (sub already on disk) or the file is gone, no completion fires, so the `submitted` row never cleared — it got re-pended then re-submitted **forever**. That zombie churn piled up orphaned rows and starved the feeder's effective depth, so genuine work stopped draining.

**Fix:** per-tick `resolve_orphaned_submitted` — **remove** `submitted` rows subgen no longer reports once past a 60s surface grace (kept while in subgen's live queue / within grace / when subgen is unreachable). A genuinely lost transcription re-surfaces as a coverage gap on the next walk. Removed the now-dead re-pend primitive, `_reconciled` flag, and boot-once reconcile.

### (d) File-removed outcomes vanished from history
subgen `404` / `walked==0` (file deleted after it was queued) set `PATH_STATUS_EMPTY`, which fell through `_path_outcome_chip` to the hidden `pending` fallback — the job **disappeared from history entirely** (watched live in subgen logs). Now surfaced as a visible **"file removed"** skip in Recently-done.

## Tests
- per-tick resolve: removes past grace, keeps within grace, keeps if still in subgen, deferred when subgen unreachable, runs every tick (not boot-once)
- `EMPTY` chip surfaces as "file removed"
- Full suite green.

## Not in scope (follow-ups)
- The deeper root — coverage flags files that already have an on-disk sub as gaps, so subgen skips them (separate issue).
- "Recently done" shows green "queued" for OK scans (the scan-handoff outcome) rather than "done" once subgen finishes — needs a completion cross-ref in the history build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)