### PR TITLE
fix(admin): containment-check the absolute partial-scan path (#285)

### DIFF
--- a/src/subarr/routers/admin.py
+++ b/src/subarr/routers/admin.py
@@ -136,6 +136,22 @@ class PartialScanRequest(BaseModel):
     path: str
 
 
+def _ensure_abs_path_contained(p: str) -> None:
+    """#285: reject an absolute partial-scan path that resolves outside every
+    configured library root. Canonical paths are already containment-checked by
+    canonical_to_fs; the absolute branch was forwarded to Plex unchecked. Reuses
+    fs_to_canonical, which raises PathOutsideRootError (realpath containment) for
+    any path under no library root."""
+    from pathlib import Path
+
+    from ..paths import PathOutsideRootError, fs_to_canonical
+
+    try:
+        fs_to_canonical(Path(p))
+    except PathOutsideRootError:
+        raise HTTPException(400, detail="path is outside the media library") from None
+
+
 @router.post("/plex/partial-scan")
 async def plex_partial_scan(req: PartialScanRequest, request: Request) -> dict:
     """v1.1.1: trigger a Plex partial scan targeting one file's directory.
@@ -154,6 +170,12 @@ async def plex_partial_scan(req: PartialScanRequest, request: Request) -> dict:
         from ..paths import canonical_to_fs
 
         p = str(canonical_to_fs(p))
+    else:
+        # #285: the absolute branch skips canonical_to_fs's containment guard.
+        # Validate it resolves inside a configured library root before handing
+        # it to Plex's scan API — admin-authed, but still don't let a caller
+        # trigger a scan of an arbitrary host directory.
+        _ensure_abs_path_contained(p)
     try:
         return await plex.partial_scan(p)
     except IntegrationError as e:

--- a/tests/test_multilib_walkers.py
+++ b/tests/test_multilib_walkers.py
@@ -110,3 +110,21 @@ def test_library_canonical_resolves_for_partial_scan(two_libraries):
 
     expected = (two_libraries / "Movies" / "film.mkv").resolve()
     assert canonical_to_fs("@disk2/Movies/film.mkv") == expected
+
+
+def test_partial_scan_absolute_path_containment(two_libraries):
+    """#285: an absolute /api/plex/partial-scan path that resolves outside every
+    configured library root is rejected (400), not forwarded to Plex's scan API.
+    A path under a library root passes."""
+    import pytest
+    from fastapi import HTTPException
+
+    from subarr.paths import canonical_to_fs
+    from subarr.routers.admin import _ensure_abs_path_contained
+
+    inside = canonical_to_fs("@disk2/Movies/film.mkv")  # under disk2's root
+    _ensure_abs_path_contained(inside)  # contained → must not raise
+
+    with pytest.raises(HTTPException) as ei:
+        _ensure_abs_path_contained("/nonexistent-root/etc/passwd")
+    assert ei.value.status_code == 400


### PR DESCRIPTION
## What & why
From the #285 path/FS review (area 1/7). `/api/plex/partial-scan` accepts either a canonical path (containment-checked via `canonical_to_fs`) or an absolute path — and the **absolute branch was forwarded to Plex's scan API verbatim**, with no containment check. Admin-authed and only triggers a Plex scan (no subarr file-content leak), so MEDIUM — but it let a caller scan an arbitrary host directory.

## Fix
`_ensure_abs_path_contained` reuses `fs_to_canonical` (which does realpath containment — `.resolve()` + `relative_to` against every library root, raising `PathOutsideRootError` for anything outside). An absolute path that resolves outside every library root → **400**; a path under a library root passes unchanged.

## Test
`test_partial_scan_absolute_path_containment` — contained path passes; out-of-root path → 400.

## Remaining in #285 (not this PR)
Runtime `arr_path_prefix`/`media_root` edit doesn't rebuild `settings.libraries` — bigger config-reactivity change, load-bearing for the #161 multi-instance epic; deferred to a focused session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)