### PR TITLE
feat(subgen): poll async /config switch so uncached-model swaps don't time out (#6)

### DIFF
--- a/src/subarr/routers/subgen_setup.py
+++ b/src/subarr/routers/subgen_setup.py
@@ -215,7 +215,15 @@ async def apply(body: ApplyBody, request: Request) -> dict[str, Any]:
             ),
         }
     try:
-        status, resp = await _post_config(request.app, model=body.model, compute_type=body.compute_type)
+        # #6: when subgen supports async /config (v4.17+), post_config sends
+        # ?wait=false + polls /queue.config_switch — so an uncached-model download
+        # (minutes) no longer dies on the 120s read timeout mid-switch.
+        status, resp = await _post_config(
+            request.app,
+            model=body.model,
+            compute_type=body.compute_type,
+            async_config=getattr(caps, "async_config", False),
+        )
     except SubgenUnavailable as e:
         # Transport failure is AMBIGUOUS — the switch may or may not have
         # landed before the connection died. Tell the user to re-detect.

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -79,6 +79,10 @@ class SubgenCapabilities:
     # detect a SPECIFIC audio stream — lets the Review track-mismatch flow confirm
     # a non-default track's language.
     detect_language_track: bool = False
+    # v4.17 capability (#6): POST /config?wait=false runs the model switch on a
+    # background thread + returns 202, with progress in /queue.config_switch.
+    # post_config() polls instead of holding a request past the 120s read timeout.
+    async_config: bool = False
     # v4.8 capability: POST /batch accepts a per-request `kwargs` JSON query
     # param that overrides global + per-language SUBGEN_KWARGS for THIS scan
     # only. The tuning-lab / arena gates on this — it lets one config sweep
@@ -156,6 +160,7 @@ class SubgenCapabilities:
             "queue_cancel": self.queue_cancel,
             "robust_language_detection": self.robust_language_detection,
             "detect_language_track": self.detect_language_track,
+            "async_config": self.async_config,
             "per_request_kwargs": self.per_request_kwargs,
             "per_request_task": self.per_request_task,
             "asr_arena": self.asr_arena,
@@ -181,6 +186,7 @@ class SubgenCapabilities:
             queue_cancel=False,
             robust_language_detection=False,
             detect_language_track=False,
+            async_config=False,
             per_request_kwargs=False,
             per_request_task=False,
             asr_arena=False,
@@ -317,6 +323,7 @@ class SubgenClient:
         queue_cancel = False
         robust_language_detection = False
         detect_language_track = False
+        async_config = False
         per_request_kwargs = False
         per_request_task = False
         asr_arena = False
@@ -351,6 +358,7 @@ class SubgenClient:
                             queue_cancel = bool(caps_block.get("queue_cancel"))
                             robust_language_detection = bool(caps_block.get("robust_language_detection"))
                             detect_language_track = bool(caps_block.get("detect_language_track"))
+                            async_config = bool(caps_block.get("async_config"))
                             per_request_kwargs = bool(caps_block.get("per_request_kwargs"))
                             per_request_task = bool(caps_block.get("per_request_task"))
                             asr_arena = bool(caps_block.get("asr_arena"))
@@ -387,6 +395,7 @@ class SubgenClient:
             queue_cancel=queue_cancel,
             robust_language_detection=robust_language_detection,
             detect_language_track=detect_language_track,
+            async_config=async_config,
             per_request_kwargs=per_request_kwargs,
             per_request_task=per_request_task,
             asr_arena=asr_arena,
@@ -413,17 +422,30 @@ class SubgenClient:
         return caps
 
     async def post_config(
-        self, *, model: str | None = None, compute_type: str | None = None
+        self,
+        *,
+        model: str | None = None,
+        compute_type: str | None = None,
+        async_config: bool = False,
+        poll_timeout_s: float = 600.0,
     ) -> tuple[int, dict]:
         """POST /config — runtime model/compute switch (subarr-subgen r9+,
         gated on caps.runtime_config). Returns (status_code, body). subgen
         guarantees it ends on a working model (rollback contract); callers
-        surface body['reason']/'current_model' on failure."""
+        surface body['reason']/'current_model' on failure.
+
+        async_config (v4.17+, caps.async_config): send ?wait=false so subgen runs
+        the switch on a background thread + returns 202, then poll /queue.config_
+        switch to completion — a switch to an uncached model (minutes-long
+        download) no longer blows our read timeout. Returns the same (status,
+        body) shape as the sync path."""
         params: dict[str, str] = {}
         if model:
             params["model"] = model
         if compute_type:
             params["compute_type"] = compute_type
+        if async_config:
+            params["wait"] = "false"
         try:
             r = await self._client.post("/config", params=params)
         except httpx.HTTPError as e:
@@ -432,7 +454,45 @@ class SubgenClient:
             body = r.json()
         except ValueError:
             body = {}
+        if r.status_code == 202:
+            return await self._poll_config_switch(poll_timeout_s)
         return r.status_code, body
+
+    async def _poll_config_switch(self, timeout_s: float) -> tuple[int, dict]:
+        """Poll GET /queue.config_switch until the async /config switch reaches a
+        terminal state. Same (status, body) shape as the sync path: 200/ok,
+        422/failed (with reason/rolled_back), or 504 on poll timeout."""
+        import asyncio
+        import time
+
+        deadline = time.monotonic() + timeout_s
+        while True:
+            try:
+                q = await self.queue()
+            except SubgenUnavailable:
+                q = {}  # transient — keep polling to the deadline
+            cs = (q or {}).get("config_switch") or {}
+            state = cs.get("state")
+            if state == "done":
+                return 200, {"ok": True, "model": cs.get("model"), "compute_type": cs.get("compute_type")}
+            if state == "failed":
+                return 422, {
+                    "ok": False,
+                    "reason": cs.get("reason"),
+                    "detail": cs.get("detail"),
+                    "rolled_back": cs.get("rolled_back"),
+                    "current_model": cs.get("model"),
+                    "current_compute_type": cs.get("compute_type"),
+                }
+            if time.monotonic() >= deadline:
+                return 504, {
+                    "ok": False,
+                    "reason": "switch_timeout",
+                    "detail": f"model switch still running after {int(timeout_s)}s",
+                    "current_model": cs.get("model"),
+                    "current_compute_type": cs.get("compute_type"),
+                }
+            await asyncio.sleep(2.0)
 
     async def batch(
         self,

--- a/tests/test_subgen_setup_client.py
+++ b/tests/test_subgen_setup_client.py
@@ -71,3 +71,66 @@ async def test_post_config_success_and_failure_shapes(subarr_env):
 
     status, body = await _client_with(oom_handler).post_config(model="large-v3")
     assert status == 422 and body["reason"] == "oom" and body["current_model"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_post_config_async_polls_to_completion(subarr_env):
+    """#6: async_config=True sends ?wait=false, gets 202, then polls
+    /queue.config_switch to a terminal 'done' state and returns the sync shape."""
+
+    def handler(req):
+        if req.url.path == "/config":
+            assert req.url.params.get("wait") == "false"
+            return httpx.Response(202, json={"status": "switching", "model": "large-v3"})
+        if req.url.path == "/queue":
+            return httpx.Response(
+                200,
+                json={
+                    "queued": [],
+                    "processing": [],
+                    "config_switch": {"state": "done", "model": "large-v3", "compute_type": "float16"},
+                },
+            )
+        if req.url.path == "/status":
+            return httpx.Response(200, json={"version": "2026.06.4"})
+        return httpx.Response(404)
+
+    status, body = await _client_with(handler).post_config(
+        model="large-v3", compute_type="float16", async_config=True, poll_timeout_s=10.0
+    )
+    assert status == 200
+    assert body == {"ok": True, "model": "large-v3", "compute_type": "float16"}
+
+
+@pytest.mark.asyncio
+async def test_post_config_async_surfaces_failed_switch(subarr_env):
+    """#6: a failed async switch (config_switch.state == 'failed') comes back as
+    the sync 422 shape with reason + rolled_back."""
+
+    def handler(req):
+        if req.url.path == "/config":
+            return httpx.Response(202, json={"status": "switching", "model": "large-v3"})
+        if req.url.path == "/queue":
+            return httpx.Response(
+                200,
+                json={
+                    "queued": [],
+                    "processing": [],
+                    "config_switch": {
+                        "state": "failed",
+                        "reason": "oom",
+                        "rolled_back": True,
+                        "model": "medium",
+                        "compute_type": "float16",
+                    },
+                },
+            )
+        if req.url.path == "/status":
+            return httpx.Response(200, json={"version": "2026.06.4"})
+        return httpx.Response(404)
+
+    status, body = await _client_with(handler).post_config(
+        model="large-v3", async_config=True, poll_timeout_s=10.0
+    )
+    assert status == 422
+    assert body["reason"] == "oom" and body["rolled_back"] is True and body["current_model"] == "medium"


### PR DESCRIPTION
The subarr half of #6 item 1 (pairs with subarr-subgen#19, image `2026.06.4-r3` / patch_rev v4.17).

## What
subarr-subgen v4.17 makes `POST /config?wait=false` return **202** and run the model switch on a background thread, with progress in `GET /queue.config_switch` and a new `capabilities.async_config`. This wires subarr to drive it:

- **`SubgenCapabilities.async_config`** — parsed from `/queue` caps (6-spot mirror of `detect_language_track`).
- **`post_config(async_config=True)`** sends `?wait=false`; on **202** it polls `/queue.config_switch` via `_poll_config_switch()` until `done`/`failed` (or a `poll_timeout_s` cap → 504). Returns the **same `(status, body)` shape** as the sync path, so every caller is unchanged. Transient `/queue` errors keep polling to the deadline rather than aborting.
- **Guided-setup model switch** passes `async_config=caps.async_config` → a switch to an **uncached** model (minutes-long download) no longer dies on the 120s client read timeout mid-swap; the wizard shows the real result instead of "may or may not have applied."

## Backward-compatible
Against pre-v4.17 subgen, `async_config` is `False` → the synchronous path runs exactly as before.

## Tests
`test_post_config_async_polls_to_completion` (202 → poll → 200/ok) and `test_post_config_async_surfaces_failed_switch` (202 → poll → 422 with `reason`/`rolled_back`). Full client/setup/caps suite green (25 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)