### PR TITLE
fix(paths): rebuild libraries on runtime scalar edit + arr_prefix uniqueness (#285)

### DIFF
--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -311,30 +311,46 @@ def load() -> Settings:
         arena_retention_days=int(_env_or("SUBARR_ARENA_RETENTION_DAYS", "30")),
     )
     _apply_persisted_overrides(_s)
+    rebuild_libraries(_s)
+    return _s
 
-    # #134 Phase 1: build the library list. Library 0 = the legacy scalars
-    # (which _apply_persisted_overrides may have adjusted). Extras come from
-    # the override store's "libraries" key. Fail-soft: any config error logs
-    # and degrades to the single default library so boot never breaks.
-    _default_lib = Library(
+
+# Scalars that define the default library (libraries[0]). A runtime edit of any
+# of these must trigger rebuild_libraries() — see #285.
+LIBRARY_DEFINING_FIELDS = ("media_root", "subgen_media_prefix", "arr_path_prefix")
+
+
+def rebuild_libraries(s: Settings) -> None:
+    """(Re)build ``s.libraries`` from the current scalar config + persisted extras.
+
+    Library 0 = the legacy scalars (``media_root`` / ``subgen_media_prefix`` /
+    ``arr_path_prefix``, which a UI/onboarding edit may have changed); extras
+    come from the override store's ``libraries`` key. Fail-soft: any config
+    error logs and degrades to the single default library so this never breaks.
+
+    Called at load AND whenever a LIBRARY_DEFINING_FIELDS scalar changes at
+    runtime (#285) — without the runtime rebuild, editing arr_path_prefix /
+    media_root leaves ``libraries[0]`` stale until restart, silently breaking
+    all library-aware path resolution.
+    """
+    from . import config_store
+
+    default_lib = Library(
         slug="",
         name="default",
-        fs_root=_s.media_root,
-        subgen_prefix=_s.subgen_media_prefix,
-        arr_prefix=_s.arr_path_prefix,
+        fs_root=s.media_root,
+        subgen_prefix=s.subgen_media_prefix,
+        arr_prefix=s.arr_path_prefix,
     )
     try:
-        from . import config_store
-
-        _raw_extras = config_store.load_overrides().get("libraries", [])
-        if not isinstance(_raw_extras, list):
-            _raw_extras = []
-        _libs = build_libraries(_default_lib, _raw_extras)
+        raw_extras = config_store.load_overrides().get("libraries", [])
+        if not isinstance(raw_extras, list):
+            raw_extras = []
+        libs = build_libraries(default_lib, raw_extras)
     except LibraryConfigError:
         log.warning("invalid libraries[] config; using single default library", exc_info=True)
-        _libs = (_default_lib,)
-    object.__setattr__(_s, "libraries", _libs)
-    return _s
+        libs = (default_lib,)
+    object.__setattr__(s, "libraries", libs)
 
 
 # ─── Onboarding clobber guard support ───────────────────────────────

--- a/src/subarr/libraries.py
+++ b/src/subarr/libraries.py
@@ -56,6 +56,18 @@ def build_libraries(default: Library, extras: list[dict]) -> tuple[Library, ...]
     lib0 = replace(default, slug="")
     out: list[Library] = [lib0]
     seen: set[str] = {""}
+
+    # #285 NIT: arr_prefix must be unique across libraries — two identical
+    # prefixes make strip_arr_prefix's longest-match assignment arbitrary (a
+    # real #161 multi-instance footgun). Normalize like the resolver (backslash
+    # + trailing slash) before comparing.
+    def _norm_ap(ap: str) -> str:
+        return ap.replace("\\", "/").rstrip("/")
+
+    seen_arr: set[str] = set()
+    if default.arr_prefix:
+        seen_arr.add(_norm_ap(default.arr_prefix))
+
     for i, raw in enumerate(extras):
         if not isinstance(raw, dict):
             raise LibraryConfigError(f"library[{i}] is not an object: {raw!r}")
@@ -74,6 +86,10 @@ def build_libraries(default: Library, extras: list[dict]) -> tuple[Library, ...]
         if slug in seen:
             raise LibraryConfigError(f"duplicate library slug {slug!r}")
         seen.add(slug)
+        ap_norm = _norm_ap(arr_prefix)
+        if ap_norm in seen_arr:
+            raise LibraryConfigError(f"library {name!r} has a duplicate arr_prefix {arr_prefix!r}")
+        seen_arr.add(ap_norm)
         subgen_prefix = str(raw.get("subgen_prefix", "")).strip() or lib0.subgen_prefix
         out.append(
             Library(

--- a/src/subarr/paths.py
+++ b/src/subarr/paths.py
@@ -7,10 +7,13 @@ boundaries.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path, PurePosixPath
 
 from .config import settings
 from .libraries import Library
+
+log = logging.getLogger(__name__)
 
 
 VIDEO_EXTS = {".mkv", ".mp4", ".avi", ".m4v", ".mov", ".webm", ".ts"}
@@ -146,6 +149,17 @@ def subgen_to_canonical(subgen_path: str) -> str:
         if prefix and (p == prefix or p.startswith(prefix + "/")) and len(prefix) > best_len:
             best, best_len = lib, len(prefix)
     if best is None:
+        if p:
+            # #285 NIT: nothing matched a configured subgen_prefix. We still
+            # return a best-effort canonical, but a completion webhook landing
+            # here silently misses its provenance-ledger entry — surface it so a
+            # misconfigured subgen_media_prefix (esp. multi-library #161) is
+            # diagnosable rather than a silent no-op.
+            log.warning(
+                "subgen_to_canonical: %r matched no configured subgen_prefix; "
+                "completion ledger lookup will miss",
+                subgen_path,
+            )
         return p.strip("/")
     prefix = best.subgen_prefix.rstrip("/")
     rel = "" if p == prefix else p[len(prefix) + 1 :].strip("/")

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -683,7 +683,7 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
     we rely on the user pinning their env vars in compose after the
     wizard finishes (the wizard's final step shows a copy-paste
     snippet of the values they entered)."""
-    from ..config import settings, env_is_set
+    from ..config import LIBRARY_DEFINING_FIELDS, env_is_set, rebuild_libraries, settings
 
     mapping = {
         "media_root": ("media_root", Path),
@@ -700,6 +700,7 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
         "ollama_url": ("ollama_url", str),
         "ollama_model": ("ollama_model", str),
     }
+    libs_dirty = False
     for src_key, (settings_attr, coerce) in mapping.items():
         if src_key in progress and progress[src_key]:
             # Clobber guard: an env-set field is the operator's
@@ -717,8 +718,16 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
                 # FrozenInstanceError. object.__setattr__ bypasses the
                 # freeze for this deliberate runtime patch.
                 object.__setattr__(settings, settings_attr, coerce(progress[src_key]))
+                if settings_attr in LIBRARY_DEFINING_FIELDS:
+                    libs_dirty = True
             except Exception as e:
                 log.warning("settings flush: %s=%r failed: %s", settings_attr, progress[src_key], e)
+
+    # #285: a flushed media_root / arr_path_prefix changes the scalars
+    # libraries[0] is derived from — re-derive the library list so path
+    # resolution doesn't silently run on a stale default library until restart.
+    if libs_dirty:
+        rebuild_libraries(settings)
 
 
 async def _rebuild_runtime_clients(state, reprobe: bool = True) -> None:

--- a/tests/test_config_libraries.py
+++ b/tests/test_config_libraries.py
@@ -53,3 +53,35 @@ def test_bad_libraries_falls_back_to_single(subarr_env, monkeypatch, tmp_path):
 
     importlib.reload(config)
     assert len(config.settings.libraries) == 1  # boot survived; only default
+
+
+def test_rebuild_libraries_picks_up_scalar_change(subarr_env):
+    # #285: rebuild_libraries() re-derives libraries[0] from the CURRENT
+    # scalars, so a runtime edit of arr_path_prefix/media_root isn't stale.
+    from pathlib import Path
+
+    from subarr import config
+
+    s = config.settings
+    object.__setattr__(s, "arr_path_prefix", "/data/Changed/")
+    object.__setattr__(s, "media_root", Path("/mnt/newroot"))
+    config.rebuild_libraries(s)
+    assert s.libraries[0].arr_prefix == "/data/Changed/"
+    assert s.libraries[0].fs_root == Path("/mnt/newroot")
+
+
+def test_rebuild_libraries_preserves_extras(subarr_env, monkeypatch, tmp_path):
+    # The rebuild must keep persisted extra libraries, not just reset to default.
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps({"libraries": [{"name": "Disk 2", "fs_root": "/mnt/d2/Movies", "arr_prefix": "/data/d2/"}]})
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    importlib.reload(__import__("subarr.config", fromlist=["x"]))
+    from subarr import config
+
+    object.__setattr__(config.settings, "arr_path_prefix", "/data/Changed/")
+    config.rebuild_libraries(config.settings)
+    libs = config.settings.libraries
+    assert libs[0].arr_prefix == "/data/Changed/"
+    assert [lib.slug for lib in libs] == ["", "disk-2"]

--- a/tests/test_config_libraries.py
+++ b/tests/test_config_libraries.py
@@ -74,7 +74,9 @@ def test_rebuild_libraries_preserves_extras(subarr_env, monkeypatch, tmp_path):
     # The rebuild must keep persisted extra libraries, not just reset to default.
     store = tmp_path / "ov.json"
     store.write_text(
-        json.dumps({"libraries": [{"name": "Disk 2", "fs_root": "/mnt/d2/Movies", "arr_prefix": "/data/d2/"}]})
+        json.dumps(
+            {"libraries": [{"name": "Disk 2", "fs_root": "/mnt/d2/Movies", "arr_prefix": "/data/d2/"}]}
+        )
     )
     monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
     importlib.reload(__import__("subarr.config", fromlist=["x"]))

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -113,8 +113,11 @@ def test_build_libraries_rejects_duplicate_arr_prefix():
     from subarr.libraries import Library, LibraryConfigError, build_libraries
 
     default = Library(
-        slug="", name="default", fs_root=Path("/media"),
-        subgen_prefix="/media", arr_prefix="/data/Media/",
+        slug="",
+        name="default",
+        fs_root=Path("/media"),
+        subgen_prefix="/media",
+        arr_prefix="/data/Media/",
     )
     # extra arr_prefix == default's, modulo trailing slash -> duplicate
     with pytest.raises(LibraryConfigError, match="duplicate"):
@@ -134,8 +137,13 @@ def test_build_libraries_distinct_arr_prefixes_ok():
     from subarr.libraries import Library, build_libraries
 
     default = Library(
-        slug="", name="default", fs_root=Path("/media"),
-        subgen_prefix="/media", arr_prefix="/data/Media/",
+        slug="",
+        name="default",
+        fs_root=Path("/media"),
+        subgen_prefix="/media",
+        arr_prefix="/data/Media/",
     )
-    libs = build_libraries(default, [{"name": "Movies2", "fs_root": "/mnt/d2", "arr_prefix": "/data/Movies2/"}])
+    libs = build_libraries(
+        default, [{"name": "Movies2", "fs_root": "/mnt/d2", "arr_prefix": "/data/Movies2/"}]
+    )
     assert [lib.slug for lib in libs] == ["", "movies2"]

--- a/tests/test_libraries.py
+++ b/tests/test_libraries.py
@@ -104,3 +104,38 @@ def test_build_libraries_requires_fs_root_and_arr_prefix(tmp_path):
         build_libraries(_default(tmp_path), [{"name": "X", "arr_prefix": "/data/x/"}])
     with pytest.raises(LibraryConfigError, match="arr_prefix"):
         build_libraries(_default(tmp_path), [{"name": "X", "fs_root": "/x"}])
+
+
+def test_build_libraries_rejects_duplicate_arr_prefix():
+    # #285 NIT: two libraries with the same arr_prefix make strip_arr_prefix's
+    # longest-match assignment arbitrary — reject it (trailing-slash/backslash
+    # normalized, matching the resolver).
+    from subarr.libraries import Library, LibraryConfigError, build_libraries
+
+    default = Library(
+        slug="", name="default", fs_root=Path("/media"),
+        subgen_prefix="/media", arr_prefix="/data/Media/",
+    )
+    # extra arr_prefix == default's, modulo trailing slash -> duplicate
+    with pytest.raises(LibraryConfigError, match="duplicate"):
+        build_libraries(default, [{"name": "Dup", "fs_root": "/mnt/d2", "arr_prefix": "/data/Media"}])
+    # two extras colliding with each other
+    with pytest.raises(LibraryConfigError, match="duplicate"):
+        build_libraries(
+            default,
+            [
+                {"name": "A", "fs_root": "/mnt/a", "arr_prefix": "/data/a/"},
+                {"name": "B", "fs_root": "/mnt/b", "arr_prefix": "/data/a"},
+            ],
+        )
+
+
+def test_build_libraries_distinct_arr_prefixes_ok():
+    from subarr.libraries import Library, build_libraries
+
+    default = Library(
+        slug="", name="default", fs_root=Path("/media"),
+        subgen_prefix="/media", arr_prefix="/data/Media/",
+    )
+    libs = build_libraries(default, [{"name": "Movies2", "fs_root": "/mnt/d2", "arr_prefix": "/data/Movies2/"}])
+    assert [lib.slug for lib in libs] == ["", "movies2"]

--- a/tests/test_live_reload.py
+++ b/tests/test_live_reload.py
@@ -147,3 +147,27 @@ async def test_rebuild_runtime_clients_swaps_and_closes():
     assert state.subgen is not old_s
     assert state.ollama is not old_o
     assert old_b.closed and old_s.closed and old_o.closed
+
+
+def test_apply_progress_arr_prefix_rebuilds_libraries(monkeypatch):
+    # #285: the onboarding flush of a library-defining scalar must rebuild
+    # libraries[0] (derived from that scalar), not leave it stale until restart.
+    monkeypatch.delenv("ARR_PATH_PREFIX", raising=False)
+    from subarr.config import settings
+    from subarr.routers.onboarding import _apply_progress_to_settings
+
+    _apply_progress_to_settings({"arr_path_prefix": "/data/NewMedia/"})
+    assert settings.arr_path_prefix == "/data/NewMedia/"
+    assert settings.libraries[0].arr_prefix == "/data/NewMedia/"
+
+
+def test_apply_progress_media_root_rebuilds_libraries(monkeypatch):
+    from pathlib import Path
+
+    monkeypatch.delenv("SUBARR_MEDIA_ROOT", raising=False)
+    from subarr.config import settings
+    from subarr.routers.onboarding import _apply_progress_to_settings
+
+    _apply_progress_to_settings({"media_root": "/mnt/newroot"})
+    assert settings.media_root == Path("/mnt/newroot")
+    assert settings.libraries[0].fs_root == Path("/mnt/newroot")


### PR DESCRIPTION
Path/FS review **area 1/7** — the remaining open items. (`strip_arr_prefix` Fix A, `fs_to_canonical` Fix B, and the `/api/plex/partial-scan` containment were already landed earlier.)

## Library-rebuild footgun — the load-bearing one for #161
`settings.libraries[0]` is derived from the `media_root`/`subgen_media_prefix`/`arr_path_prefix` scalars at load. The onboarding flush (`_apply_progress_to_settings`) writes `media_root`/`arr_path_prefix` via `object.__setattr__` but **never rebuilt `libraries[0]`** → all library-aware path resolution silently ran on a stale default library until a restart, with no warning.

- Extracted the load-time build into **`config.rebuild_libraries(settings)`** — `load()` now calls it (single source of truth).
- **`LIBRARY_DEFINING_FIELDS`** names the three scalars; the onboarding flush calls `rebuild_libraries()` iff one of them actually changed.

## arr_prefix uniqueness (NIT → real #161 footgun)
`build_libraries()` now **rejects two libraries sharing an `arr_prefix`** (normalized for backslash + trailing slash, matching the resolver) — duplicates made `strip_arr_prefix`'s longest-match assignment arbitrary. Fail-soft: a bad override degrades to the single default library.

## subgen_to_canonical silent miss (NIT)
A subgen path matching no configured `subgen_prefix` now **logs a warning** — a completion webhook landing there silently misses its provenance-ledger entry; surfacing it makes a misconfigured `subgen_media_prefix` diagnosable (esp. multi-library).

## Deliberately skipped
The slug-lowercase NIT: library slugs are **immutable identifiers**, so lowercasing an existing explicit slug would silently break references — not worth the footgun for a cosmetic consistency win.

## Tests
`rebuild_libraries` picks up a scalar change + preserves extras; onboarding flush of `arr_path_prefix`/`media_root` rebuilds `libraries[0]`; duplicate `arr_prefix` rejected (default-vs-extra and extra-vs-extra); distinct prefixes OK. **Full suite: 1318 passed, 2 skipped.**

Closes #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)