### PR TITLE
feat(#161): multi-instance Phase 1 — inert plumbing

### DIFF
--- a/docs/superpowers/plans/2026-06-25-161-phase1-inert-plumbing.md
+++ b/docs/superpowers/plans/2026-06-25-161-phase1-inert-plumbing.md
@@ -1,0 +1,992 @@
+# #161 Phase 1 — Inert Plumbing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce the multi-instance data model, per-service client lists, and the `clients_for` resolver as *inert plumbing* — every behaviour byte-identical for single-stack installs, with no UI to add a second instance yet.
+
+**Architecture:** Mirror #134's `libraries.py` pattern exactly. A new pure `instances.py` module models `Instance`; `config.py` seeds instance 0 from the existing env scalars and rebuilds on runtime edits; the arr/Bazarr clients gain optional explicit `(base_url, api_key)` defaulting to the scalars; `IntegrationBundle` becomes per-service dicts keyed by instance id with `bundle.sonarr/.radarr/.bazarr` retained as instance-0 alias properties so the ~52 read sites are untouched. A `clients_for(canonical)` resolver maps a row's `@slug` library to its bound instances, defaulting to instance 0 when bindings are empty.
+
+**Tech Stack:** Python 3.11+, frozen dataclasses, pytest, httpx. Spec: `docs/superpowers/specs/2026-06-25-161-multi-instance-design.md`.
+
+**Back-compat invariant (CI-enforced):** With no `instances` override configured, every binding id is `""`, `clients_for` returns instance 0, and `bundle.sonarr/.radarr/.bazarr` resolve to a client with base_url/headers identical to today. Task 8 locks this in.
+
+---
+
+## File Structure
+
+- **Create:** `src/subarr/instances.py` — pure `Instance` model + `build_instances` (no env/IO/settings import), mirroring `libraries.py`.
+- **Create:** `tests/test_instances.py` — unit tests for `build_instances`.
+- **Modify:** `src/subarr/libraries.py` — add `sonarr_id`/`radarr_id`/`bazarr_id` binding fields to `Library` + passthrough in `build_libraries`.
+- **Modify:** `src/subarr/config.py` — `Settings.instances` field, `rebuild_instances()`, `INSTANCE_DEFINING_FIELDS`, call in `load()`.
+- **Modify:** `src/subarr/integrations/sonarr.py`, `radarr.py`, `bazarr.py` — constructors accept optional explicit `(base_url, api_key)`.
+- **Modify:** `src/subarr/coverage_engine.py` — `IntegrationBundle` per-service dicts + alias properties + `client_for`; module-level `clients_for`.
+- **Modify:** `src/subarr/paths.py` — public `library_for_canonical()` helper.
+- **Modify/Create tests:** `tests/test_config_libraries.py` (binding fields), `tests/test_integration_bundle_multi.py` (new), `tests/test_clients_for.py` (new).
+
+---
+
+## Task 0: Test fixture for a second instance + bound library
+
+The suite reads the import-time `config.settings` singleton; `coverage_engine.py`
+does `from .config import settings` (a by-value binding). So tests can NOT
+`monkeypatch.setattr(config, "settings", ...)` — that wouldn't change what the
+bundle reads. The established pattern (conftest `two_libraries`) is: set
+`SUBARR_CONFIG_STORE`, write the override JSON, then `importlib.reload(...)`.
+`subarr_env` already reloads `config`, `paths`, `coverage_engine`, and the client
+modules, so single-stack tests just use `subarr_env`. Multi-instance tests need a
+fixture that also reloads after writing an `instances` override.
+
+**Files:**
+- Modify: `tests/conftest.py` (add the `anime_stack` fixture after `two_libraries`, ~line 76)
+
+- [ ] **Step 1: Add the fixture (no test-first here — it is test infrastructure)**
+
+```python
+# tests/conftest.py  (add after the two_libraries fixture)
+@pytest.fixture
+def anime_stack(subarr_env, monkeypatch, tmp_path: Path):
+    """A second Sonarr instance 'anime' plus a library 'anime' bound to it.
+    Writes both override keys and reloads config/paths/coverage_engine so
+    settings.instances, settings.libraries, and a freshly built IntegrationBundle
+    all reflect them. Returns the anime library fs_root. (#161 Phase 1)"""
+    import importlib
+    import json
+
+    anime_root = tmp_path / "anime"
+    (anime_root / "Show").mkdir(parents=True)
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps(
+            {
+                "instances": {
+                    "sonarr": [
+                        {"name": "Anime", "url": "http://s2.test:8989", "api_key": "anime-key"}
+                    ]
+                },
+                "libraries": [
+                    {
+                        "slug": "anime",
+                        "name": "Anime",
+                        "fs_root": str(anime_root),
+                        "subgen_prefix": "/media",
+                        "arr_prefix": "/data/anime/",
+                        "sonarr_id": "anime",
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config, coverage_engine, paths
+
+    importlib.reload(config)
+    importlib.reload(paths)
+    importlib.reload(coverage_engine)
+    return anime_root
+```
+
+- [ ] **Step 2: Sanity-check the fixture loads (no assertion logic yet)**
+
+Run: `pytest tests/test_libraries.py -q` (existing suite still imports conftest cleanly)
+Expected: PASS — conftest imports without error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+ruff check tests/conftest.py && ruff format tests/conftest.py
+git add tests/conftest.py
+git commit -m "test(#161): anime_stack fixture (second instance + bound library)"
+```
+
+---
+
+## Task 1: Instance model + `build_instances`
+
+**Files:**
+- Create: `src/subarr/instances.py`
+- Test: `tests/test_instances.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_instances.py
+"""Unit tests for the multi-instance config model (#161 Phase 1)."""
+from __future__ import annotations
+
+import pytest
+
+
+def _defaults():
+    from subarr.instances import Instance
+
+    return [
+        Instance(id="", service="sonarr", name="default", url="http://sonarr:8989", api_key="k1"),
+        Instance(id="", service="radarr", name="default", url="http://radarr:7878", api_key="k2"),
+        Instance(id="", service="bazarr", name="default", url="http://bazarr:6767", api_key="k3"),
+    ]
+
+
+def test_build_instances_single_is_just_defaults():
+    from subarr.instances import build_instances
+
+    insts = build_instances(_defaults(), {})
+    assert len(insts) == 3
+    assert {i.service for i in insts} == {"sonarr", "radarr", "bazarr"}
+    assert all(i.id == "" for i in insts)
+
+
+def test_build_instances_forces_default_id_empty():
+    from subarr.instances import Instance, build_instances
+
+    bad_default = [Instance(id="nonempty", service="sonarr", name="d", url="u", api_key="k")]
+    insts = build_instances(bad_default, {})
+    assert insts[0].id == ""
+
+
+def test_build_instances_adds_extra_with_slug_from_name():
+    from subarr.instances import build_instances
+
+    extras = {"sonarr": [{"name": "Anime", "url": "http://s2:8989", "api_key": "kk"}]}
+    insts = build_instances(_defaults(), extras)
+    sonarrs = [i for i in insts if i.service == "sonarr"]
+    assert len(sonarrs) == 2
+    extra = next(i for i in sonarrs if i.id != "")
+    assert extra.id == "anime"
+    assert extra.name == "Anime"
+    assert extra.url == "http://s2:8989"
+
+
+def test_build_instances_explicit_slug_preferred():
+    from subarr.instances import build_instances
+
+    extras = {"radarr": [{"slug": "fixed", "name": "Anime Films", "url": "u", "api_key": "k"}]}
+    insts = build_instances(_defaults(), extras)
+    assert any(i.id == "fixed" for i in insts if i.service == "radarr")
+
+
+@pytest.mark.parametrize(
+    "extras",
+    [
+        {"sonarr": [{"name": "", "url": "u", "api_key": "k"}]},          # missing name
+        {"sonarr": [{"name": "x", "url": "", "api_key": "k"}]},          # missing url
+        {"sonarr": [{"name": "x", "url": "u", "api_key": ""}]},          # missing api_key
+        {"sonarr": [{"name": "///", "url": "u", "api_key": "k"}]},       # unslugifiable name
+        {"sonarr": [{"slug": "", "name": "x", "url": "u", "api_key": "k"},
+                    {"slug": "", "name": "x", "url": "u2", "api_key": "k2"}]},  # dup ids ("" twice via name x->x)
+    ],
+)
+def test_build_instances_rejects_bad(extras):
+    from subarr.instances import InstanceConfigError, build_instances
+
+    with pytest.raises(InstanceConfigError):
+        build_instances(_defaults(), extras)
+
+
+def test_build_instances_ignores_unknown_service_key():
+    from subarr.instances import build_instances
+
+    insts = build_instances(_defaults(), {"plex": [{"name": "x", "url": "u", "api_key": "k"}]})
+    assert len(insts) == 3  # plex is not a multi-instance service; key ignored
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_instances.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'subarr.instances'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/subarr/instances.py
+"""Multi-instance config model (#161 Phase 1).
+
+An Instance = one Sonarr/Radarr/Bazarr container's credentials (url + api_key).
+Instance identity is a short immutable slug; the default/legacy instance per
+service uses the EMPTY slug (its credentials come from the env scalars), so
+existing single-stack installs need no config and stay byte-identical.
+
+Pure module: no env, no IO, no `settings` import — `build_instances` is a
+deterministic function so it unit-tests in isolation. config.py owns the IO
+seam (reads persisted extras) and the fail-soft load wrapper. Mirrors
+libraries.py by design.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from .libraries import slugify  # reuse the exact kebab-case rule
+
+MULTI_INSTANCE_SERVICES = ("sonarr", "radarr", "bazarr")
+
+
+@dataclass(frozen=True)
+class Instance:
+    id: str        # "" = default/legacy instance (env-backed); else unique kebab slug within its service
+    service: str    # "sonarr" | "radarr" | "bazarr"
+    name: str       # human-facing label
+    url: str
+    api_key: str
+
+
+class InstanceConfigError(ValueError):
+    """Invalid instances config (dup/empty id, missing fields, ...)."""
+
+
+def build_instances(defaults: list[Instance], extras: dict) -> tuple[Instance, ...]:
+    """Assemble the validated instance tuple.
+
+    `defaults` is the per-service instance 0 list (their ids are FORCED to "").
+    `extras` is the persisted override dict: {service: [{name, url, api_key,
+    slug?}, ...]}. Unknown service keys are ignored. Raises InstanceConfigError
+    on any invalid/duplicate extra — config.load() catches this and falls back
+    to defaults only (fail-soft boot).
+    """
+    out: list[Instance] = []
+    seen: dict[str, set[str]] = {svc: {""} for svc in MULTI_INSTANCE_SERVICES}
+
+    for d in defaults:
+        out.append(replace(d, id=""))
+
+    for svc in MULTI_INSTANCE_SERVICES:
+        raw_list = extras.get(svc, []) if isinstance(extras, dict) else []
+        if not isinstance(raw_list, list):
+            raise InstanceConfigError(f"{svc} instances is not a list: {raw_list!r}")
+        for i, raw in enumerate(raw_list):
+            if not isinstance(raw, dict):
+                raise InstanceConfigError(f"{svc}[{i}] is not an object: {raw!r}")
+            name = str(raw.get("name", "")).strip()
+            url = str(raw.get("url", "")).strip()
+            api_key = str(raw.get("api_key", "")).strip()
+            if not name:
+                raise InstanceConfigError(f"{svc}[{i}] missing 'name'")
+            if not url:
+                raise InstanceConfigError(f"{svc} instance {name!r} missing 'url'")
+            if not api_key:
+                raise InstanceConfigError(f"{svc} instance {name!r} missing 'api_key'")
+            iid = str(raw.get("slug", "")).strip() or slugify(name)
+            if not iid:
+                raise InstanceConfigError(f"{svc} instance {name!r} has no usable id")
+            if iid in seen[svc]:
+                raise InstanceConfigError(f"duplicate {svc} instance id {iid!r}")
+            seen[svc].add(iid)
+            out.append(Instance(id=iid, service=svc, name=name, url=url, api_key=api_key))
+
+    return tuple(out)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_instances.py -v`
+Expected: PASS (all cases)
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/instances.py tests/test_instances.py && ruff format src/subarr/instances.py tests/test_instances.py
+git add src/subarr/instances.py tests/test_instances.py
+git commit -m "feat(#161): instances.py multi-instance config model (phase 1)"
+```
+
+---
+
+## Task 2: Library binding fields
+
+**Files:**
+- Modify: `src/subarr/libraries.py:30-37` (the `Library` dataclass) and `src/subarr/libraries.py:94-102` (the `out.append(Library(...))` block)
+- Test: `tests/test_config_libraries.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config_libraries.py  (append)
+def test_library_binding_fields_default_empty(tmp_path):
+    from subarr.libraries import Library
+
+    lib = Library(slug="", name="d", fs_root=tmp_path, subgen_prefix="/media", arr_prefix="/data/")
+    assert lib.sonarr_id == ""
+    assert lib.radarr_id == ""
+    assert lib.bazarr_id == ""
+
+
+def test_build_libraries_passes_through_bindings(tmp_path):
+    from subarr.libraries import Library, build_libraries
+
+    default = Library(slug="", name="default", fs_root=tmp_path / "m", subgen_prefix="/media", arr_prefix="/data/tv/")
+    extras = [{
+        "name": "Anime", "fs_root": str(tmp_path / "anime"), "arr_prefix": "/data/anime/",
+        "sonarr_id": "anime", "bazarr_id": "anime",
+    }]
+    libs = build_libraries(default, extras)
+    anime = next(l for l in libs if l.slug == "anime")
+    assert anime.sonarr_id == "anime"
+    assert anime.radarr_id == ""   # unset stays empty
+    assert anime.bazarr_id == "anime"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_config_libraries.py -k binding -v`
+Expected: FAIL with `TypeError: __init__() got an unexpected keyword argument 'sonarr_id'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/subarr/libraries.py`, add three fields to the `Library` dataclass (after `arr_prefix`):
+
+```python
+@dataclass(frozen=True)
+class Library:
+    slug: str  # "" = default/legacy library 0; else unique kebab slug
+    name: str  # human-facing label
+    fs_root: Path  # subarr's filesystem view of this library's root
+    subgen_prefix: str  # subgen-space absolute prefix (e.g. "/media")
+    arr_prefix: str  # *arr container path prefix (e.g. "/data/Media/")
+    # #161 Phase 1: which instance serves this library. "" = instance 0
+    # (env-backed default). A library uses one media-manager (Sonarr OR Radarr,
+    # by content type) + one Bazarr. Inert in Phase 1 — no UI sets these yet.
+    sonarr_id: str = ""
+    radarr_id: str = ""
+    bazarr_id: str = ""
+```
+
+In `build_libraries`, update the `out.append(Library(...))` call to pass the bindings:
+
+```python
+        out.append(
+            Library(
+                slug=slug,
+                name=name,
+                fs_root=Path(fs_root),
+                subgen_prefix=subgen_prefix,
+                arr_prefix=arr_prefix,
+                sonarr_id=str(raw.get("sonarr_id", "")).strip(),
+                radarr_id=str(raw.get("radarr_id", "")).strip(),
+                bazarr_id=str(raw.get("bazarr_id", "")).strip(),
+            )
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_config_libraries.py tests/test_libraries.py -v`
+Expected: PASS (new binding tests pass; existing library tests still green — fields are defaulted so `replace(default, slug="")` and lib0 construction are unaffected)
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/libraries.py tests/test_config_libraries.py && ruff format src/subarr/libraries.py tests/test_config_libraries.py
+git add src/subarr/libraries.py tests/test_config_libraries.py
+git commit -m "feat(#161): library->instance binding fields (phase 1, inert)"
+```
+
+---
+
+## Task 3: config.py — seed + rebuild instances
+
+**Files:**
+- Modify: `src/subarr/config.py` — add `instances` field to `Settings` (near `libraries`, ~line 235); add `INSTANCE_DEFINING_FIELDS` + `rebuild_instances()` (after `rebuild_libraries`, ~line 354); call `rebuild_instances(_s)` in `load()` (~line 314).
+- Test: `tests/test_config_store.py` (append) — uses the existing override-store fixtures.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config_store.py  (append)
+def test_rebuild_instances_seeds_instance0_from_scalars(subarr_env):
+    from subarr import config
+
+    s = config.settings  # the reloaded singleton (subarr_env seeded it from env)
+    sonarrs = [i for i in s.instances if i.service == "sonarr"]
+    inst0 = next(i for i in sonarrs if i.id == "")
+    assert inst0.url == s.sonarr_url     # "http://sonarr.test:8989" from subarr_env
+    assert inst0.api_key == s.sonarr_api_key
+
+
+def test_rebuild_instances_picks_up_extras(subarr_env, monkeypatch, tmp_path):
+    import importlib
+    import json
+
+    store = tmp_path / "ov.json"
+    store.write_text(json.dumps({
+        "instances": {"sonarr": [{"name": "Anime", "url": "http://s2:8989", "api_key": "kk"}]}
+    }))
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config
+
+    importlib.reload(config)
+    ids = {i.id for i in config.settings.instances if i.service == "sonarr"}
+    assert "" in ids and "anime" in ids
+
+
+def test_rebuild_instances_failsoft_on_bad_config(subarr_env, monkeypatch, tmp_path):
+    import importlib
+    import json
+
+    store = tmp_path / "ov.json"
+    store.write_text(json.dumps({
+        "instances": {"sonarr": [{"name": "x", "url": "u"}]}  # missing api_key
+    }))
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config
+
+    importlib.reload(config)  # must not raise
+    # degrades to defaults-only (the 3 instance-0 entries)
+    assert len([i for i in config.settings.instances if i.service == "sonarr"]) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_config_store.py -k instances -v`
+Expected: FAIL with `AttributeError: 'Settings' object has no attribute 'instances'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the import near the top of `config.py` (alongside the libraries import at line 14):
+
+```python
+from .instances import Instance, InstanceConfigError, build_instances
+```
+
+Add the field to `Settings` (immediately after the `libraries` field at line 235):
+
+```python
+    # #161 Phase 1: validated instance list (flat tuple; each Instance carries
+    # its .service). Per-service instance 0 (id "") mirrors the legacy
+    # sonarr_url/api_key/... scalars for back-compat; extras come from the
+    # override store's "instances" key. Built in load() after scalars+overrides.
+    instances: tuple[Instance, ...] = ()
+```
+
+Add the call in `load()` immediately after `rebuild_libraries(_s)` (line 314):
+
+```python
+    rebuild_libraries(_s)
+    rebuild_instances(_s)
+    return _s
+```
+
+Add `INSTANCE_DEFINING_FIELDS` + `rebuild_instances` after `rebuild_libraries` (after line 353):
+
+```python
+# Scalars that define each service's instance 0. A runtime edit of any of these
+# must trigger rebuild_instances() so credential changes take effect live (#161,
+# mirrors LIBRARY_DEFINING_FIELDS / #285).
+INSTANCE_DEFINING_FIELDS = (
+    "sonarr_url", "sonarr_api_key",
+    "radarr_url", "radarr_api_key",
+    "bazarr_url", "bazarr_api_key",
+)
+
+
+def rebuild_instances(s: Settings) -> None:
+    """(Re)build ``s.instances`` from the current scalar config + persisted
+    extras. Instance 0 per service = the legacy scalars; extras come from the
+    override store's ``instances`` key. Fail-soft: any config error logs and
+    degrades to the per-service defaults so this never breaks boot."""
+    from . import config_store
+
+    defaults = [
+        Instance(id="", service="sonarr", name="default", url=s.sonarr_url, api_key=s.sonarr_api_key),
+        Instance(id="", service="radarr", name="default", url=s.radarr_url, api_key=s.radarr_api_key),
+        Instance(id="", service="bazarr", name="default", url=s.bazarr_url, api_key=s.bazarr_api_key),
+    ]
+    try:
+        raw_extras = config_store.load_overrides().get("instances", {})
+        if not isinstance(raw_extras, dict):
+            raw_extras = {}
+        insts = build_instances(defaults, raw_extras)
+    except InstanceConfigError:
+        log.warning("invalid instances config; using per-service defaults", exc_info=True)
+        insts = tuple(defaults)
+    object.__setattr__(s, "instances", insts)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_config_store.py -k instances -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/config.py tests/test_config_store.py && ruff format src/subarr/config.py tests/test_config_store.py
+git add src/subarr/config.py tests/test_config_store.py
+git commit -m "feat(#161): seed + rebuild instances in config (phase 1)"
+```
+
+---
+
+## Task 4: Arr/Bazarr clients accept explicit credentials
+
+**Files:**
+- Modify: `src/subarr/integrations/sonarr.py:20-24`, `src/subarr/integrations/radarr.py:17-21`, `src/subarr/integrations/bazarr.py:25-28`
+- Test: `tests/test_integration_credentials.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_integration_credentials.py  (append)
+def test_sonarr_client_explicit_credentials():
+    from subarr.integrations.sonarr import SonarrClient
+
+    c = SonarrClient(base_url="http://s2:8989", api_key="explicitkey")
+    assert c._base_url == "http://s2:8989"
+    assert c._client.headers["X-Api-Key"] == "explicitkey"
+
+
+def test_sonarr_client_defaults_to_settings(subarr_env):
+    # Settings is a frozen dataclass — do NOT mutate it. subarr_env seeds the
+    # scalars from env; assert the no-arg client mirrors them (today's behaviour).
+    from subarr import config
+    from subarr.integrations.sonarr import SonarrClient
+
+    c = SonarrClient()  # no args = today's behaviour
+    assert c._base_url == config.settings.sonarr_url        # "http://sonarr.test:8989"
+    assert c._client.headers["X-Api-Key"] == config.settings.sonarr_api_key
+
+
+def test_bazarr_client_explicit_uses_caps_header():
+    from subarr.integrations.bazarr import BazarrClient
+
+    c = BazarrClient(base_url="http://b2:6767", api_key="bk")
+    # Bazarr header is X-API-KEY (caps), NOT X-Api-Key
+    assert c._client.headers["X-API-KEY"] == "bk"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_integration_credentials.py -k "explicit or defaults_to_settings" -v`
+Expected: FAIL with `TypeError: __init__() got an unexpected keyword argument 'base_url'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/subarr/integrations/sonarr.py` — replace the constructor:
+
+```python
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        url = settings.sonarr_url if base_url is None else base_url
+        key = settings.sonarr_api_key if api_key is None else api_key
+        super().__init__(
+            base_url=url if key else "",
+            headers={"X-Api-Key": key} if key else None,
+        )
+```
+
+`src/subarr/integrations/radarr.py` — replace the constructor:
+
+```python
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        url = settings.radarr_url if base_url is None else base_url
+        key = settings.radarr_api_key if api_key is None else api_key
+        super().__init__(
+            base_url=url if key else "",
+            headers={"X-Api-Key": key} if key else None,
+        )
+```
+
+`src/subarr/integrations/bazarr.py` — replace the constructor (note the CAPS header):
+
+```python
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        url = settings.bazarr_url if base_url is None else base_url
+        key = settings.bazarr_api_key if api_key is None else api_key
+        super().__init__(
+            base_url=url if key else "",
+            headers={"X-API-KEY": key} if key else None,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_integration_credentials.py -v`
+Expected: PASS (new tests + all existing credential tests still green — default-None path is byte-identical to the old `settings.*` reads)
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/integrations/sonarr.py src/subarr/integrations/radarr.py src/subarr/integrations/bazarr.py tests/test_integration_credentials.py && ruff format src/subarr/integrations/sonarr.py src/subarr/integrations/radarr.py src/subarr/integrations/bazarr.py tests/test_integration_credentials.py
+git add src/subarr/integrations/sonarr.py src/subarr/integrations/radarr.py src/subarr/integrations/bazarr.py tests/test_integration_credentials.py
+git commit -m "feat(#161): arr/bazarr clients accept explicit credentials (phase 1)"
+```
+
+---
+
+## Task 5: IntegrationBundle per-service dicts + instance-0 alias
+
+**Files:**
+- Modify: `src/subarr/coverage_engine.py:227-257` (the `IntegrationBundle` class)
+- Test: `tests/test_integration_bundle_multi.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_integration_bundle_multi.py
+"""IntegrationBundle multi-instance dicts + instance-0 alias (#161 Phase 1)."""
+from __future__ import annotations
+
+
+def test_bundle_alias_resolves_instance0(subarr_env):
+    # single-stack: settings.instances has only the 3 instance-0 defaults
+    from subarr.coverage_engine import IntegrationBundle
+
+    bundle = IntegrationBundle()
+    assert bundle.sonarr is bundle.client_for("sonarr", "")
+    assert bundle.radarr is bundle.client_for("radarr", "")
+    assert bundle.bazarr is bundle.client_for("bazarr", "")
+
+
+def test_bundle_client_for_unknown_id_falls_back_to_instance0(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle
+
+    bundle = IntegrationBundle()
+    # an unbound/empty id and an unknown id both resolve to instance 0
+    assert bundle.client_for("sonarr", "") is bundle.sonarr
+    assert bundle.client_for("sonarr", "doesnotexist") is bundle.sonarr
+
+
+def test_bundle_builds_extra_instance(anime_stack):
+    # anime_stack reloaded coverage_engine after writing the override store
+    from subarr.coverage_engine import IntegrationBundle
+
+    bundle = IntegrationBundle()
+    anime = bundle.client_for("sonarr", "anime")
+    assert anime is not bundle.sonarr
+    assert anime._base_url == "http://s2.test:8989"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_integration_bundle_multi.py -v`
+Expected: FAIL with `AttributeError: 'IntegrationBundle' object has no attribute 'client_for'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the `IntegrationBundle` class body (`coverage_engine.py:227-257`):
+
+```python
+class IntegrationBundle:
+    """Holds the integration clients + close-all helper. App lifespan owns one
+    instance. #161: the arr/bazarr trio is keyed per instance id; tautulli/plex
+    stay singleton. `bundle.sonarr/.radarr/.bazarr` alias instance 0 so the many
+    existing read sites keep working unchanged."""
+
+    _ARR_SERVICES = ("sonarr", "radarr", "bazarr")
+
+    def __init__(self):
+        # SonarrClient/RadarrClient/BazarrClient are already imported at module
+        # scope (coverage_engine.py:30-32) — reuse them, do not re-import locally.
+        ctors = {"sonarr": SonarrClient, "radarr": RadarrClient, "bazarr": BazarrClient}
+        self._clients: dict[str, dict[str, object]] = {svc: {} for svc in self._ARR_SERVICES}
+        for inst in settings.instances:
+            if inst.service not in self._clients:
+                continue
+            self._clients[inst.service][inst.id] = ctors[inst.service](
+                base_url=inst.url, api_key=inst.api_key
+            )
+        # Defensive: guarantee an instance 0 per service even if settings.instances
+        # was never rebuilt (keeps the alias properties total). Uses env defaults.
+        # Guard with `in` (NOT setdefault) — setdefault would eagerly construct a
+        # throwaway client every time, leaking an unclosed httpx.AsyncClient.
+        for svc in self._ARR_SERVICES:
+            if "" not in self._clients[svc]:
+                self._clients[svc][""] = ctors[svc]()
+
+        self.tautulli = TautulliClient()
+        from .integrations.plex import PlexClient
+
+        self.plex = PlexClient(
+            base_url=settings.plex_url,
+            token=settings.plex_token,
+            default_section=settings.plex_section,
+            path_prefix=settings.plex_path_prefix,
+            media_root=str(settings.media_root),
+        )
+
+    def client_for(self, service: str, instance_id: str | None):
+        """Resolve a client by (service, instance id). Empty/unknown id falls
+        back to instance 0 — the single-stack invariant."""
+        pool = self._clients[service]
+        return pool.get(instance_id or "") or pool[""]
+
+    @property
+    def sonarr(self):
+        return self._clients["sonarr"][""]
+
+    @property
+    def radarr(self):
+        return self._clients["radarr"][""]
+
+    @property
+    def bazarr(self):
+        return self._clients["bazarr"][""]
+
+    async def aclose(self) -> None:
+        closers = [c.aclose() for pool in self._clients.values() for c in pool.values()]
+        closers.append(self.tautulli.aclose())
+        closers.append(self.plex.aclose())
+        await asyncio.gather(*closers, return_exceptions=True)
+```
+
+Note: the module-level `TautulliClient` import (coverage_engine.py:33) is still used
+(singleton). The three arr/bazarr client imports stay used too (the `ctors` map
+references them). No import removals expected — but run `ruff check` in Step 5 and
+act on anything it reports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_integration_bundle_multi.py tests/test_integration_versions.py tests/test_integrations_health_probe.py -v`
+Expected: PASS (new bundle tests + existing bundle consumers still green)
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/coverage_engine.py tests/test_integration_bundle_multi.py && ruff format src/subarr/coverage_engine.py tests/test_integration_bundle_multi.py
+git add src/subarr/coverage_engine.py tests/test_integration_bundle_multi.py
+git commit -m "feat(#161): IntegrationBundle per-service dicts + instance-0 alias (phase 1)"
+```
+
+---
+
+## Task 6: `library_for_canonical` public helper
+
+**Files:**
+- Modify: `src/subarr/paths.py` (add the helper after `_library_by_slug`, ~line 56)
+- Test: `tests/test_paths.py` if it exists, else `tests/test_clients_for.py` covers it in Task 7. Create `tests/test_paths_library_for.py`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_paths_library_for.py
+"""library_for_canonical resolves a canonical's @slug to its Library (#161)."""
+from __future__ import annotations
+
+
+def test_library_for_canonical_default_library(subarr_env):
+    from subarr.paths import library_for_canonical
+
+    lib = library_for_canonical("Show/S01E01.mkv")  # no @slug head = library 0
+    assert lib.slug == ""
+
+
+def test_library_for_canonical_unknown_slug_failsoft_to_library0(subarr_env):
+    from subarr.paths import library_for_canonical
+
+    # unknown @slug must not raise — Phase 1 resolver is fail-soft to library 0
+    lib = library_for_canonical("@nope/x")
+    assert lib.slug == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_paths_library_for.py -v`
+Expected: FAIL with `ImportError: cannot import name 'library_for_canonical'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/subarr/paths.py` after `_library_by_slug` (~line 56):
+
+```python
+def library_for_canonical(canonical: str) -> Library:
+    """Public, fail-soft resolver: a canonical's '@<slug>/' head -> its Library.
+    Unknown/empty slug returns library 0 (the default) rather than raising —
+    callers (clients_for, #161) must degrade to instance 0, never crash a row.
+    """
+    slug, _rel = _split_canonical(canonical)
+    try:
+        return _library_by_slug(slug)
+    except PathOutsideRootError:
+        return _library_by_slug("")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_paths_library_for.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/paths.py tests/test_paths_library_for.py && ruff format src/subarr/paths.py tests/test_paths_library_for.py
+git add src/subarr/paths.py tests/test_paths_library_for.py
+git commit -m "feat(#161): library_for_canonical fail-soft helper (phase 1)"
+```
+
+---
+
+## Task 7: `clients_for` resolver
+
+**Files:**
+- Modify: `src/subarr/coverage_engine.py` (add module-level `clients_for` + the `ResolvedClients` namedtuple after `IntegrationBundle`)
+- Test: `tests/test_clients_for.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_clients_for.py
+"""clients_for maps a row's @slug library to its bound instance clients (#161)."""
+from __future__ import annotations
+
+
+def test_clients_for_empty_bindings_resolve_instance0(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle, clients_for
+
+    bundle = IntegrationBundle()
+    rc = clients_for(bundle, "Show/S01E01.mkv")  # library 0, all bindings ""
+    assert rc.sonarr is bundle.sonarr
+    assert rc.radarr is bundle.radarr
+    assert rc.bazarr is bundle.bazarr
+
+
+def test_clients_for_bound_library_routes_to_instance(anime_stack):
+    # anime_stack: library 'anime' bound sonarr_id='anime'; bazarr_id unset
+    from subarr.coverage_engine import IntegrationBundle, clients_for
+
+    bundle = IntegrationBundle()
+    rc = clients_for(bundle, "@anime/Naruto/S01E01.mkv")
+    assert rc.sonarr is bundle.client_for("sonarr", "anime")
+    assert rc.bazarr is bundle.bazarr  # bazarr_id unset -> instance 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_clients_for.py -v`
+Expected: FAIL with `ImportError: cannot import name 'clients_for'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the existing paths import at `coverage_engine.py:28` (do not add a second
+`from .paths import` line):
+
+```python
+from .paths import UNSUPPORTED_EXTS, canonical_to_fs, library_for_canonical, strip_arr_prefix
+```
+
+Add after the `IntegrationBundle` class:
+
+```python
+from typing import NamedTuple
+
+
+class ResolvedClients(NamedTuple):
+    sonarr: object
+    radarr: object
+    bazarr: object
+
+
+def clients_for(bundle: "IntegrationBundle", canonical: str) -> ResolvedClients:
+    """Resolve the (sonarr, radarr, bazarr) clients that own a row's library.
+    The row's '@slug' head -> Library -> bound instance ids -> clients. Empty
+    bindings resolve to instance 0, so single-stack is byte-identical. The
+    caller picks sonarr vs radarr by content type (#161 Phase 2+ wiring)."""
+    lib = library_for_canonical(canonical)
+    return ResolvedClients(
+        sonarr=bundle.client_for("sonarr", lib.sonarr_id),
+        radarr=bundle.client_for("radarr", lib.radarr_id),
+        bazarr=bundle.client_for("bazarr", lib.bazarr_id),
+    )
+```
+
+(If `ruff` prefers the `NamedTuple`/`typing` import at the top of the file rather than inline, move it there — match the file's existing import grouping.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_clients_for.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check src/subarr/coverage_engine.py tests/test_clients_for.py && ruff format src/subarr/coverage_engine.py tests/test_clients_for.py
+git add src/subarr/coverage_engine.py tests/test_clients_for.py
+git commit -m "feat(#161): clients_for resolver (phase 1, inert)"
+```
+
+---
+
+## Task 8: Back-compat characterization test (CI-enforced invariant)
+
+**Files:**
+- Test: `tests/test_multi_instance_backcompat.py` (create) — the byte-identical single-stack guard.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_multi_instance_backcompat.py
+"""#161 single-stack byte-identical invariant: with no `instances`/`libraries`
+overrides, the multi-instance plumbing must behave exactly like instance 0.
+This is the CI guard that single-stack installs (the majority) are unaffected.
+"""
+from __future__ import annotations
+
+
+def test_single_stack_bundle_matches_direct_construction(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle
+    from subarr.integrations.sonarr import SonarrClient
+
+    bundle = IntegrationBundle()
+    direct = SonarrClient()  # the pre-#161 construction path
+
+    assert bundle.sonarr._base_url == direct._base_url
+    assert dict(bundle.sonarr._client.headers).get("X-Api-Key") == \
+        dict(direct._client.headers).get("X-Api-Key")
+
+
+def test_single_stack_clients_for_is_always_instance0(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle, clients_for
+
+    bundle = IntegrationBundle()
+    for canonical in ["", "Show/S01E01.mkv", "@unknownlib/x", "Movie (2020)/m.mkv"]:
+        rc = clients_for(bundle, canonical)
+        assert rc.sonarr is bundle.sonarr
+        assert rc.radarr is bundle.radarr
+        assert rc.bazarr is bundle.bazarr
+
+
+def test_single_stack_has_exactly_one_instance_per_service(subarr_env):
+    from subarr import config
+
+    for svc in ("sonarr", "radarr", "bazarr"):
+        assert len([i for i in config.settings.instances if i.service == svc]) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails (then passes)**
+
+Run: `pytest tests/test_multi_instance_backcompat.py -v`
+Expected: PASS immediately if Tasks 1-7 are complete (this task adds no new production code — it *locks in* the invariant). If any assertion fails, a prior task regressed single-stack behaviour — fix the offending task before continuing.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `pytest -q`
+Expected: PASS — full suite green (was 1318 passing at handoff; expect 1318 + the new Phase 1 tests). Investigate any failure; do not proceed with reds.
+
+- [ ] **Step 4: Run all three lint gates**
+
+Run: `ruff check src tests && ruff format --check src tests && bandit -q -r src`
+Expected: all clean (per the handoff: local-verify all three gates before pushing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_multi_instance_backcompat.py
+git commit -m "test(#161): single-stack byte-identical back-compat guard (phase 1)"
+```
+
+---
+
+## Done criteria for Phase 1
+
+- `instances.py` model + `build_instances` (Task 1).
+- Library binding fields, inert (Task 2).
+- `Settings.instances` seeded + rebuilt, fail-soft (Task 3).
+- Arr/Bazarr clients take explicit creds, default to scalars (Task 4).
+- `IntegrationBundle` per-service dicts + instance-0 alias + `client_for` (Task 5).
+- `library_for_canonical` fail-soft helper (Task 6).
+- `clients_for` resolver, inert (Task 7).
+- Back-compat characterization guard green; full suite + all three lint gates green (Task 8).
+- **No UI to add a second instance** (Phase 4) and **no call site rewired to `clients_for`** (Phases 2-3) — Phase 1 ships inert.
+
+## Out of scope (later phases — do NOT build here)
+
+- Bazarr wanted-list merge over N instances + instance tagging (Phase 2).
+- Dedup re-keying to `(instance_id, id)` (Phase 2).
+- Wiring the ~14 writeback sites + `_bazarr_sync_task_id` per-instance cache to `clients_for` (Phase 3).
+- Settings ▸ Instances / Libraries binding UI, root-folder auto-enumerate, resolved-topology (Phase 4).
+- Wizard "add another stack" branch (Phase 5).

--- a/docs/superpowers/specs/2026-06-25-161-multi-instance-design.md
+++ b/docs/superpowers/specs/2026-06-25-161-multi-instance-design.md
@@ -1,0 +1,255 @@
+# #161 — Multiple Sonarr/Radarr/Bazarr instances — Design
+
+**Issue:** [coaxk/subarr#161](https://github.com/coaxk/subarr/issues/161) (author: @KRDucky)
+**Date:** 2026-06-25
+**Status:** Design approved; ready for implementation planning.
+**Supersedes:** the 2026-06-11 recon comment on #161 (this design replaces its "instance-tag every coverage row + row migration" approach with a slug-provenance approach — see §3).
+
+---
+
+## 1. Problem
+
+subarr holds exactly one Sonarr, one Radarr, and one Bazarr client. Users who run
+**separate "normal" and "anime" stacks** (one Sonarr/Radarr/Bazarr each) cannot
+point subarr at both. KRDucky's setup is the canonical case: paired stacks with
+trash-guides mounts (`/data/{tv,anime,movies,animefilms}`). subarr is the *only*
+component in that topology that naturally sits above the split arr trios, so
+aggregating them is squarely its job.
+
+## 2. Scope boundary — what actually multiplies
+
+subarr integrates **seven** services (`coverage_engine.py:227` `IntegrationBundle`).
+Only the media-manager trio splits per-stack:
+
+- **Multiplies (the #161 work):** Sonarr, Radarr, Bazarr → per-stack lists.
+- **Stays singleton (untouched):** Plex (one server, N library *sections*),
+  Tautulli (1:1 with Plex), subgen (one transcoder), ollama (one analysis backend).
+
+Nobody runs two Plex servers for an anime split — one Plex holds an Anime library
+and a TV library. **Multi-Plex / multi-subgen is explicitly out of scope** (a
+separate future epic if real demand ever appears).
+
+## 3. Core insight — the library is the provenance carrier
+
+#134 made every coverage and queue row keyed by a canonical path that already
+embeds its library via the `@<slug>/` head (`paths.py:_split_canonical`,
+`fs_to_canonical`; library 0 = empty slug). **So instances do not need a parallel
+per-row tag.** A row's `@anime/…` head → library *anime* → its bound instances.
+
+This is the central simplification over the 2026-06-11 recon, which proposed adding
+`instance` columns to coverage rows (a real DB migration on every install). We don't:
+**there is no row/schema migration** — existing rows are byte-for-byte untouched.
+
+### Three layers
+
+1. **Instances** — flat per-service credential lists (`sonarr[]`, `radarr[]`,
+   `bazarr[]`). Instance 0 = today's env-backed scalars.
+2. **Libraries** (#134, already exist) — `slug · fs_root · subgen_prefix · arr_prefix`.
+   Instances bind *here*.
+3. **Rows** — canonical key `@slug/path` already carries the library, hence the
+   binding, hence the owning instances.
+
+## 4. Data model
+
+### 4.1 Instance model (new `instances.py`)
+
+Pure, unit-testable module mirroring `libraries.py` (no env, no IO, no `settings`
+import — `config.py` owns the IO seam and fail-soft load wrapper):
+
+```python
+@dataclass(frozen=True)
+class Instance:
+    id: str        # immutable slug; "" = instance 0 (env-backed legacy)
+    service: str    # "sonarr" | "radarr" | "bazarr"
+    name: str       # human label, e.g. "anime"
+    url: str
+    api_key: str
+```
+
+- `build_instances(default, extras)` validates non-empty unique ids; `""` reserved
+  for instance 0. Direct copy of `build_libraries`'s shape including **fail-soft
+  fallback to single-instance** on bad config.
+- Stored in the override store (the same store `libraries[]` extras use) under one
+  `instances` key → `{sonarr:[...], radarr:[...], bazarr:[...]}`.
+- Instance 0 of each list is **synthesised from the existing scalars**
+  (`sonarr_url`/`sonarr_api_key`/… at `config.py:126-131`) so an existing install
+  boots with `[instance0]` and is byte-identical.
+
+### 4.2 Library binding fields
+
+`Library` (`libraries.py`) gains: `sonarr_id`, `radarr_id`, `bazarr_id`.
+
+- A library uses exactly **one** media-manager (Sonarr *or* Radarr, by content
+  type) plus **one** Bazarr.
+- Empty/unset = "resolve against instance 0" → preserves single-instance back-compat.
+- Binding is **auto-derived** from each instance's `root_folders()` on add, stored,
+  and **overridable** (the agreed hybrid).
+
+### 4.3 Library granularity rule (important)
+
+A subarr library keys on a **path** = an **arr root folder**, *not* a mount. The
+model is mount-agnostic (`fs_to_canonical` longest-prefix match), so both topologies
+work:
+
+- Separate mounts (`/mnt/tv`, `/mnt/anime`).
+- **Single mount + content subfolders** (trash-guides: one `/data` mount,
+  `/data/media/{tv,anime}` subfolders — the *recommended* layout, enabling
+  hardlinks/atomic-moves). This is the common case.
+
+**Rule:** libraries are defined at **root-folder granularity, one library per arr
+root folder** — not at mount granularity. A coarse mount-level library that
+*contained* root folders from two different arrs would span two instances and break
+the 1-arr-per-library binding. We don't rely on users getting this right:
+**#134 Phase 0 already shipped `/onboarding/root-folders`** (`onboarding.py:368`),
+documented as "the ground truth Phase 1's multi-library auto-detect builds on." The
+auto-flow enumerates every root folder across all configured arrs and proposes one
+pre-bound library each.
+
+**Cardinality:** instance → library = **1:N** (a Sonarr with `/data/tv` and
+`/data/tv-4k` = two libraries); library → arr = **1:1** (by construction).
+
+### 4.4 Migration
+
+No SQL/row migration. The only migration is **config-shape** seeding at load:
+`rebuild_instances()` paralleling #285's `rebuild_libraries()` — idempotent,
+fail-soft. An `INSTANCE_DEFINING_FIELDS` sibling to `LIBRARY_DEFINING_FIELDS`
+(`config.py:320`) makes runtime credential edits rebuild the instance list live
+(no restart).
+
+## 5. Routing — the four risky seams
+
+One resolution helper underpins everything; the slug is already on every row/path:
+
+```python
+def clients_for(canonical) -> (media_mgr_client, bazarr_client):
+    lib = library_for_canonical(canonical)            # paths.py already splits @slug
+    arr = instance_client(lib.sonarr_id or lib.radarr_id)
+    baz = instance_client(lib.bazarr_id)
+    return arr, baz
+```
+
+`IntegrationBundle` changes from one client per arr service to **per-service dicts
+keyed by instance id**, with `bundle.sonarr` / `.radarr` / `.bazarr` retained as
+**instance-0 alias properties** (`self.sonarr_instances[""]`). This keeps the ~52
+read sites compiling unchanged; only owner-routing sites switch to `clients_for`.
+
+| # | Seam | Location | Fix |
+|---|------|----------|-----|
+| 1 | Bazarr wanted-list merge (riskiest) | `coverage_engine.py:~1281` | Iterate `bazarr` instances; **tag each item by the instance it was queried from** before path→canonical. Unique `arr_prefix` (#285) makes the resolution deterministic. "Episode 101 in both Sonarrs" collision dies — we key by `@slug/path`, never raw arr id. |
+| 2 | Writebacks route by owner (safety-critical) | `completion_watcher.py:~297`, `blacklist.py`, `audio_lang.py:~154` | Fire at `clients_for(row.canonical)` instead of the global client. Wrong-instance metadata corruption becomes structurally impossible. |
+| 3 | `_bazarr_sync_task_id` process-global | `audio_lang.py:189` | Becomes a **dict keyed by bazarr instance id**; each Bazarr caches its own task id. |
+| 4 | Dedup sets collide | `seen_ep_ids`, `radarr_by_title` | Re-key from `id` to `(instance_id, id)`. |
+
+## 6. Single-stack back-compat & safety (first-class concern)
+
+Single-stack is the majority. "No breakage for single-stack" is a **CI-enforced
+invariant**, not a hope. Three structural mechanisms:
+
+1. **Instance-0 alias** keeps all 66 client-consumer sites untouched; only the ~14
+   writebacks + the coverage merge loop switch to `clients_for`. We are *not*
+   rewriting 66 sites in lockstep (the trap).
+2. **No row/schema migration** — `@slug` already carries provenance; existing rows
+   untouched. The only migration is idempotent, fail-soft config seeding.
+3. **Absent-config = today's exact path** — no `instances` key → seed instance 0
+   from scalars → every binding id empty → `clients_for` returns instance 0 → dedup
+   keys `("", id)` ≡ `id` → coverage loops over one Bazarr. **Identical output and
+   writeback targets.**
+
+The one real (non-behavioural) risk is that the refactor *touches* load-bearing
+code (`IntegrationBundle`, coverage merge). Mitigation — prove, don't assert:
+
+- **Characterization tests at a byte-identical bar** (same bar #134 held): capture
+  current single-instance coverage-merge output / writeback routing / dedup *before*
+  the refactor; assert identical *after*. CI gate.
+- **Phase 1 ships inert** — plumbing proven byte-identical before any multi-instance
+  config is reachable.
+- **Live dogfood on :9923** with crash telemetry (#157 P2) as the rollout net.
+
+## 7. UI
+
+Three surfaces; the add/edit/test widget is **built once** and mounted in both
+Settings and the wizard.
+
+1. **Settings ▸ Instances** — per-service lists. Each row: name · url · health, with
+   Test / Edit / Remove. Instance 0 = env-backed default, editable but **not
+   removable**. On add: url + api-key + name → live **Test** → on save, root folders
+   auto-enumerate and propose/refresh libraries.
+2. **Settings ▸ Libraries — resolved-topology table** — per library: bound arr +
+   Bazarr (auto-filled, overridable dropdowns) and a **derived, read-only Plex
+   section** column. Plex section is *not* stored — it is matched live by
+   `integrations/plex.py:_section_for_path`; a **no-match ⚠** surfaces a mis-mounted
+   library at config time. (Decided: display the Plex link, don't store it.)
+3. **Wizard — optional skippable branch** (option C). First-instance flow unchanged;
+   after the first stack tests green, a collapsed *"Run separate stacks? + Add
+   another | Skip ›"* appears. Skip = identical to single-instance onboarding.
+
+Rejected: by-stack grouping cards — reintroduces the stack-symmetry assumption
+(breaks for e.g. 3 Sonarrs behind 1 Bazarr). Flat per-service lists chosen throughout;
+the stack *grouping* remains visible where it matters (the resolved-topology table,
+grouped by library).
+
+## 8. Phasing
+
+One reviewed PR per phase; **byte-identical for single-stack through Phase 3**; each
+independently shippable. The ordering enforces one safety invariant: **the UI that
+lets a user create a second instance (Phase 4) lands only after both read (P2) and
+write (P3) routing exist** — so it is never possible to add a second Bazarr and have
+subs silently upload to the wrong one.
+
+- **Phase 1 — Inert plumbing.** `instances.py`; `rebuild_instances()`;
+  `IntegrationBundle` per-service dicts + instance-0 alias; `clients_for` +
+  empty-defaulting binding fields. Characterization tests (CI gate). No second-instance
+  UI. Ships inert.
+- **Phase 2 — Read path.** Multi-Bazarr wanted-list merge with tag-by-queried-instance
+  (seam 1); dedup re-key (seam 4). Reads route by owner. Tested by hand-seeding a
+  second instance. Ships inert.
+- **Phase 3 — Write path (safety-critical).** `clients_for` at all writeback sites
+  (seam 2); per-Bazarr task-id cache (seam 3). **Full Tier-2 review** (auth/concurrency
+  + failure-mode lens, ultra at milestone). After this, multi-instance is safe to expose.
+- **Phase 4 — Expose it.** Settings ▸ Instances + Libraries binding UI +
+  resolved-topology + root-folder auto-enumerate. First point a second instance is
+  user-creatable. **Live dogfood on a dedicated anime-stack test environment + KRDucky
+  beta.**
+- **Phase 5 — Wizard branch + docs + announce.** Option C's skippable branch (reusing
+  the Phase 4 component) + docs + the anime-hook release note. Lowest risk, last.
+
+## 9. Testing strategy
+
+- **Characterization (Phase 1):** single-instance byte-identical bar on coverage merge,
+  writeback routing, dedup — CI gate.
+- **Unit:** `build_instances` (dup/empty id, fail-soft), `clients_for` resolution
+  (empty binding → instance 0; explicit binding → correct client), seam-1 instance
+  tagging, seam-4 `(instance_id, id)` keying.
+- **Endpoint/persistence:** instance add/test/remove, override-store round-trip,
+  `rebuild_instances` runtime reactivity.
+- **Live (Phase 4-5):** a dedicated **anime-shaped topology** test environment (2×
+  Sonarr/Radarr/Bazarr) on the dev box, plus **KRDucky as beta partner** validating on
+  his real stack — the strongest net for the safety-critical write path.
+
+## 10. Strategic context (non-architectural)
+
+Multi-instance is the **price of entry for the anime userbase** — a large segment
+subarr currently locks out entirely. Separate anime stacks are near-universal there
+(absolute numbering, alternate-title matching, AnimeBytes/Nyaa indexers force a
+dedicated Sonarr). This:
+
+- **Validates the flat-lists decision** — anime users have the least symmetric setups
+  (sometimes 2-3 anime Sonarrs); by-stack grouping would have broken for them.
+- **Has ready-made demo hooks** — subarr's forced-sub handling (#317) and audio-language
+  verification land hardest on the JP-audio + EN-sub + signs/songs anime workflow.
+- **Flips the launch's deliberate anti-anime framing** (see launch-prep notes) — not by
+  pivoting to anime, but by finally not excluding them.
+
+This changes no architecture (Section 5 already serves it); it raises the stakes on
+getting write-path routing right and adds the anime test env + KRDucky beta to Phase 4.
+
+## 11. Open assumptions (flag if wrong)
+
+- **One media-manager arr per library** — holds by construction given root-folder
+  granularity (§4.3). Would only break if a single library were deliberately defined
+  to span two arrs' root folders; the auto-enumerate flow steers away from this.
+- **Plex/Tautulli/subgen/ollama remain singleton** for the foreseeable future.
+- **Bazarr fronts only its stack-mate arrs** — used by seam 1's tag-by-queried-instance
+  resolution. True for the paired-stack topology; a Bazarr fronting arrs across stacks
+  would still resolve correctly via path→slug (the tag is a disambiguation aid, not the
+  sole key).

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -11,6 +11,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
+from .instances import Instance, InstanceConfigError, build_instances
 from .libraries import Library, LibraryConfigError, build_libraries
 
 log = logging.getLogger(__name__)
@@ -234,6 +235,12 @@ class Settings:
     # Tuple (not list) because Settings is frozen.
     libraries: tuple[Library, ...] = ()
 
+    # #161 Phase 1: validated instance list (flat tuple; each Instance carries
+    # its .service). Per-service instance 0 (id "") mirrors the legacy
+    # sonarr_url/api_key/... scalars for back-compat; extras come from the
+    # override store's "instances" key. Built in load() after scalars+overrides.
+    instances: tuple[Instance, ...] = ()
+
 
 def load() -> Settings:
     # See _env_or docstring for the empty-string fall-through rule (#127).
@@ -312,6 +319,7 @@ def load() -> Settings:
     )
     _apply_persisted_overrides(_s)
     rebuild_libraries(_s)
+    rebuild_instances(_s)
     return _s
 
 
@@ -351,6 +359,42 @@ def rebuild_libraries(s: Settings) -> None:
         log.warning("invalid libraries[] config; using single default library", exc_info=True)
         libs = (default_lib,)
     object.__setattr__(s, "libraries", libs)
+
+
+# Scalars that define each service's instance 0. A runtime edit of any of these
+# must trigger rebuild_instances() so credential changes take effect live (#161,
+# mirrors LIBRARY_DEFINING_FIELDS / #285).
+INSTANCE_DEFINING_FIELDS = (
+    "sonarr_url",
+    "sonarr_api_key",
+    "radarr_url",
+    "radarr_api_key",
+    "bazarr_url",
+    "bazarr_api_key",
+)
+
+
+def rebuild_instances(s: Settings) -> None:
+    """(Re)build ``s.instances`` from the current scalar config + persisted
+    extras. Instance 0 per service = the legacy scalars; extras come from the
+    override store's ``instances`` key. Fail-soft: any config error logs and
+    degrades to the per-service defaults so this never breaks boot."""
+    from . import config_store
+
+    defaults = [
+        Instance(id="", service="sonarr", name="default", url=s.sonarr_url, api_key=s.sonarr_api_key),
+        Instance(id="", service="radarr", name="default", url=s.radarr_url, api_key=s.radarr_api_key),
+        Instance(id="", service="bazarr", name="default", url=s.bazarr_url, api_key=s.bazarr_api_key),
+    ]
+    try:
+        raw_extras = config_store.load_overrides().get("instances", {})
+        if not isinstance(raw_extras, dict):
+            raw_extras = {}
+        insts = build_instances(defaults, raw_extras)
+    except InstanceConfigError:
+        log.warning("invalid instances config; using per-service defaults", exc_info=True)
+        insts = tuple(defaults)
+    object.__setattr__(s, "instances", insts)
 
 
 # ─── Onboarding clobber guard support ───────────────────────────────

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -225,13 +225,32 @@ class CoverageReport:
 
 
 class IntegrationBundle:
-    """Holds the four integration clients + close-all helper. App lifespan
-    owns one instance."""
+    """Holds the integration clients + close-all helper. App lifespan owns one
+    instance. #161: the arr/bazarr trio is keyed per instance id; tautulli/plex
+    stay singleton. ``bundle.sonarr/.radarr/.bazarr`` alias instance 0 so the
+    many existing read sites keep working unchanged."""
+
+    _ARR_SERVICES = ("sonarr", "radarr", "bazarr")
 
     def __init__(self):
-        self.bazarr = BazarrClient()
-        self.sonarr = SonarrClient()
-        self.radarr = RadarrClient()
+        # SonarrClient/RadarrClient/BazarrClient are already imported at module
+        # scope — reuse them, do not re-import locally.
+        ctors = {"sonarr": SonarrClient, "radarr": RadarrClient, "bazarr": BazarrClient}
+        self._clients: dict[str, dict[str, object]] = {svc: {} for svc in self._ARR_SERVICES}
+        for inst in settings.instances:
+            if inst.service not in self._clients:
+                continue
+            self._clients[inst.service][inst.id] = ctors[inst.service](
+                base_url=inst.url, api_key=inst.api_key
+            )
+        # Defensive: guarantee an instance 0 per service even if settings.instances
+        # was never rebuilt (keeps the alias properties total). Guard with ``in``
+        # (NOT setdefault) — setdefault would eagerly construct a throwaway client
+        # every call, leaking an unclosed httpx.AsyncClient.
+        for svc in self._ARR_SERVICES:
+            if "" not in self._clients[svc]:
+                self._clients[svc][""] = ctors[svc]()
+
         self.tautulli = TautulliClient()
         # v1.1.1: Plex client for partial-scan-on-sidecar-write. Constructed
         # with env-driven config; .is_configured() reflects whether url+token
@@ -246,15 +265,29 @@ class IntegrationBundle:
             media_root=str(settings.media_root),
         )
 
+    def client_for(self, service: str, instance_id: str | None):
+        """Resolve a client by (service, instance id). Empty/unknown id falls
+        back to instance 0 — the single-stack invariant."""
+        pool = self._clients[service]
+        return pool.get(instance_id or "") or pool[""]
+
+    @property
+    def sonarr(self):
+        return self._clients["sonarr"][""]
+
+    @property
+    def radarr(self):
+        return self._clients["radarr"][""]
+
+    @property
+    def bazarr(self):
+        return self._clients["bazarr"][""]
+
     async def aclose(self) -> None:
-        await asyncio.gather(
-            self.bazarr.aclose(),
-            self.sonarr.aclose(),
-            self.radarr.aclose(),
-            self.tautulli.aclose(),
-            self.plex.aclose(),
-            return_exceptions=True,
-        )
+        closers = [c.aclose() for pool in self._clients.values() for c in pool.values()]
+        closers.append(self.tautulli.aclose())
+        closers.append(self.plex.aclose())
+        await asyncio.gather(*closers, return_exceptions=True)
 
 
 # ───────────────────────────── helpers ──────────────────────────────────────

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -271,17 +271,33 @@ class IntegrationBundle:
         pool = self._clients[service]
         return pool.get(instance_id or "") or pool[""]
 
+    # Read/write aliases for instance 0. Reads resolve the env-backed default
+    # client; writes swap it (preserves the long-standing test idiom + any
+    # runtime that replaces a single client). Multi-instance code uses
+    # client_for()/clients_for() instead.
     @property
     def sonarr(self):
         return self._clients["sonarr"][""]
+
+    @sonarr.setter
+    def sonarr(self, client):
+        self._clients["sonarr"][""] = client
 
     @property
     def radarr(self):
         return self._clients["radarr"][""]
 
+    @radarr.setter
+    def radarr(self, client):
+        self._clients["radarr"][""] = client
+
     @property
     def bazarr(self):
         return self._clients["bazarr"][""]
+
+    @bazarr.setter
+    def bazarr(self, client):
+        self._clients["bazarr"][""] = client
 
     async def aclose(self) -> None:
         closers = [c.aclose() for pool in self._clients.values() for c in pool.values()]

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -22,10 +22,10 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from .config import settings
-from .paths import UNSUPPORTED_EXTS, canonical_to_fs, strip_arr_prefix
+from .paths import UNSUPPORTED_EXTS, canonical_to_fs, library_for_canonical, strip_arr_prefix
 from .integrations import IntegrationError
 from .integrations.bazarr import BazarrClient
 from .integrations.radarr import RadarrClient
@@ -288,6 +288,25 @@ class IntegrationBundle:
         closers.append(self.tautulli.aclose())
         closers.append(self.plex.aclose())
         await asyncio.gather(*closers, return_exceptions=True)
+
+
+class ResolvedClients(NamedTuple):
+    sonarr: object
+    radarr: object
+    bazarr: object
+
+
+def clients_for(bundle: "IntegrationBundle", canonical: str) -> ResolvedClients:
+    """Resolve the (sonarr, radarr, bazarr) clients that own a row's library.
+    The row's '@slug' head -> Library -> bound instance ids -> clients. Empty
+    bindings resolve to instance 0, so single-stack is byte-identical. The
+    caller picks sonarr vs radarr by content type (#161 Phase 2+ wiring)."""
+    lib = library_for_canonical(canonical)
+    return ResolvedClients(
+        sonarr=bundle.client_for("sonarr", lib.sonarr_id),
+        radarr=bundle.client_for("radarr", lib.radarr_id),
+        bazarr=bundle.client_for("bazarr", lib.bazarr_id),
+    )
 
 
 # ───────────────────────────── helpers ──────────────────────────────────────

--- a/src/subarr/instances.py
+++ b/src/subarr/instances.py
@@ -1,0 +1,75 @@
+"""Multi-instance config model (#161 Phase 1).
+
+An Instance = one Sonarr/Radarr/Bazarr container's credentials (url + api_key).
+Instance identity is a short immutable slug; the default/legacy instance per
+service uses the EMPTY slug (its credentials come from the env scalars), so
+existing single-stack installs need no config and stay byte-identical.
+
+Pure module: no env, no IO, no `settings` import -- `build_instances` is a
+deterministic function so it unit-tests in isolation. config.py owns the IO
+seam (reads persisted extras) and the fail-soft load wrapper. Mirrors
+libraries.py by design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from .libraries import slugify  # reuse the exact kebab-case rule
+
+MULTI_INSTANCE_SERVICES = ("sonarr", "radarr", "bazarr")
+
+
+@dataclass(frozen=True)
+class Instance:
+    id: str  # "" = default/legacy instance (env-backed); else unique kebab slug within its service
+    service: str  # "sonarr" | "radarr" | "bazarr"
+    name: str  # human-facing label
+    url: str
+    api_key: str
+
+
+class InstanceConfigError(ValueError):
+    """Invalid instances config (dup/empty id, missing fields, ...)."""
+
+
+def build_instances(defaults: list[Instance], extras: dict) -> tuple[Instance, ...]:
+    """Assemble the validated instance tuple.
+
+    `defaults` is the per-service instance 0 list (their ids are FORCED to "").
+    `extras` is the persisted override dict: {service: [{name, url, api_key,
+    slug?}, ...]}. Unknown service keys are ignored. Raises InstanceConfigError
+    on any invalid/duplicate extra -- config.load() catches this and falls back
+    to defaults only (fail-soft boot).
+    """
+    out: list[Instance] = []
+    seen: dict[str, set[str]] = {svc: {""} for svc in MULTI_INSTANCE_SERVICES}
+
+    for d in defaults:
+        out.append(replace(d, id=""))
+
+    for svc in MULTI_INSTANCE_SERVICES:
+        raw_list = extras.get(svc, []) if isinstance(extras, dict) else []
+        if not isinstance(raw_list, list):
+            raise InstanceConfigError(f"{svc} instances is not a list: {raw_list!r}")
+        for i, raw in enumerate(raw_list):
+            if not isinstance(raw, dict):
+                raise InstanceConfigError(f"{svc}[{i}] is not an object: {raw!r}")
+            name = str(raw.get("name", "")).strip()
+            url = str(raw.get("url", "")).strip()
+            api_key = str(raw.get("api_key", "")).strip()
+            if not name:
+                raise InstanceConfigError(f"{svc}[{i}] missing 'name'")
+            if not url:
+                raise InstanceConfigError(f"{svc} instance {name!r} missing 'url'")
+            if not api_key:
+                raise InstanceConfigError(f"{svc} instance {name!r} missing 'api_key'")
+            iid = str(raw.get("slug", "")).strip() or slugify(name)
+            if not iid:
+                raise InstanceConfigError(f"{svc} instance {name!r} has no usable id")
+            if iid in seen[svc]:
+                raise InstanceConfigError(f"duplicate {svc} instance id {iid!r}")
+            seen[svc].add(iid)
+            out.append(Instance(id=iid, service=svc, name=name, url=url, api_key=api_key))
+
+    return tuple(out)

--- a/src/subarr/integrations/bazarr.py
+++ b/src/subarr/integrations/bazarr.py
@@ -22,10 +22,12 @@ from .base import IntegrationClient
 class BazarrClient(IntegrationClient):
     name = "bazarr"
 
-    def __init__(self):
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        url = settings.bazarr_url if base_url is None else base_url
+        key = settings.bazarr_api_key if api_key is None else api_key
         super().__init__(
-            base_url=settings.bazarr_url if settings.bazarr_api_key else "",
-            headers={"X-API-KEY": settings.bazarr_api_key} if settings.bazarr_api_key else None,
+            base_url=url if key else "",
+            headers={"X-API-KEY": key} if key else None,
         )
 
     async def status(self) -> dict[str, Any]:

--- a/src/subarr/integrations/radarr.py
+++ b/src/subarr/integrations/radarr.py
@@ -14,10 +14,12 @@ from .base import IntegrationClient
 class RadarrClient(IntegrationClient):
     name = "radarr"
 
-    def __init__(self):
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        url = settings.radarr_url if base_url is None else base_url
+        key = settings.radarr_api_key if api_key is None else api_key
         super().__init__(
-            base_url=settings.radarr_url if settings.radarr_api_key else "",
-            headers={"X-Api-Key": settings.radarr_api_key} if settings.radarr_api_key else None,
+            base_url=url if key else "",
+            headers={"X-Api-Key": key} if key else None,
         )
 
     async def status(self) -> dict[str, Any]:

--- a/src/subarr/integrations/sonarr.py
+++ b/src/subarr/integrations/sonarr.py
@@ -17,10 +17,12 @@ from .base import IntegrationClient
 class SonarrClient(IntegrationClient):
     name = "sonarr"
 
-    def __init__(self):
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        url = settings.sonarr_url if base_url is None else base_url
+        key = settings.sonarr_api_key if api_key is None else api_key
         super().__init__(
-            base_url=settings.sonarr_url if settings.sonarr_api_key else "",
-            headers={"X-Api-Key": settings.sonarr_api_key} if settings.sonarr_api_key else None,
+            base_url=url if key else "",
+            headers={"X-Api-Key": key} if key else None,
         )
 
     async def status(self) -> dict[str, Any]:

--- a/src/subarr/libraries.py
+++ b/src/subarr/libraries.py
@@ -34,6 +34,12 @@ class Library:
     fs_root: Path  # subarr's filesystem view of this library's root
     subgen_prefix: str  # subgen-space absolute prefix (e.g. "/media")
     arr_prefix: str  # *arr container path prefix (e.g. "/data/Media/")
+    # #161 Phase 1: which instance serves this library. "" = instance 0
+    # (env-backed default). A library uses one media-manager (Sonarr OR Radarr,
+    # by content type) + one Bazarr. Inert in Phase 1 — no UI sets these yet.
+    sonarr_id: str = ""
+    radarr_id: str = ""
+    bazarr_id: str = ""
 
 
 class LibraryConfigError(ValueError):
@@ -98,6 +104,9 @@ def build_libraries(default: Library, extras: list[dict]) -> tuple[Library, ...]
                 fs_root=Path(fs_root),
                 subgen_prefix=subgen_prefix,
                 arr_prefix=arr_prefix,
+                sonarr_id=str(raw.get("sonarr_id", "")).strip(),
+                radarr_id=str(raw.get("radarr_id", "")).strip(),
+                bazarr_id=str(raw.get("bazarr_id", "")).strip(),
             )
         )
     return tuple(out)

--- a/src/subarr/paths.py
+++ b/src/subarr/paths.py
@@ -55,6 +55,18 @@ def _library_by_slug(slug: str) -> Library:
     raise PathOutsideRootError(f"unknown library @{slug}")
 
 
+def library_for_canonical(canonical: str) -> Library:
+    """Public, fail-soft resolver: a canonical's '@<slug>/' head -> its Library.
+    Unknown/empty slug returns library 0 (the default) rather than raising —
+    callers (clients_for, #161) must degrade to instance 0, never crash a row.
+    """
+    slug, _rel = _split_canonical(canonical)
+    try:
+        return _library_by_slug(slug)
+    except PathOutsideRootError:
+        return _library_by_slug("")
+
+
 def canonical_to_fs(canonical: str) -> Path:
     """Resolve a canonical to an absolute filesystem path under its library's
     root, guarding against traversal. A leading '@<slug>/' selects the

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -683,7 +683,14 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
     we rely on the user pinning their env vars in compose after the
     wizard finishes (the wizard's final step shows a copy-paste
     snippet of the values they entered)."""
-    from ..config import LIBRARY_DEFINING_FIELDS, env_is_set, rebuild_libraries, settings
+    from ..config import (
+        INSTANCE_DEFINING_FIELDS,
+        LIBRARY_DEFINING_FIELDS,
+        env_is_set,
+        rebuild_instances,
+        rebuild_libraries,
+        settings,
+    )
 
     mapping = {
         "media_root": ("media_root", Path),
@@ -701,6 +708,7 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
         "ollama_model": ("ollama_model", str),
     }
     libs_dirty = False
+    instances_dirty = False
     for src_key, (settings_attr, coerce) in mapping.items():
         if src_key in progress and progress[src_key]:
             # Clobber guard: an env-set field is the operator's
@@ -720,6 +728,8 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
                 object.__setattr__(settings, settings_attr, coerce(progress[src_key]))
                 if settings_attr in LIBRARY_DEFINING_FIELDS:
                     libs_dirty = True
+                if settings_attr in INSTANCE_DEFINING_FIELDS:
+                    instances_dirty = True
             except Exception as e:
                 log.warning("settings flush: %s=%r failed: %s", settings_attr, progress[src_key], e)
 
@@ -728,6 +738,13 @@ def _apply_progress_to_settings(progress: dict[str, Any]) -> None:
     # resolution doesn't silently run on a stale default library until restart.
     if libs_dirty:
         rebuild_libraries(settings)
+    # #161: a flushed sonarr/radarr/bazarr url or api_key changes the scalars
+    # instance 0 is derived from — re-derive settings.instances so the rebuilt
+    # IntegrationBundle talks to the new credentials, not stale ones until
+    # restart. (Pre-#161 the bundle read the live scalars directly; the instance
+    # list must be refreshed to preserve that behaviour.)
+    if instances_dirty:
+        rebuild_instances(settings)
 
 
 async def _rebuild_runtime_clients(state, reprobe: bool = True) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,45 @@ def two_libraries(subarr_env, monkeypatch, tmp_path: Path):
 
 
 @pytest.fixture
+def anime_stack(subarr_env, monkeypatch, tmp_path: Path):
+    """A second Sonarr instance 'anime' plus a library 'anime' bound to it.
+    Writes both override keys and reloads config/paths/coverage_engine so
+    settings.instances, settings.libraries, and a freshly built IntegrationBundle
+    all reflect them. Returns the anime library fs_root. (#161 Phase 1)"""
+    import json
+
+    anime_root = tmp_path / "anime"
+    (anime_root / "Show").mkdir(parents=True)
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps(
+            {
+                "instances": {
+                    "sonarr": [{"name": "Anime", "url": "http://s2.test:8989", "api_key": "anime-key"}]
+                },
+                "libraries": [
+                    {
+                        "slug": "anime",
+                        "name": "Anime",
+                        "fs_root": str(anime_root),
+                        "subgen_prefix": "/media",
+                        "arr_prefix": "/data/anime/",
+                        "sonarr_id": "anime",
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config, coverage_engine, paths
+
+    importlib.reload(config)
+    importlib.reload(paths)
+    importlib.reload(coverage_engine)
+    return anime_root
+
+
+@pytest.fixture
 def subarr_env(monkeypatch, tmp_path: Path, media_root: Path):
     compose = tmp_path / "compose.yaml"
     _make_compose(compose)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,24 +390,35 @@ def _make_integration_bundle(
 
     class _StubBundle(IntegrationBundle):
         def __init__(self):
-            self.bazarr = _wrap(
-                BazarrClient,
-                bazarr_handler,
-                "http://bazarr.test:6767",
-                {"X-API-KEY": "bz-test-key"} if bazarr_handler else None,
-            )
-            self.sonarr = _wrap(
-                SonarrClient,
-                sonarr_handler,
-                "http://sonarr.test:8989",
-                {"X-Api-Key": "sn-test-key"} if sonarr_handler else None,
-            )
-            self.radarr = _wrap(
-                RadarrClient,
-                radarr_handler,
-                "http://radarr.test:7878",
-                {"X-Api-Key": "rd-test-key"} if radarr_handler else None,
-            )
+            # #161: bundle.sonarr/.radarr/.bazarr are now instance-0 alias
+            # properties reading self._clients[svc][""], so populate that dict
+            # (not the read-only attributes) with the mock-transport clients.
+            self._clients = {
+                "bazarr": {
+                    "": _wrap(
+                        BazarrClient,
+                        bazarr_handler,
+                        "http://bazarr.test:6767",
+                        {"X-API-KEY": "bz-test-key"} if bazarr_handler else None,
+                    )
+                },
+                "sonarr": {
+                    "": _wrap(
+                        SonarrClient,
+                        sonarr_handler,
+                        "http://sonarr.test:8989",
+                        {"X-Api-Key": "sn-test-key"} if sonarr_handler else None,
+                    )
+                },
+                "radarr": {
+                    "": _wrap(
+                        RadarrClient,
+                        radarr_handler,
+                        "http://radarr.test:7878",
+                        {"X-Api-Key": "rd-test-key"} if radarr_handler else None,
+                    )
+                },
+            }
             self.tautulli = _wrap(TautulliClient, tautulli_handler, "http://tautulli.test:8181")
             # v1.1.1: tests don't exercise Plex; stub with an unconfigured
             # client so .is_configured() returns False and code paths skip.

--- a/tests/test_clients_for.py
+++ b/tests/test_clients_for.py
@@ -1,0 +1,23 @@
+"""clients_for maps a row's @slug library to its bound instance clients (#161)."""
+
+from __future__ import annotations
+
+
+def test_clients_for_empty_bindings_resolve_instance0(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle, clients_for
+
+    bundle = IntegrationBundle()
+    rc = clients_for(bundle, "Show/S01E01.mkv")  # library 0, all bindings ""
+    assert rc.sonarr is bundle.sonarr
+    assert rc.radarr is bundle.radarr
+    assert rc.bazarr is bundle.bazarr
+
+
+def test_clients_for_bound_library_routes_to_instance(anime_stack):
+    # anime_stack: library 'anime' bound sonarr_id='anime'; bazarr_id unset
+    from subarr.coverage_engine import IntegrationBundle, clients_for
+
+    bundle = IntegrationBundle()
+    rc = clients_for(bundle, "@anime/Naruto/S01E01.mkv")
+    assert rc.sonarr is bundle.client_for("sonarr", "anime")
+    assert rc.bazarr is bundle.bazarr  # bazarr_id unset -> instance 0

--- a/tests/test_config_libraries.py
+++ b/tests/test_config_libraries.py
@@ -87,3 +87,34 @@ def test_rebuild_libraries_preserves_extras(subarr_env, monkeypatch, tmp_path):
     libs = config.settings.libraries
     assert libs[0].arr_prefix == "/data/Changed/"
     assert [lib.slug for lib in libs] == ["", "disk-2"]
+
+
+def test_library_binding_fields_default_empty(tmp_path):
+    from subarr.libraries import Library
+
+    lib = Library(slug="", name="d", fs_root=tmp_path, subgen_prefix="/media", arr_prefix="/data/")
+    assert lib.sonarr_id == ""
+    assert lib.radarr_id == ""
+    assert lib.bazarr_id == ""
+
+
+def test_build_libraries_passes_through_bindings(tmp_path):
+    from subarr.libraries import Library, build_libraries
+
+    default = Library(
+        slug="", name="default", fs_root=tmp_path / "m", subgen_prefix="/media", arr_prefix="/data/tv/"
+    )
+    extras = [
+        {
+            "name": "Anime",
+            "fs_root": str(tmp_path / "anime"),
+            "arr_prefix": "/data/anime/",
+            "sonarr_id": "anime",
+            "bazarr_id": "anime",
+        }
+    ]
+    libs = build_libraries(default, extras)
+    anime = next(l for l in libs if l.slug == "anime")
+    assert anime.sonarr_id == "anime"
+    assert anime.radarr_id == ""
+    assert anime.bazarr_id == "anime"

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -93,3 +93,22 @@ def test_rebuild_instances_failsoft_on_bad_config(subarr_env, monkeypatch, tmp_p
 
     importlib.reload(config)  # must not raise
     assert len([i for i in config.settings.instances if i.service == "sonarr"]) == 1
+
+
+def test_credential_flush_rebuilds_instances(subarr_env, monkeypatch):
+    # #161 back-compat: a wizard credential edit must refresh settings.instances
+    # (instance 0), else the rebuilt IntegrationBundle would use a stale URL.
+    # sonarr_url must NOT be env-set, or the clobber-guard skips the flush.
+    import importlib
+
+    monkeypatch.delenv("SONARR_URL", raising=False)
+    monkeypatch.delenv("SONARR_API_KEY", raising=False)
+    from subarr import config
+
+    importlib.reload(config)
+    from subarr.routers.onboarding import _apply_progress_to_settings
+
+    _apply_progress_to_settings({"sonarr_url": "http://newsonarr:8989", "sonarr_api_key": "newkey"})
+    inst0 = next(i for i in config.settings.instances if i.service == "sonarr" and i.id == "")
+    assert inst0.url == "http://newsonarr:8989"
+    assert inst0.api_key == "newkey"

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -48,3 +48,48 @@ def test_env_beats_file_override(tmp_path, monkeypatch):
     cs.save_override("vad_enabled", False)  # UI tried OFF
     s = config.load()
     assert s.vad_enabled is True  # env is authoritative
+
+
+def test_rebuild_instances_seeds_instance0_from_scalars(subarr_env):
+    from subarr import config
+
+    s = config.settings  # the reloaded singleton (subarr_env seeded it from env)
+    sonarrs = [i for i in s.instances if i.service == "sonarr"]
+    inst0 = next(i for i in sonarrs if i.id == "")
+    assert inst0.url == s.sonarr_url  # "http://sonarr.test:8989" from subarr_env
+    assert inst0.api_key == s.sonarr_api_key
+
+
+def test_rebuild_instances_picks_up_extras(subarr_env, monkeypatch, tmp_path):
+    import importlib
+    import json
+
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps({"instances": {"sonarr": [{"name": "Anime", "url": "http://s2:8989", "api_key": "kk"}]}})
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config
+
+    importlib.reload(config)
+    ids = {i.id for i in config.settings.instances if i.service == "sonarr"}
+    assert "" in ids and "anime" in ids
+
+
+def test_rebuild_instances_failsoft_on_bad_config(subarr_env, monkeypatch, tmp_path):
+    import importlib
+    import json
+
+    store = tmp_path / "ov.json"
+    store.write_text(
+        json.dumps(
+            {
+                "instances": {"sonarr": [{"name": "x", "url": "u"}]}  # missing api_key
+            }
+        )
+    )
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    from subarr import config
+
+    importlib.reload(config)  # must not raise
+    assert len([i for i in config.settings.instances if i.service == "sonarr"]) == 1

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -1,0 +1,82 @@
+"""Unit tests for the multi-instance config model (#161 Phase 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _defaults():
+    from subarr.instances import Instance
+
+    return [
+        Instance(id="", service="sonarr", name="default", url="http://sonarr:8989", api_key="k1"),
+        Instance(id="", service="radarr", name="default", url="http://radarr:7878", api_key="k2"),
+        Instance(id="", service="bazarr", name="default", url="http://bazarr:6767", api_key="k3"),
+    ]
+
+
+def test_build_instances_single_is_just_defaults():
+    from subarr.instances import build_instances
+
+    insts = build_instances(_defaults(), {})
+    assert len(insts) == 3
+    assert {i.service for i in insts} == {"sonarr", "radarr", "bazarr"}
+    assert all(i.id == "" for i in insts)
+
+
+def test_build_instances_forces_default_id_empty():
+    from subarr.instances import Instance, build_instances
+
+    bad_default = [Instance(id="nonempty", service="sonarr", name="d", url="u", api_key="k")]
+    insts = build_instances(bad_default, {})
+    assert insts[0].id == ""
+
+
+def test_build_instances_adds_extra_with_slug_from_name():
+    from subarr.instances import build_instances
+
+    extras = {"sonarr": [{"name": "Anime", "url": "http://s2:8989", "api_key": "kk"}]}
+    insts = build_instances(_defaults(), extras)
+    sonarrs = [i for i in insts if i.service == "sonarr"]
+    assert len(sonarrs) == 2
+    extra = next(i for i in sonarrs if i.id != "")
+    assert extra.id == "anime"
+    assert extra.name == "Anime"
+    assert extra.url == "http://s2:8989"
+
+
+def test_build_instances_explicit_slug_preferred():
+    from subarr.instances import build_instances
+
+    extras = {"radarr": [{"slug": "fixed", "name": "Anime Films", "url": "u", "api_key": "k"}]}
+    insts = build_instances(_defaults(), extras)
+    assert any(i.id == "fixed" for i in insts if i.service == "radarr")
+
+
+@pytest.mark.parametrize(
+    "extras",
+    [
+        {"sonarr": [{"name": "", "url": "u", "api_key": "k"}]},
+        {"sonarr": [{"name": "x", "url": "", "api_key": "k"}]},
+        {"sonarr": [{"name": "x", "url": "u", "api_key": ""}]},
+        {"sonarr": [{"name": "///", "url": "u", "api_key": "k"}]},
+        {
+            "sonarr": [
+                {"slug": "", "name": "x", "url": "u", "api_key": "k"},
+                {"slug": "", "name": "x", "url": "u2", "api_key": "k2"},
+            ]
+        },
+    ],
+)
+def test_build_instances_rejects_bad(extras):
+    from subarr.instances import InstanceConfigError, build_instances
+
+    with pytest.raises(InstanceConfigError):
+        build_instances(_defaults(), extras)
+
+
+def test_build_instances_ignores_unknown_service_key():
+    from subarr.instances import build_instances
+
+    insts = build_instances(_defaults(), {"plex": [{"name": "x", "url": "u", "api_key": "k"}]})
+    assert len(insts) == 3

--- a/tests/test_integration_bundle_multi.py
+++ b/tests/test_integration_bundle_multi.py
@@ -1,0 +1,32 @@
+"""IntegrationBundle multi-instance dicts + instance-0 alias (#161 Phase 1)."""
+
+from __future__ import annotations
+
+
+def test_bundle_alias_resolves_instance0(subarr_env):
+    # single-stack: settings.instances has only the 3 instance-0 defaults
+    from subarr.coverage_engine import IntegrationBundle
+
+    bundle = IntegrationBundle()
+    assert bundle.sonarr is bundle.client_for("sonarr", "")
+    assert bundle.radarr is bundle.client_for("radarr", "")
+    assert bundle.bazarr is bundle.client_for("bazarr", "")
+
+
+def test_bundle_client_for_unknown_id_falls_back_to_instance0(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle
+
+    bundle = IntegrationBundle()
+    # an unbound/empty id and an unknown id both resolve to instance 0
+    assert bundle.client_for("sonarr", "") is bundle.sonarr
+    assert bundle.client_for("sonarr", "doesnotexist") is bundle.sonarr
+
+
+def test_bundle_builds_extra_instance(anime_stack):
+    # anime_stack reloaded coverage_engine after writing the override store
+    from subarr.coverage_engine import IntegrationBundle
+
+    bundle = IntegrationBundle()
+    anime = bundle.client_for("sonarr", "anime")
+    assert anime is not bundle.sonarr
+    assert anime._base_url == "http://s2.test:8989"

--- a/tests/test_integration_credentials.py
+++ b/tests/test_integration_credentials.py
@@ -265,3 +265,30 @@ def test_test_connection_unreachable(app_with_stub, monkeypatch):
     body = r.json()
     assert body["ok"] is False
     assert body["error"]
+
+
+def test_sonarr_client_explicit_credentials():
+    from subarr.integrations.sonarr import SonarrClient
+
+    c = SonarrClient(base_url="http://s2:8989", api_key="explicitkey")
+    assert c._base_url == "http://s2:8989"
+    assert c._client.headers["X-Api-Key"] == "explicitkey"
+
+
+def test_sonarr_client_defaults_to_settings(subarr_env):
+    # Settings is a frozen dataclass — do NOT mutate it. subarr_env seeds the
+    # scalars from env; assert the no-arg client mirrors them (today's behaviour).
+    from subarr import config
+    from subarr.integrations.sonarr import SonarrClient
+
+    c = SonarrClient()  # no args = today's behaviour
+    assert c._base_url == config.settings.sonarr_url
+    assert c._client.headers["X-Api-Key"] == config.settings.sonarr_api_key
+
+
+def test_bazarr_client_explicit_uses_caps_header():
+    from subarr.integrations.bazarr import BazarrClient
+
+    c = BazarrClient(base_url="http://b2:6767", api_key="bk")
+    # Bazarr header is X-API-KEY (caps), NOT X-Api-Key
+    assert c._client.headers["X-API-KEY"] == "bk"

--- a/tests/test_multi_instance_backcompat.py
+++ b/tests/test_multi_instance_backcompat.py
@@ -1,0 +1,37 @@
+"""#161 single-stack byte-identical invariant: with no `instances`/`libraries`
+overrides, the multi-instance plumbing must behave exactly like instance 0.
+This is the CI guard that single-stack installs (the majority) are unaffected.
+"""
+
+from __future__ import annotations
+
+
+def test_single_stack_bundle_matches_direct_construction(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle
+    from subarr.integrations.sonarr import SonarrClient
+
+    bundle = IntegrationBundle()
+    direct = SonarrClient()  # the pre-#161 construction path
+
+    assert bundle.sonarr._base_url == direct._base_url
+    assert dict(bundle.sonarr._client.headers).get("X-Api-Key") == dict(direct._client.headers).get(
+        "X-Api-Key"
+    )
+
+
+def test_single_stack_clients_for_is_always_instance0(subarr_env):
+    from subarr.coverage_engine import IntegrationBundle, clients_for
+
+    bundle = IntegrationBundle()
+    for canonical in ["", "Show/S01E01.mkv", "@unknownlib/x", "Movie (2020)/m.mkv"]:
+        rc = clients_for(bundle, canonical)
+        assert rc.sonarr is bundle.sonarr
+        assert rc.radarr is bundle.radarr
+        assert rc.bazarr is bundle.bazarr
+
+
+def test_single_stack_has_exactly_one_instance_per_service(subarr_env):
+    from subarr import config
+
+    for svc in ("sonarr", "radarr", "bazarr"):
+        assert len([i for i in config.settings.instances if i.service == svc]) == 1

--- a/tests/test_paths_library_for.py
+++ b/tests/test_paths_library_for.py
@@ -1,0 +1,18 @@
+"""library_for_canonical resolves a canonical's @slug to its Library (#161)."""
+
+from __future__ import annotations
+
+
+def test_library_for_canonical_default_library(subarr_env):
+    from subarr.paths import library_for_canonical
+
+    lib = library_for_canonical("Show/S01E01.mkv")  # no @slug head = library 0
+    assert lib.slug == ""
+
+
+def test_library_for_canonical_unknown_slug_failsoft_to_library0(subarr_env):
+    from subarr.paths import library_for_canonical
+
+    # unknown @slug must not raise — Phase 1 resolver is fail-soft to library 0
+    lib = library_for_canonical("@nope/x")
+    assert lib.slug == ""


### PR DESCRIPTION
Phase 1 of #161 (multiple Sonarr/Radarr/Bazarr instances). **Inert plumbing**: the multi-instance data model + resolver land, but nothing is wired into call sites and there is no UI to add a second instance yet. Byte-identical for single-stack installs (the majority).

Design spec: `docs/superpowers/specs/2026-06-25-161-multi-instance-design.md`
Plan: `docs/superpowers/plans/2026-06-25-161-phase1-inert-plumbing.md`

## Summary
- New pure `instances.py` (`Instance` + `build_instances`), mirroring `libraries.py`.
- `Library` gains `sonarr_id`/`radarr_id`/`bazarr_id` binding fields (defaulted, inert).
- `config.py`: `Settings.instances` seeded from the env scalars + override store; `rebuild_instances()` + `INSTANCE_DEFINING_FIELDS`; wired into the onboarding credential-flush so a runtime edit refreshes instance 0.
- arr/bazarr clients accept optional explicit `(base_url, api_key)`, defaulting to settings.
- `IntegrationBundle` becomes per-service client dicts keyed by instance id, with `sonarr/radarr/bazarr` read/write alias properties for instance 0, a `client_for(service, id)` resolver, and a module-level `clients_for(bundle, canonical)` + `ResolvedClients`.
- `paths.library_for_canonical()` fail-soft helper.

## Back-compat invariant (the point of Phase 1)
With no `instances` override, every binding id is `""`, `clients_for` returns instance 0, and `bundle.sonarr/.radarr/.bazarr` resolve to a client identical to today. There is **no row/schema migration** — provenance rides the existing `@slug` canonical head. Guarded by `tests/test_multi_instance_backcompat.py`.

## Test plan
- [ ] CI green (full pytest on Linux + CodeQL/Trivy/semgrep)
- Local: full suite **1347 passed, 2 skipped, 0 failures**
- Local gates: `ruff check`, `ruff format --check`, `bandit` (no new findings) all clean
- Independent code review passed; one back-compat gap (credential-flush not refreshing `settings.instances`) found + fixed + regression-tested in this branch.

## Not in this PR (later phases)
Bazarr wanted-list merge over N instances (P2), writeback routing (P3), Settings/onboarding UI (P4), wizard branch (P5). Phase 2+ is parked pending @KRDucky's topology answers on #161.