### PR TITLE
#365: per-instance Sonarr/Radarr sources health rollup + library binding validation

### DIFF
--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -359,6 +359,10 @@ def rebuild_libraries(s: Settings) -> None:
         log.warning("invalid libraries[] config; using single default library", exc_info=True)
         libs = (default_lib,)
     object.__setattr__(s, "libraries", libs)
+    # #365: at load, instances build right after this (skip the premature check);
+    # a runtime library edit re-validates against the already-built instances.
+    if s.instances:
+        _warn_dangling_bindings(s)
 
 
 # Scalars that define each service's instance 0. A runtime edit of any of these
@@ -395,6 +399,37 @@ def rebuild_instances(s: Settings) -> None:
         log.warning("invalid instances config; using per-service defaults", exc_info=True)
         insts = tuple(defaults)
     object.__setattr__(s, "instances", insts)
+    # #365: surface library bindings that reference an unconfigured instance.
+    _warn_dangling_bindings(s)
+
+
+def validate_library_bindings(libraries, instances) -> list[str]:
+    """#365: return a warning message per library that binds an arr/bazarr
+    instance id which isn't configured. Coverage routing degrades a dangling
+    binding to instance 0, so these are visibility signals — we warn, never
+    raise (a typo must not nuke a whole multi-library config)."""
+    by_service: dict[str, set[str]] = {"sonarr": set(), "radarr": set(), "bazarr": set()}
+    for inst in instances:
+        if inst.service in by_service:
+            by_service[inst.service].add(inst.id)
+    out: list[str] = []
+    for lib in libraries:
+        for service, bound in (
+            ("sonarr", lib.sonarr_id),
+            ("radarr", lib.radarr_id),
+            ("bazarr", lib.bazarr_id),
+        ):
+            if bound and bound not in by_service[service]:
+                out.append(
+                    f"library {lib.slug or '(default)'!r} binds {service}_id={bound!r} which is not a "
+                    f"configured {service} instance; its rows fall back to instance 0"
+                )
+    return out
+
+
+def _warn_dangling_bindings(s: Settings) -> None:
+    for msg in validate_library_bindings(s.libraries, s.instances):
+        log.warning("%s", msg)
 
 
 # ─── Onboarding clobber guard support ───────────────────────────────

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -428,8 +428,12 @@ def validate_library_bindings(libraries, instances) -> list[str]:
 
 
 def _warn_dangling_bindings(s: Settings) -> None:
-    for msg in validate_library_bindings(s.libraries, s.instances):
-        log.warning("%s", msg)
+    # Runs inside the fail-soft rebuild paths — must never break boot.
+    try:
+        for msg in validate_library_bindings(s.libraries, s.instances):
+            log.warning("%s", msg)
+    except Exception:  # noqa: BLE001 — binding validation is advisory, never fatal
+        log.warning("library binding validation failed", exc_info=True)
 
 
 # ─── Onboarding clobber guard support ───────────────────────────────

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -1390,6 +1390,30 @@ def _disqualify_unsupported(items: list[CoverageItem]) -> None:
             it.verification_state = "unsupported"
 
 
+def _rollup_arr_health(instances: list[dict]) -> dict:
+    """#365: roll a list of per-instance arr health dicts into a back-compat top
+    level: ok = all configured instances ok, configured = any configured, numeric
+    keys summed, warnings/errors concatenated, plus the `instances` list. A single
+    instance reproduces the old flat shape + a one-element `instances` list."""
+    configured = [h for h in instances if h.get("configured")]
+    roll: dict = {
+        "ok": bool(configured) and all(h.get("ok") for h in configured),
+        "configured": bool(configured),
+        "instances": instances,
+    }
+    for key in ("count", "wanted_missing", "recent_imports_24h", "airing_within_48h"):
+        vals = [h[key] for h in instances if isinstance(h.get(key), int)]
+        if vals:
+            roll[key] = sum(vals)
+    warnings = [w for h in instances for w in h.get("warnings", [])]
+    if warnings:
+        roll["warnings"] = warnings
+    errors = [f"[{h.get('id') or '0'}] {h['error']}" for h in instances if h.get("error")]
+    if errors:
+        roll["error"] = "; ".join(errors)
+    return roll
+
+
 def _bazarr_routing(libraries) -> tuple[dict[str, str], dict[str, str]]:
     """#161 Phase 2: map each Bazarr instance id to the SINGLE Sonarr / Radarr
     instance that owns its episode / movie wanted items. A Bazarr fronts one
@@ -1501,32 +1525,40 @@ async def build_coverage(
     # a fetch blowing up (even a non-IntegrationError) degrades THAT instance to
     # empty data instead of sinking the whole build (per-instance isolation is
     # the point of the fan-out).
+    # #365: each fetch writes into a PER-INSTANCE scratch dict so health can be
+    # rolled up under sources[svc]["instances"] instead of N instances clobbering
+    # one flat sources[svc]. Returns (id, data_tuple, health) where health is the
+    # instance's sources[svc] entry tagged with its id.
     async def _fetch_sonarr_inst(iid: str):
         client = bundle._clients["sonarr"][iid]
+        inst_src: dict = {}
         try:
-            return iid, await asyncio.gather(
-                _fetch_arr("sonarr", client, sources, "series"),
-                _fetch_arr_tags("sonarr", client, sources),
-                _fetch_wanted_missing("sonarr", client, sources),
-                _fetch_recent_imports("sonarr", client, sources),
-                _fetch_calendar_upcoming(client, sources),
+            data = await asyncio.gather(
+                _fetch_arr("sonarr", client, inst_src, "series"),
+                _fetch_arr_tags("sonarr", client, inst_src),
+                _fetch_wanted_missing("sonarr", client, inst_src),
+                _fetch_recent_imports("sonarr", client, inst_src),
+                _fetch_calendar_upcoming(client, inst_src),
             )
         except Exception as e:  # noqa: BLE001 — isolate a bad instance, never sink the fleet
             log.warning("sonarr instance %r fetch failed: %s", iid, e)
-            return iid, ([], {}, set(), {}, set())
+            data = ([], {}, set(), {}, set())
+        return iid, data, {"id": iid, **inst_src.get("sonarr", {})}
 
     async def _fetch_radarr_inst(iid: str):
         client = bundle._clients["radarr"][iid]
+        inst_src: dict = {}
         try:
-            return iid, await asyncio.gather(
-                _fetch_arr("radarr", client, sources, "movies"),
-                _fetch_arr_tags("radarr", client, sources),
-                _fetch_wanted_missing("radarr", client, sources),
-                _fetch_recent_imports("radarr", client, sources),
+            data = await asyncio.gather(
+                _fetch_arr("radarr", client, inst_src, "movies"),
+                _fetch_arr_tags("radarr", client, inst_src),
+                _fetch_wanted_missing("radarr", client, inst_src),
+                _fetch_recent_imports("radarr", client, inst_src),
             )
         except Exception as e:  # noqa: BLE001 — isolate a bad instance, never sink the fleet
             log.warning("radarr instance %r fetch failed: %s", iid, e)
-            return iid, ([], {}, set(), {})
+            data = ([], {}, set(), {})
+        return iid, data, {"id": iid, **inst_src.get("radarr", {})}
 
     # v1.1-E: NOW PLAYING via Tautulli get_activity (singleton, fired in parallel).
     tautulli_activity_task = (
@@ -1535,8 +1567,13 @@ async def build_coverage(
     tautulli_task = asyncio.create_task(_fetch_tautulli(bundle.tautulli, sources)) if use_tautulli else None
 
     # iid -> (series, tags, missing_ids, recent_ids, airing_ids) / (movies, ...)
-    sonarr_data = dict(await asyncio.gather(*[_fetch_sonarr_inst(i) for i in sonarr_ids]))
-    radarr_data = dict(await asyncio.gather(*[_fetch_radarr_inst(i) for i in radarr_ids]))
+    _sonarr_fetched = await asyncio.gather(*[_fetch_sonarr_inst(i) for i in sonarr_ids])
+    _radarr_fetched = await asyncio.gather(*[_fetch_radarr_inst(i) for i in radarr_ids])
+    sonarr_data = {iid: data for iid, data, _h in _sonarr_fetched}
+    radarr_data = {iid: data for iid, data, _h in _radarr_fetched}
+    # #365: per-instance health rolled up to a back-compat top level + instances[].
+    sources["sonarr"] = _rollup_arr_health([h for _i, _d, h in _sonarr_fetched])
+    sources["radarr"] = _rollup_arr_health([h for _i, _d, h in _radarr_fetched])
     history = await tautulli_task if tautulli_task else []
     activity = (
         await tautulli_activity_task

--- a/tests/test_coverage_multi_instance.py
+++ b/tests/test_coverage_multi_instance.py
@@ -129,3 +129,38 @@ def test_route_wanted_dangling_binding_degrades_to_instance0():
     bz_to_sonarr = {"ghostbz": "ghost"}  # "ghost" is not a real instance id
     assert _route_wanted(eps, bz_to_sonarr, {"", "s1"}, "") == eps
     assert _route_wanted(eps, bz_to_sonarr, {"", "s1"}, "s1") == []
+
+
+def test_rollup_arr_health_rolls_ok_configured_and_sums():
+    """#365: per-instance arr health rolls up to a back-compat top level —
+    ok = all configured instances ok, configured = any configured, numeric
+    keys summed, warnings concatenated, plus the per-instance `instances` list."""
+    from subarr.coverage_engine import _rollup_arr_health
+
+    insts = [
+        {"id": "", "ok": True, "configured": True, "count": 5, "wanted_missing": 2},
+        {"id": "anime", "ok": False, "configured": True, "count": 3, "error": "boom"},
+    ]
+    roll = _rollup_arr_health(insts)
+    assert roll["configured"] is True
+    assert roll["ok"] is False  # one configured instance is down
+    assert roll["count"] == 8  # summed across instances
+    assert roll["instances"] == insts
+
+    # unconfigured-only -> configured False, ok False (matches the old flat shape)
+    roll2 = _rollup_arr_health([{"id": "", "ok": False, "configured": False}])
+    assert roll2["configured"] is False
+    assert roll2["ok"] is False
+
+
+def test_sources_sonarr_per_instance_health(anime_stack_full):
+    """#365: build_coverage records per-instance Sonarr/Radarr health under
+    sources[svc]["instances"] with a rolled-up top level (mirrors bazarr)."""
+    from subarr.coverage_engine import build_coverage
+
+    report = asyncio.run(build_coverage(anime_stack_full, use_tautulli=False))
+    src = report.to_dict()["sources"]
+    assert {i["id"] for i in src["sonarr"]["instances"]} == {"", "anime"}
+    assert src["sonarr"]["configured"] is True
+    assert src["sonarr"]["ok"] is True  # both instances healthy
+    assert {i["id"] for i in src["radarr"]["instances"]} == {"", "anime"}

--- a/tests/test_library_binding_validation.py
+++ b/tests/test_library_binding_validation.py
@@ -1,0 +1,42 @@
+"""#365: warn (don't fail) when a library binds to an unconfigured arr instance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _lib(slug, **ids):
+    from subarr.libraries import Library
+
+    return Library(
+        slug=slug,
+        name=slug or "default",
+        fs_root=Path(f"/{slug or 'd'}"),
+        subgen_prefix="/media",
+        arr_prefix=f"/data/{slug or ''}",
+        **ids,
+    )
+
+
+def _inst(iid, service):
+    from subarr.instances import Instance
+
+    return Instance(id=iid, service=service, name=iid or "default", url="http://x", api_key="k")
+
+
+def test_dangling_binding_warns():
+    from subarr.config import validate_library_bindings
+
+    libs = (_lib(""), _lib("anime", sonarr_id="ghost", bazarr_id="anime"))
+    insts = (_inst("", "sonarr"), _inst("anime", "bazarr"))
+    warnings = validate_library_bindings(libs, insts)
+    assert len(warnings) == 1
+    assert "ghost" in warnings[0] and "sonarr" in warnings[0]
+
+
+def test_valid_bindings_no_warning():
+    from subarr.config import validate_library_bindings
+
+    libs = (_lib(""), _lib("anime", sonarr_id="anime", bazarr_id="anime"))
+    insts = (_inst("", "sonarr"), _inst("anime", "sonarr"), _inst("anime", "bazarr"))
+    assert validate_library_bindings(libs, insts) == []


### PR DESCRIPTION
Closes #365 — the two non-blocking findings deferred from the #161 Phase 2 review.

## Per-instance arr health (MEDIUM)
Each Sonarr/Radarr instance's fetches now write into a per-instance scratch dict; `_rollup_arr_health` merges them into a back-compat top level (`ok` = all configured instances ok, `configured` = any, numeric keys summed, warnings/errors concatenated) **plus** `sources[svc]["instances"][]`. Mirrors `_fetch_bazarr_all`. Previously N instances clobbered one flat `sources[svc]` last-writer-wins, masking a failing secondary. Single-instance unchanged — `degraded_sources` still reads the same top-level `ok`/`configured`.

## Library binding validation (LOW)
`validate_library_bindings` **warns (never raises)** when a library binds an arr/bazarr instance id that isn't configured. Routing already degrades a dangling binding to instance 0, so this is a visibility signal. Wired into `rebuild_instances` (+ `rebuild_libraries` once instances exist) so it fires at load and on runtime config changes.

**Deviation from the issue:** warn instead of raising `LibraryConfigError` — raising would degrade ALL libraries to single-default for one typo, and routing is already safe.

## Tests / gates
TDD: 4 new tests (rollup unit, per-instance sources integration, dangling-binding warn, valid-no-warn). Characterization byte-identical; full suite **1363 passed, 2 skipped**; ruff + format + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)