### PR TITLE
#372: isolate the completion_watcher Bazarr retry fan-out per instance

### DIFF
--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -308,25 +308,29 @@ class CompletionWatcher:
             clients.setdefault(key, bz)
             by_instance.setdefault(key, []).append(entry)
         for key, entries in by_instance.items():
-            bz = clients[key]
-            if not bz.is_configured():
-                continue
-            tid = await self._bazarr_task_for(bz)
-            if tid is None:
-                continue
+            # #372: isolate each instance. The task-discovery call (_bazarr_task_for)
+            # only catches IntegrationError, so a non-IntegrationError from one
+            # Bazarr's list_tasks would otherwise abort the pass for every remaining
+            # instance. Mirror the scheduler's per-instance broad-except fan-out.
             try:
+                bz = clients[key]
+                if not bz.is_configured():
+                    continue
+                tid = await self._bazarr_task_for(bz)
+                if tid is None:
+                    continue
                 await bz.trigger_task(tid)
                 log.info(
                     "bazarr scan-disk retry fired on %s for %d completed-but-not-notified rows",
                     key,
                     len(entries),
                 )
-            except IntegrationError as e:
+                # Mark each row notified so we don't keep re-firing.
+                for entry in entries:
+                    self._provenance.mark_bazarr_triggered(entry.id)
+            except Exception as e:  # noqa: BLE001 - one instance's failure must not abort the rest
                 log.warning("bazarr scan-disk retry failed on %s: %s", key, e)
                 continue
-            # Mark each row notified so we don't keep re-firing.
-            for entry in entries:
-                self._provenance.mark_bazarr_triggered(entry.id)
 
     async def _try_upload_to_bazarr(self, entry) -> bool:
         """v1.1-G: Multipart-upload the freshly-Whispered .srt directly

--- a/tests/test_writeback_routing.py
+++ b/tests/test_writeback_routing.py
@@ -207,3 +207,43 @@ def test_scheduler_poke_fans_out_per_bazarr_instance(writeback_stack):
     assert trig(("bazarr", "anime")), "anime bazarr should be poked"
     assert trig(("bazarr", "")), "instance 0 should be poked too"
     assert res["fired"] is True
+
+
+def test_retry_bazarr_notify_isolates_one_instances_unexpected_error(writeback_stack):
+    # #372: a NON-IntegrationError from one Bazarr's task discovery must not abort
+    # the retry pass for the other instances. Anime's list_tasks blows up; the
+    # default instance must still fire its scan-disk trigger.
+    import asyncio
+    from types import SimpleNamespace
+
+    from subarr.completion_watcher import CompletionWatcher
+
+    ws = writeback_stack
+    # anime row first so the raising instance is processed before the survivor —
+    # under the bug this aborts the whole pass before instance 0 is reached.
+    entries = [
+        SimpleNamespace(id=1, series_id=10, canonical_path="@anime/Naruto/Season 1/Naruto.S01E01.mkv"),
+        SimpleNamespace(id=2, series_id=20, canonical_path="ShowTV/Season 1/ShowTV.S01E01.mkv"),
+    ]
+    marked: list[int] = []
+    prov = SimpleNamespace(
+        completed_without_bazarr=lambda max_age_s=0: entries,
+        mark_bazarr_triggered=lambda _id: marked.append(_id),
+    )
+    watcher = CompletionWatcher(provenance=prov, bundle_provider=lambda: ws.bundle)
+
+    async def boom():
+        raise RuntimeError("list_tasks exploded")  # NOT an IntegrationError
+
+    ws.bundle._clients["bazarr"]["anime"].list_tasks = boom
+
+    asyncio.run(watcher._pass_retry_bazarr_notify())
+
+    default_triggers = [
+        c
+        for c in ws.calls.get(("bazarr", ""), [])
+        if c["path"] == "/api/system/tasks" and c["method"] != "GET"
+    ]
+    assert default_triggers, "instance 0 must still fire despite anime's non-IntegrationError"
+    assert 2 in marked  # the default row was notified
+    assert 1 not in marked  # the anime row was NOT (its trigger never fired)


### PR DESCRIPTION
Phase-3 follow-up surfaced by the #161 Tier-2 review.

## Bug
`_pass_retry_bazarr_notify` wrapped only `trigger_task` in `except IntegrationError`, but the task-discovery call (`_bazarr_task_for` → `bz.list_tasks`) also only catches `IntegrationError`. So a **non-`IntegrationError`** from one Bazarr's `list_tasks` propagated and **aborted the retry pass for every remaining instance** that tick — a failure-isolation hole in the multi-instance writeback path.

## Fix
Wrap the whole per-instance loop body in a broad `except Exception` + `continue` + log, mirroring the sibling scheduler fan-out (`_maybe_poke_bazarr_for_stale_disk`). **Success-path semantics unchanged:** a row is marked notified only after its `trigger_task` succeeds; `IntegrationError` still logs + continues without marking. Routing is untouched — only failure isolation.

## Tests (TDD)
A `writeback_stack` test where the anime Bazarr's `list_tasks` raises a `RuntimeError` (processed before the survivor) and asserts the default instance **still fires** and the failed row is **not** marked. Full writeback suite 10✓; full backend suite green.

## Review
Tier-2 failure-mode lens: **clean**. Verified success/IntegrationError/not-configured/tid-None/non-IntegrationError control flow, idempotency (Bazarr scan-disk is library-wide + self-healing), and that routing is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)