### PR TITLE
#371: per-instance Bazarr scan-disk poke cooldown

### DIFF
--- a/src/subarr/scheduler.py
+++ b/src/subarr/scheduler.py
@@ -252,15 +252,15 @@ class Scheduler:
         if not stale:
             return {"fired": False, "reason": "no stale-disk items"}
 
-        # Cooldown check — initialised on first call (global to the poke op).
+        # #371: per-instance cooldown. A recent poke on one Bazarr instance must
+        # not gate a DIFFERENT instance whose rows just went stale, and a failed
+        # instance must not be left under cooldown — so the cooldown is keyed per
+        # instance (same base_url key as the task-id cache) and only advances for
+        # an instance that actually fired. (Was a single global timestamp.)
         now = time.time()
-        last = getattr(self, "_last_bazarr_poke_ts", 0.0)
-        if now - last < self._BAZARR_POKE_COOLDOWN_S:
-            return {
-                "fired": False,
-                "reason": f"cooldown ({int(self._BAZARR_POKE_COOLDOWN_S - (now - last))}s left)",
-                "stale_count": len(stale),
-            }
+        cooldowns = getattr(self, "_bazarr_poke_ts", None)
+        if cooldowns is None:
+            cooldowns = self._bazarr_poke_ts = {}
 
         # #161 P3: group stale rows by the Bazarr instance that owns their
         # library and fire one scan-disk per instance (was a single trigger on
@@ -285,6 +285,18 @@ class Scheduler:
             if not bz.is_configured():
                 instances.append({"instance": key, "fired": False, "reason": "bazarr not configured"})
                 continue
+            # #371: skip an instance still inside its own cooldown window.
+            since = now - cooldowns.get(key, 0.0)
+            if since < self._BAZARR_POKE_COOLDOWN_S:
+                instances.append(
+                    {
+                        "instance": key,
+                        "fired": False,
+                        "reason": f"cooldown ({int(self._BAZARR_POKE_COOLDOWN_S - since)}s left)",
+                        "count": slot["count"],
+                    }
+                )
+                continue
             try:
                 task_id = await self._discover_bazarr_scan_task(bz)
             except Exception as e:  # noqa: BLE001 — one bad instance must not abort the poke
@@ -297,6 +309,7 @@ class Scheduler:
             try:
                 await bz.trigger_task(task_id)
                 fired_any = True
+                cooldowns[key] = now  # #371: advance ONLY this instance's cooldown, on success
                 instances.append({"instance": key, "fired": True, "task_id": task_id, "count": slot["count"]})
                 log.info(
                     "coverage_walk: poked Bazarr %s scan-disk (%s) — %d stale-disk items",
@@ -307,8 +320,6 @@ class Scheduler:
             except Exception as e:  # noqa: BLE001
                 log.warning("coverage_walk: bazarr trigger_task failed on %s: %s", key, e)
                 instances.append({"instance": key, "fired": False, "reason": str(e)})
-        if fired_any:
-            self._last_bazarr_poke_ts = now
         return {"fired": fired_any, "stale_count": len(stale), "instances": instances}
 
     async def _discover_bazarr_scan_task(self, bz) -> str | None:
@@ -376,9 +387,9 @@ class Scheduler:
         # because of release-name mismatch or external sub source). The
         # completion watcher only fires Bazarr scan-disk after subarr's OWN
         # transcriptions; this covers the "existing sub Bazarr never
-        # noticed" case. Single library-wide trigger — Bazarr's scan-disk
-        # is global, no need to fan out per-file. Rate-limited via the
-        # _last_bazarr_poke_ts attribute so back-to-back walks don't spam.
+        # noticed" case. One library-wide trigger per Bazarr instance —
+        # Bazarr's scan-disk is global, no need to fan out per-file. Rate-limited
+        # per instance via the _bazarr_poke_ts map so back-to-back walks don't spam.
         bazarr_poked = await self._maybe_poke_bazarr_for_stale_disk(report.items)
 
         # Build the in-flight set from the provenance ledger so the

--- a/src/subarr/scheduler.py
+++ b/src/subarr/scheduler.py
@@ -245,8 +245,11 @@ class Scheduler:
         to re-scan is the only way to get those items off the wanted list
         (Bazarr only re-checks disk on its scheduled cadence otherwise).
 
-        Returns: dict with {fired, reason, stale_count, ...}. Logged for
-        the run-now JSON response so users can see what happened.
+        Returns: a dict logged for the run-now JSON response so users can see
+        what happened. Two shapes: the no-work early-out is
+        {fired: False, reason: "no stale-disk items"}; otherwise
+        {fired, stale_count, instances: [{instance, fired, reason|task_id, count}]}
+        — fired/skip reasons are per-instance (#371), not a single top-level reason.
         """
         stale = [it for it in items if getattr(it, "suggest_bazarr_rescan", False)]
         if not stale:

--- a/tests/test_writeback_routing.py
+++ b/tests/test_writeback_routing.py
@@ -247,3 +247,42 @@ def test_retry_bazarr_notify_isolates_one_instances_unexpected_error(writeback_s
     assert default_triggers, "instance 0 must still fire despite anime's non-IntegrationError"
     assert 2 in marked  # the default row was notified
     assert 1 not in marked  # the anime row was NOT (its trigger never fired)
+
+
+def test_poke_cooldown_is_per_instance(writeback_stack):
+    # #371: a recent poke on one Bazarr instance must NOT gate a DIFFERENT
+    # instance whose rows just went stale. Cooldown is keyed per instance.
+    import asyncio
+    import time
+    from types import SimpleNamespace
+
+    from subarr.scheduler import Scheduler
+
+    ws = writeback_stack
+    sched = Scheduler(None, bundle=ws.bundle)
+    # instance 0 (tv) was poked just now; the anime instance never was.
+    cooled = time.time()
+    sched._bazarr_poke_ts = {"http://bazarr-0.test": cooled}
+    items = [
+        SimpleNamespace(
+            suggest_bazarr_rescan=True,
+            file_canonical_path="@anime/Naruto/Season 1/Naruto.S01E01.mkv",
+            canonical_path=None,
+        ),
+        SimpleNamespace(
+            suggest_bazarr_rescan=True,
+            file_canonical_path="ShowTV/Season 1/ShowTV.S01E01.mkv",
+            canonical_path=None,
+        ),
+    ]
+    res = asyncio.run(sched._maybe_poke_bazarr_for_stale_disk(items))
+
+    def trig(key):
+        return [c for c in ws.calls.get(key, []) if c["path"] == "/api/system/tasks"]
+
+    assert trig(("bazarr", "anime")), "anime is not under cooldown — it must fire"
+    assert not trig(("bazarr", "")), "instance 0 is under its own cooldown — it must NOT fire"
+    assert res["fired"] is True  # the op fired (anime), even though instance 0 was gated
+    # per-instance advance: anime now cooled; instance 0's ts is unchanged (it didn't fire)
+    assert "http://bazarr-anime.test" in sched._bazarr_poke_ts
+    assert sched._bazarr_poke_ts["http://bazarr-0.test"] == cooled


### PR DESCRIPTION
Phase-3 follow-up surfaced by the #161 Tier-2 review. **Deliberate design call: global → per-instance cooldown** (the more faithful Phase-3 shape, what the review recommended).

## Problem
The scheduler's stale-disk poke gated on a single global `_last_bazarr_poke_ts` — checked once before the per-instance fan-out and advanced once after. With 2+ Bazarr stacks: (a) a recent poke on instance A blocked instance B's newly-stale rows for up to the cooldown, and (b) if A fired but B errored, the global timestamp advanced anyway so B stayed gated next tick.

## Fix
A `_bazarr_poke_ts` map keyed by the same `base_url` the task-id cache uses. Each instance is checked against **its own** window inside the loop, and its timestamp advances **only when that instance actually fires**. Routing is unchanged; the errs-toward-under-poking safety is preserved (no flood, never the wrong instance, self-heals).

## Tests (TDD)
A `writeback_stack` test: instance 0 is pre-cooled → the anime instance still fires, instance 0 stays gated, and only the fired instance's timestamp advances. Writeback suite 11✓, scheduler/walk suite 49✓, full backend suite green.

## Review
Tier-1/2 (correctness + regression + failure-mode): **clean**. Verified per-instance advance placement (success-only), key consistency between grouping and lookup, bounded map growth, single-stack parity, and that no consumer depends on the removed op-level `reason` (one docstring nit fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)