### PR TITLE
#368: upload movie subtitles to the owning Bazarr (not just scan-disk)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -479,6 +479,7 @@ async def lifespan(app_: FastAPI):
             source=SOURCE_SUBGENSCAN,
             series_id=job.series_id,
             sonarr_episode_id=job.sonarr_episode_id,
+            radarr_movie_id=job.radarr_movie_id,  # #368: movie upload provenance
         )
 
     app_.state.queue_feeder = PendingQueueFeeder(

--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -359,9 +359,18 @@ class CompletionWatcher:
                 self._provenance.mark_bazarr_triggered(entry.id)
                 log.info("bazarr upload OK for episode %d (ledger #%d)", entry.sonarr_episode_id, entry.id)
                 return True
-            # Movie path (radarr_movie_id) — we'd need radarr id on the
-            # entry. Provenance ledger has radarr_movie_id; not all paths
-            # populate it. Skip for now; fall through to scan-disk.
+            # #368: movie path — same direct upload, keyed by radarr_movie_id
+            # (now carried on the job → provenance). Routes to the owning Bazarr
+            # via _bazarr_for above. No radarr id → fall through to scan-disk.
+            if entry.radarr_movie_id:
+                await bz.upload_movie_subtitle(
+                    radarr_id=entry.radarr_movie_id,
+                    language="en",
+                    file_path=srt_path,
+                )
+                self._provenance.mark_bazarr_triggered(entry.id)
+                log.info("bazarr upload OK for movie %d (ledger #%d)", entry.radarr_movie_id, entry.id)
+                return True
             return False
         except IntegrationError as e:
             log.warning("bazarr upload failed (%s); falling back to scan-disk", e)

--- a/src/subarr/migrations/026_pending_queue_radarr_movie_id.sql
+++ b/src/subarr/migrations/026_pending_queue_radarr_movie_id.sql
@@ -1,0 +1,12 @@
+-- 026_pending_queue_radarr_movie_id.sql
+--
+-- #368: a pending job can now carry the owning movie's Radarr id so that, when
+-- subgen finishes, completion_watcher uploads the generated .srt straight to the
+-- owning Bazarr's /api/movies/subtitles (the episode path already does this via
+-- series_id + sonarr_episode_id). Without it, movie subtitles only reached Bazarr
+-- via the slower scan-disk fallback.
+--
+-- Nullable INTEGER: episode jobs and manual/path-only jobs leave it NULL and keep
+-- their existing behaviour; only movie jobs that resolved a Radarr id set it.
+-- Pre-existing rows get NULL, which is correct.
+ALTER TABLE pending_queue ADD COLUMN radarr_movie_id INTEGER;

--- a/src/subarr/pending_queue.py
+++ b/src/subarr/pending_queue.py
@@ -65,6 +65,10 @@ class PendingJob:
     # so a forced-only file is transcribed instead of skipped ("transcribe a
     # full sub anyway"). Default False = normal skip behaviour.
     ignore_forced: bool = False
+    # #368: owning movie's Radarr id, carried so completion_watcher can upload the
+    # finished .srt straight to the owning Bazarr (the movie analogue of
+    # series_id + sonarr_episode_id). None for episodes / path-only jobs.
+    radarr_movie_id: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -82,13 +86,14 @@ class PendingJob:
             "series_id": self.series_id,
             "sonarr_episode_id": self.sonarr_episode_id,
             "ignore_forced": self.ignore_forced,
+            "radarr_movie_id": self.radarr_movie_id,
         }
 
 
 _COLS = (
     "id, canonical_path, position, priority, status, "
     "audio_language_override, task, source, created_at, submitted_at, error, "
-    "series_id, sonarr_episode_id, ignore_forced"
+    "series_id, sonarr_episode_id, ignore_forced, radarr_movie_id"
 )
 
 # Statements built ONCE as constants. The only interpolation is the static
@@ -103,7 +108,7 @@ _SELECT = f"SELECT {_COLS} FROM pending_queue"  # nosec B608
 _Q_ACTIVE_BY_PATH = f"{_SELECT} WHERE canonical_path = ? AND status IN (?, ?) LIMIT 1"
 _Q_MAXPOS = "SELECT MAX(position) FROM pending_queue WHERE status = ? AND priority = ?"
 _Q_INSERT = (  # nosec B608
-    f"INSERT INTO pending_queue ({_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    f"INSERT INTO pending_queue ({_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 )
 _Q_GET = f"{_SELECT} WHERE id = ?"
 _Q_LIST_ALL = f"{_SELECT} ORDER BY priority DESC, position ASC, created_at ASC"
@@ -131,6 +136,7 @@ def _row(r: tuple) -> PendingJob:
         series_id=r[11],
         sonarr_episode_id=r[12],
         ignore_forced=bool(r[13]),
+        radarr_movie_id=r[14],
     )
 
 
@@ -162,6 +168,7 @@ class PendingQueueStore:
         series_id: int | None = None,
         sonarr_episode_id: int | None = None,
         ignore_forced: bool = False,
+        radarr_movie_id: int | None = None,
     ) -> PendingJob:
         """Add a job, or return the existing ACTIVE one for this path (dedup —
         we never double-queue a file that's already pending or in subgen).
@@ -201,6 +208,7 @@ class PendingQueueStore:
                 series_id=series_id,
                 sonarr_episode_id=sonarr_episode_id,
                 ignore_forced=ignore_forced,
+                radarr_movie_id=radarr_movie_id,
             )
             self._conn.execute(
                 _Q_INSERT,
@@ -219,6 +227,7 @@ class PendingQueueStore:
                     job.series_id,
                     job.sonarr_episode_id,
                     int(job.ignore_forced),
+                    job.radarr_movie_id,
                 ),
             )
             return job

--- a/src/subarr/scheduler.py
+++ b/src/subarr/scheduler.py
@@ -609,12 +609,16 @@ class Scheduler:
         # #66/#116 slice 6: route through the pending queue (the feeder drains
         # to subgen at target depth + writes provenance). Falls back to direct
         # submission if no pending_queue is wired (older callers / tests).
+        # #368: movies carry their Radarr id in bazarr_radarr_id (None for
+        # episodes) — thread it so completion_watcher can upload the movie .srt
+        # to the owning Bazarr instead of only the scan-disk fallback.
         if self._pending_queue is not None:
             job = self._pending_queue.enqueue(
                 canonical,
                 source="auto",
                 series_id=series_id,
                 sonarr_episode_id=item.bazarr_episode_id,
+                radarr_movie_id=item.bazarr_radarr_id,
             )
             return job.id, None
         scan = self._scan_store.create([canonical], reverse=False)
@@ -625,5 +629,6 @@ class Scheduler:
             source=SOURCE_SUBGENSCAN,
             series_id=series_id,
             sonarr_episode_id=item.bazarr_episode_id,
+            radarr_movie_id=item.bazarr_radarr_id,
         )
         return scan.id, None

--- a/tests/test_pending_queue.py
+++ b/tests/test_pending_queue.py
@@ -243,3 +243,20 @@ def test_resolve_orphaned_submitted_keeps_if_in_subgen(store):
     removed = store.resolve_orphaned_submitted(live, older_than_s=60.0)
     assert removed == 0
     assert store.get(job.id).status == STATUS_SUBMITTED
+
+
+def test_enqueue_persists_radarr_movie_id(store):
+    # #368: a movie job carries its Radarr id so completion_watcher can upload
+    # the finished .srt to the owning Bazarr. It must round-trip through the DB.
+    j = store.enqueue("Movies/Dune (2021)/Dune.mkv", source="auto", radarr_movie_id=909)
+    assert j.radarr_movie_id == 909
+    fetched = store.get(j.id)
+    assert fetched is not None and fetched.radarr_movie_id == 909
+    assert fetched.to_dict()["radarr_movie_id"] == 909
+
+
+def test_enqueue_radarr_movie_id_defaults_none(store):
+    # episodes / path-only jobs leave it NULL (byte-identical to before #368)
+    j = store.enqueue("TV/A/s01e01.mkv", source="manual")
+    assert j.radarr_movie_id is None
+    assert store.get(j.id).radarr_movie_id is None

--- a/tests/test_writeback_routing.py
+++ b/tests/test_writeback_routing.py
@@ -60,6 +60,48 @@ def test_subtitle_upload_routes_to_owning_bazarr(writeback_stack):
     assert not _subtitle_posts(ws.calls, ("bazarr", "")), "instance 0 must NOT receive it"
 
 
+def _movie_subtitle_posts(calls, key):
+    return [c for c in calls.get(key, []) if c["path"] == "/api/movies/subtitles"]
+
+
+def test_movie_subtitle_upload_routes_to_owning_bazarr(writeback_stack):
+    # #368: a completed MOVIE row with a known radarr_movie_id uploads its .srt
+    # directly to the owning Bazarr (instead of falling back to scan-disk).
+    import asyncio
+    from types import SimpleNamespace
+
+    ws = writeback_stack
+    canonical = "@anime/Naruto/Season 1/Naruto.S01E01.mkv"  # anime library → anime bazarr
+    _seed_srt(canonical)
+    w = _watcher(ws.bundle)
+    entry = SimpleNamespace(
+        id=7, canonical_path=canonical, sonarr_episode_id=None, series_id=None, radarr_movie_id=909
+    )
+
+    assert asyncio.run(w._try_upload_to_bazarr(entry)) is True
+    posts = _movie_subtitle_posts(ws.calls, ("bazarr", "anime"))
+    assert posts, "anime bazarr should receive the movie upload"
+    assert not _movie_subtitle_posts(ws.calls, ("bazarr", "")), "instance 0 must NOT receive it"
+
+
+def test_movie_upload_without_radarr_id_falls_back(writeback_stack):
+    # #368: no radarr_movie_id (and not an episode) → return False so the caller
+    # falls through to the (instance-aware) scan-disk trigger, as today.
+    import asyncio
+    from types import SimpleNamespace
+
+    ws = writeback_stack
+    canonical = "@anime/Naruto/Season 1/Naruto.S01E01.mkv"
+    _seed_srt(canonical)
+    w = _watcher(ws.bundle)
+    entry = SimpleNamespace(
+        id=8, canonical_path=canonical, sonarr_episode_id=None, series_id=None, radarr_movie_id=None
+    )
+
+    assert asyncio.run(w._try_upload_to_bazarr(entry)) is False
+    assert not _movie_subtitle_posts(ws.calls, ("bazarr", "anime"))
+
+
 def test_subtitle_upload_default_row_hits_instance0(writeback_stack):
     import asyncio
     from types import SimpleNamespace


### PR DESCRIPTION
The last multi-instance loose end (deferred from #161 Phase 3). `completion_watcher` uploaded generated **episode** subtitles straight to Bazarr, but the **movie** path was a stub that fell through to the slower scan-disk trigger — because the provenance entry never carried `radarr_movie_id`. This threads it through.

## What
- **Migration 026** — nullable `radarr_movie_id` column on `pending_queue` (pre-existing rows = NULL).
- **`PendingJob`** carries `radarr_movie_id` (field · `_COLS` · `_Q_INSERT` · `_row` round-trip).
- **Auto-queue** (`scheduler._enqueue`) populates it from the row's `bazarr_radarr_id` (None for episodes); the feeder writes it into provenance at submit time (`app.py`).
- **`completion_watcher`** movie path now calls `bz.upload_movie_subtitle(radarr_id=…)` on the **instance that owns the row** (`_bazarr_for`, #161 Phase 3), marks notified on success, and falls back to scan-disk when there's no radarr id.

The Bazarr client's `upload_movie_subtitle` already existed — this wires the provenance + the watcher. **Episodes and manual/path-only jobs are byte-identical** (`radarr_movie_id` stays NULL). The manual "fill this gap" on a movie still uses the (instance-aware) scan-disk fallback — a small follow-up, no regression.

## Tests (TDD)
- completion_watcher: movie upload routes to the owning Bazarr · falls back without a radarr id.
- pending_queue: `radarr_movie_id` round-trips through the DB · defaults None.
- Writeback (13) + pending_queue (24) + scheduler/backfill (36) suites green; migration idempotent; full backend suite running.

## Review
Tier-2 (correctness + data-integrity + writeback): **clean**. 15-column INSERT/SELECT alignment verified, instance-aware routing, `bazarr_radarr_id` = Bazarr's `radarrid`, no episode/manual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)