### PR TITLE
#363: NVML fallback for the GPU card when nvidia-smi is absent (WSL2-Docker)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ dependencies = [
     # is the Pallets lib Starlette uses for this (ubiquitous, audited). We don't
     # hand-roll session crypto.
     "itsdangerous>=2.0,<3.0",
+    # #363: NVML fallback for the GPU card when the nvidia-smi BINARY is absent
+    # but libnvidia-ml.so.1 IS mounted (the standard WSL2 + nvidia-container-
+    # toolkit container). nvidia-ml-py is NVIDIA's official pure-Python ctypes
+    # binding (provides `import pynvml`); it only dlopens the lib at call time,
+    # so it imports cleanly everywhere and just fails to {online:false} on hosts
+    # without a GPU. nvidia-smi stays the primary source.
+    "nvidia-ml-py>=12.0,<13.0",
 ]
 
 [project.optional-dependencies]

--- a/src/subarr/routers/gpu.py
+++ b/src/subarr/routers/gpu.py
@@ -76,10 +76,148 @@ def _parse_float(s: str) -> float | None:
         return None
 
 
+# ───── #363: NVML fallback ──────────────────────────────────────────────────
+#
+# On WSL2 + nvidia-container-toolkit the GPU compute libs (libcuda,
+# libnvidia-ml.so.1) are mounted but the nvidia-smi BINARY is not — so the
+# binary path above finds nothing even though CUDA runs fine. NVML IS present,
+# so query it directly (via NVIDIA's official pure-Python binding) to populate
+# the same vitals. nvidia-smi stays primary; this is the no-config fallback.
+
+
+def _nvml_shape(
+    *,
+    name: str,
+    mem_used_b: int | None,
+    mem_total_b: int | None,
+    mem_free_b: int | None,
+    util_gpu_pct: int | None,
+    util_mem_pct: int | None,
+    temp_c: int | None,
+    power_draw_mw: int | None,
+    power_limit_mw: int | None,
+    cc_major: int | None,
+    cc_minor: int | None,
+    driver_version: str | None,
+    procs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Pure: shape raw NVML readings into the exact /api/gpu result dict (bytes →
+    MiB, milliwatts → W, (major, minor) → the compute_cap float nvidia-smi emits)."""
+
+    def _mib(b: int | None) -> float | None:
+        return None if b is None else round(b / (1024 * 1024), 1)
+
+    def _w(mw: int | None) -> float | None:
+        return None if mw is None else round(mw / 1000.0, 1)
+
+    cc = float(f"{cc_major}.{cc_minor}") if cc_major is not None and cc_minor is not None else None
+    return {
+        "online": True,
+        "name": name,
+        "memory": {
+            "used_mib": _mib(mem_used_b),
+            "total_mib": _mib(mem_total_b),
+            "free_mib": _mib(mem_free_b),
+        },
+        "utilization": {"gpu_pct": util_gpu_pct, "memory_pct": util_mem_pct},
+        "temperature_c": temp_c,
+        "power": {"draw_w": _w(power_draw_mw), "limit_w": _w(power_limit_mw)},
+        "compute_cap": cc,
+        "driver_version": driver_version,
+        "processes": procs,
+    }
+
+
+def _nvml_try(fn: Any) -> Any:
+    """Best-effort single NVML query — some vitals (power, temp) are unsupported
+    on some GPUs and raise; treat those as None rather than failing the snapshot."""
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+def _nvml_processes(pynvml: Any, handle: Any) -> list[dict[str, Any]]:
+    """Running compute processes via NVML (best-effort; [] on any error)."""
+    out: list[dict[str, Any]] = []
+    try:
+        procs = pynvml.nvmlDeviceGetComputeRunningProcesses(handle)
+    except Exception:
+        return out
+    for p in procs:
+        used = getattr(p, "usedGpuMemory", None)
+        name = _nvml_try(lambda pid=p.pid: pynvml.nvmlSystemGetProcessName(pid))
+        if isinstance(name, bytes):
+            name = name.decode(errors="replace")
+        out.append(
+            {
+                "pid": int(p.pid),
+                "name": name or "unknown",
+                "memory_mib": round(used / (1024 * 1024), 1) if used else 0.0,
+            }
+        )
+    return out
+
+
+def _nvml_status() -> dict[str, Any] | None:
+    """NVML snapshot for when the nvidia-smi binary is absent. Returns the same
+    shape as the nvidia-smi path, or None when NVML itself is unavailable (no GPU
+    / lib not mounted) so the caller reports offline exactly as before. Never
+    raises — import, init, and every query are guarded."""
+    try:
+        import pynvml  # nvidia-ml-py; dlopens libnvidia-ml.so.1 lazily
+    except Exception:
+        return None
+    try:
+        pynvml.nvmlInit()
+    except Exception:
+        return None  # lib absent / no GPU — behave like nvidia-smi-missing
+    try:
+        h = pynvml.nvmlDeviceGetHandleByIndex(0)
+        name = pynvml.nvmlDeviceGetName(h)
+        if isinstance(name, bytes):
+            name = name.decode(errors="replace")
+        mem = pynvml.nvmlDeviceGetMemoryInfo(h)
+        util = _nvml_try(lambda: pynvml.nvmlDeviceGetUtilizationRates(h))
+        temp = _nvml_try(lambda: pynvml.nvmlDeviceGetTemperature(h, pynvml.NVML_TEMPERATURE_GPU))
+        cc = _nvml_try(lambda: pynvml.nvmlDeviceGetCudaComputeCapability(h))
+        driver = _nvml_try(pynvml.nvmlSystemGetDriverVersion)
+        if isinstance(driver, bytes):
+            driver = driver.decode(errors="replace")
+        return _nvml_shape(
+            name=name,
+            mem_used_b=getattr(mem, "used", None),
+            mem_total_b=getattr(mem, "total", None),
+            mem_free_b=getattr(mem, "free", None),
+            util_gpu_pct=getattr(util, "gpu", None) if util else None,
+            util_mem_pct=getattr(util, "memory", None) if util else None,
+            temp_c=temp,
+            power_draw_mw=_nvml_try(lambda: pynvml.nvmlDeviceGetPowerUsage(h)),
+            power_limit_mw=_nvml_try(lambda: pynvml.nvmlDeviceGetEnforcedPowerLimit(h)),
+            cc_major=cc[0] if cc else None,
+            cc_minor=cc[1] if cc else None,
+            driver_version=driver,
+            procs=_nvml_processes(pynvml, h),
+        )
+    except Exception as e:
+        log.debug("nvml fallback failed: %s", e)
+        return None
+    finally:
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:
+            pass
+
+
 @router.get("/gpu")
 async def gpu_status() -> dict[str, Any]:
     exe = _nvidia_smi_path()
     if exe is None:
+        # #363: no nvidia-smi binary (common on WSL2-Docker) — try NVML, which
+        # the container toolkit DOES mount, before reporting offline.
+        nvml = _nvml_status()
+        if nvml is not None:
+            return nvml
         return {"online": False, "error": "nvidia-smi not found"}
 
     legacy = False

--- a/tests/test_admin_gpu.py
+++ b/tests/test_admin_gpu.py
@@ -12,10 +12,12 @@ import pytest
 
 
 def test_gpu_returns_offline_when_smi_missing(app_with_stub, monkeypatch):
-    # Force nvidia-smi resolution to fail.
+    # Force nvidia-smi resolution to fail AND the #363 NVML fallback to be
+    # unavailable, so the result doesn't depend on the test host's GPU state.
     from subarr.routers import gpu as gpu_mod
 
     monkeypatch.setattr(gpu_mod, "_nvidia_smi_path", lambda: None)
+    monkeypatch.setattr(gpu_mod, "_nvml_status", lambda: None)
 
     r = app_with_stub.get("/api/gpu")
     assert r.status_code == 200
@@ -223,3 +225,50 @@ def test_logs_sse_emits_error_when_docker_down(app_with_stub):
     # #328: a dedicated event name (not "error") so the frontend can tell a
     # server-sent docker-down notice from an EventSource transport error.
     assert events[0][0] == "stream_error"
+
+
+# ───── #363: NVML fallback (nvidia-smi binary absent on WSL2-Docker) ─────────
+
+
+def test_nvml_shape_converts_units():
+    from subarr.routers.gpu import _nvml_shape
+
+    out = _nvml_shape(
+        name="NVIDIA GeForce RTX 4090",
+        mem_used_b=2 * 1024 * 1024 * 1024,  # 2 GiB
+        mem_total_b=24 * 1024 * 1024 * 1024,  # 24 GiB
+        mem_free_b=22 * 1024 * 1024 * 1024,
+        util_gpu_pct=37,
+        util_mem_pct=12,
+        temp_c=51,
+        power_draw_mw=120_000,  # 120 W
+        power_limit_mw=450_000,  # 450 W
+        cc_major=8,
+        cc_minor=9,
+        driver_version="550.54.14",
+        procs=[{"pid": 42, "name": "python", "memory_mib": 1024.0}],
+    )
+    assert out["online"] is True
+    assert out["name"] == "NVIDIA GeForce RTX 4090"
+    assert out["memory"]["used_mib"] == 2048.0
+    assert out["memory"]["total_mib"] == 24576.0
+    assert out["utilization"] == {"gpu_pct": 37, "memory_pct": 12}
+    assert out["temperature_c"] == 51
+    assert out["power"] == {"draw_w": 120.0, "limit_w": 450.0}
+    assert out["compute_cap"] == 8.9
+    assert out["driver_version"] == "550.54.14"
+    assert out["processes"] == [{"pid": 42, "name": "python", "memory_mib": 1024.0}]
+
+
+def test_gpu_falls_back_to_nvml_when_smi_missing(app_with_stub, monkeypatch):
+    from subarr.routers import gpu as gpu_mod
+
+    monkeypatch.setattr(gpu_mod, "_nvidia_smi_path", lambda: None)
+    monkeypatch.setattr(
+        gpu_mod, "_nvml_status", lambda: {"online": True, "name": "Tesla T4", "processes": []}
+    )
+    r = app_with_stub.get("/api/gpu")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["online"] is True
+    assert body["name"] == "Tesla T4"


### PR DESCRIPTION
On WSL2 + nvidia-container-toolkit the GPU compute libs (`libcuda`, `libnvidia-ml.so.1`) are mounted but the **nvidia-smi binary is not** — so `/api/gpu` returned `{online:false}` and the dashboard card showed "no telemetry" **even though CUDA ran fine** (subgen transcribed normally). The only workaround was bind-mounting the WSL host `nvidia-smi`, which nobody knows to add.

## Fix
When the binary is unavailable, fall back to **NVML** (which *is* present) via NVIDIA's official pure-Python binding (`nvidia-ml-py` → `import pynvml`), producing the **exact same `/api/gpu` shape**. nvidia-smi stays primary; NVML is the no-config fallback.

- `_nvml_status()` never raises — import, `nvmlInit`, and every query are guarded; returns `None` (→ offline, as before) on hosts without a GPU; `nvmlShutdown` always runs after a successful init.
- `_nvml_shape()` (pure) converts bytes→MiB, mW→W, `(major,minor)`→the `compute_cap` float; partial NVML (unsupported power/temp) degrades to null.
- Pure-Python dep, pinned `>=12.0,<13.0`; dlopens the lib lazily so it imports cleanly everywhere.

## Tests / verification
- TDD: `_nvml_shape` unit conversions + endpoint uses the fallback when the binary's missing; existing offline test stubs the fallback for determinism. gpu suite **12✓**, ruff clean, full backend suite running.
- **Smoke-tested against real NVML** (RTX 3060): correct name / 12 GiB mem / util / 47°C / 17.5W·170W / compute_cap **8.6** / driver / 25 processes — validates the actual attribute access the unit tests mock.

**Note:** activates once the image is rebuilt with the new dep (the next release); the running image is unaffected until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)