### PR TITLE
fix: degrade gracefully when an integration client is closed mid-request

### DIFF
--- a/src/subarr/integrations/base.py
+++ b/src/subarr/integrations/base.py
@@ -19,6 +19,19 @@ log = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT = httpx.Timeout(connect=3.0, read=90.0, write=10.0, pool=3.0)
 
 
+def _is_client_closed(e: BaseException) -> bool:
+    """True for httpx's RuntimeError("Cannot send a request, as the client has
+    been closed.") — raised when this client was aclose()'d out from under an
+    in-flight call. The live instance/credential rebuild
+    (_rebuild_runtime_clients) swaps the bundle and closes the old clients, so a
+    concurrent poll can hit this. It's our race, not an upstream failure — degrade
+    to IntegrationError so the request soft-fails and the next poll uses the new
+    client, instead of bubbling an uncaught 500. Match the full httpx phrase, not
+    a bare "closed", so unrelated RuntimeErrors ("Event loop is closed", "File is
+    closed") still surface as real bugs."""
+    return isinstance(e, RuntimeError) and "client has been closed" in str(e).lower()
+
+
 class IntegrationClient:
     """Base class. Holds an httpx.AsyncClient bound to a base_url."""
 
@@ -77,6 +90,10 @@ class IntegrationClient:
         except httpx.HTTPError as e:
             self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        except RuntimeError as e:
+            if not _is_client_closed(e):
+                raise
+            raise IntegrationError(f"{self.name} {path}: client closed mid-request (live rebuild)") from e
         self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
@@ -94,6 +111,10 @@ class IntegrationClient:
         except httpx.HTTPError as e:
             self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        except RuntimeError as e:
+            if not _is_client_closed(e):
+                raise
+            raise IntegrationError(f"{self.name} {path}: client closed mid-request (live rebuild)") from e
         self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")
@@ -116,6 +137,10 @@ class IntegrationClient:
         except httpx.HTTPError as e:
             self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        except RuntimeError as e:
+            if not _is_client_closed(e):
+                raise
+            raise IntegrationError(f"{self.name} {path}: client closed mid-request (live rebuild)") from e
         self._record(r.status_code)
         if r.status_code >= 400:
             raise IntegrationError(f"{self.name} {path}: HTTP {r.status_code}: {r.text[:200]}")

--- a/tests/test_base_post_put_contract.py
+++ b/tests/test_base_post_put_contract.py
@@ -135,3 +135,61 @@ async def test_post_204_no_content_returns_none():
     c = _client(handler)
     result = await c._post("/api/v3/command")
     assert result is None
+
+
+# ── closed-client race (live instance/credential rebuild) ──────────────────────
+# _rebuild_runtime_clients swaps the integration bundle and aclose()s the old
+# clients. A request already in flight on an old client then hits httpx's
+# RuntimeError("Cannot send a request, as the client has been closed.") — which
+# is NOT an httpx.HTTPError, so it used to escape _get/_post/_put as an uncaught
+# 500. It must degrade to IntegrationError (the next poll uses the new client).
+
+
+@pytest.mark.asyncio
+async def test_get_on_closed_client_degrades_to_integration_error():
+    c = IntegrationClient("http://up.test")
+    await c.aclose()  # simulate the rebuild teardown
+    with pytest.raises(IntegrationError):
+        await c._get("/api/v3/system/status")
+
+
+@pytest.mark.asyncio
+async def test_post_on_closed_client_degrades_to_integration_error():
+    c = IntegrationClient("http://up.test")
+    await c.aclose()
+    with pytest.raises(IntegrationError):
+        await c._post("/api/v3/command", json_body={"name": "x"})
+
+
+@pytest.mark.asyncio
+async def test_put_on_closed_client_degrades_to_integration_error():
+    c = IntegrationClient("http://up.test")
+    await c.aclose()
+    with pytest.raises(IntegrationError):
+        await c._put("/api/v3/episodefile/1", json_body={"language": "en"})
+
+
+@pytest.mark.asyncio
+async def test_unexpected_runtime_error_still_propagates():
+    """A RuntimeError that is NOT the closed-client case must surface, not be
+    swallowed as a soft IntegrationError."""
+
+    def boom(req: httpx.Request) -> httpx.Response:
+        raise RuntimeError("something genuinely broken")
+
+    c = _client(boom)
+    with pytest.raises(RuntimeError, match="genuinely broken"):
+        await c._get("/api/v3/system/status")
+
+
+@pytest.mark.asyncio
+async def test_event_loop_closed_runtime_error_propagates():
+    """The matcher targets httpx's "client has been closed" specifically — an
+    "Event loop is closed" RuntimeError (async teardown) must NOT be swallowed."""
+
+    def boom(req: httpx.Request) -> httpx.Response:
+        raise RuntimeError("Event loop is closed")
+
+    c = _client(boom)
+    with pytest.raises(RuntimeError, match="Event loop is closed"):
+        await c._get("/api/v3/system/status")


### PR DESCRIPTION
A request in flight while the user adds/edits an instance or credential (which runs `_rebuild_runtime_clients` → swaps the bundle + `aclose()`s the old clients) hit httpx's `RuntimeError("...client has been closed.")` — **not** an `httpx.HTTPError`, so it escaped `_get`/`_post`/`_put` as an uncaught 500 + a recorded crash_event (seen on the dev box during multi-instance live testing).

Catch the closed-client RuntimeError in all three base methods → `IntegrationError` (soft-fail; next poll uses the new client). Matches the full httpx phrase `"client has been closed"` (not a bare `"closed"`) so `"Event loop is closed"` / real bugs still surface; the breaker is **not** tripped (our race, not an upstream flap).

**TDD:** closed-client `_get`/`_post`/`_put` → `IntegrationError`; unrelated + `"Event loop is closed"` RuntimeErrors propagate. Full suite **1410✓**. Tier-2 failure-mode review clean after the matcher tightening. Subclass direct `self._client` calls share the gap → follow-up #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)