### PR TITLE
#392: harden subclass direct httpx calls vs the closed-client rebuild race

### DIFF
--- a/src/subarr/integrations/ollama.py
+++ b/src/subarr/integrations/ollama.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx
 
 from ..config import settings
+from .base import _is_client_closed
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +100,9 @@ class OllamaClient:
                 return str(v) if v else None
         except (httpx.HTTPError, ValueError):
             pass
+        except RuntimeError as e:  # #392: closed-client mid-rebuild → best-effort None
+            if not _is_client_closed(e):
+                raise
         return None
 
     async def tags(self) -> dict[str, Any]:
@@ -107,6 +111,10 @@ class OllamaClient:
             r = await self._client.get("/api/tags")
         except httpx.HTTPError as e:
             raise OllamaError(f"ollama /api/tags failed: {e}") from e
+        except RuntimeError as e:  # #392: client closed mid-rebuild → graceful
+            if not _is_client_closed(e):
+                raise
+            raise OllamaError("ollama /api/tags: client closed mid-request (live rebuild)") from e
         if r.status_code != 200:
             raise OllamaError(f"ollama /api/tags status {r.status_code}")
         return r.json()
@@ -151,6 +159,10 @@ class OllamaClient:
             r = await self._client.post("/api/generate", json=body)
         except httpx.HTTPError as e:
             raise OllamaError(f"ollama /api/generate failed: {e}") from e
+        except RuntimeError as e:  # #392: client closed mid-rebuild → graceful
+            if not _is_client_closed(e):
+                raise
+            raise OllamaError("ollama /api/generate: client closed mid-request (live rebuild)") from e
         if r.status_code != 200:
             raise OllamaError(f"ollama /api/generate status {r.status_code}: {r.text[:200]}")
         try:
@@ -237,6 +249,10 @@ class OllamaClient:
                         yield chunk
         except httpx.HTTPError as e:
             raise OllamaError(f"ollama /api/pull failed: {e}") from e
+        except RuntimeError as e:  # #392: client closed mid-rebuild → graceful
+            if not _is_client_closed(e):
+                raise
+            raise OllamaError("ollama /api/pull: client closed mid-request (live rebuild)") from e
         # New model — invalidate the vision-resolve cache.
         self.reset_vision_cache()
 
@@ -293,6 +309,10 @@ class OllamaClient:
             r = await self._client.post("/api/generate", json=body)
         except httpx.HTTPError as e:
             raise OllamaError(f"ollama vision: {e}") from e
+        except RuntimeError as e:  # #392: client closed mid-rebuild → graceful
+            if not _is_client_closed(e):
+                raise
+            raise OllamaError("ollama vision: client closed mid-request (live rebuild)") from e
         if r.status_code != 200:
             raise OllamaError(f"ollama vision HTTP {r.status_code}: {r.text[:200]}")
         try:

--- a/src/subarr/integrations/plex.py
+++ b/src/subarr/integrations/plex.py
@@ -47,7 +47,7 @@ import httpx
 
 from ..circuit_breaker import CircuitBreaker
 from . import IntegrationError
-from .base import _DEFAULT_TIMEOUT
+from .base import _DEFAULT_TIMEOUT, _is_client_closed
 
 log = logging.getLogger(__name__)
 
@@ -132,6 +132,12 @@ class PlexClient:
         except httpx.HTTPError as e:
             self._breaker.record_failure()
             raise IntegrationError(f"{self.name} {path}: {e}") from e
+        except RuntimeError as e:
+            # #392: the live _rebuild_runtime_clients aclose()d the client mid-call.
+            # Our race, not an upstream flap — degrade without tripping the breaker.
+            if not _is_client_closed(e):
+                raise
+            raise IntegrationError(f"{self.name} {path}: client closed mid-request (live rebuild)") from e
         if r.status_code >= 500:
             self._breaker.record_failure()
         else:

--- a/tests/test_closed_client_subclass_calls.py
+++ b/tests/test_closed_client_subclass_calls.py
@@ -1,0 +1,130 @@
+"""#392: subclass methods that call self._client.* directly must degrade the
+closed-client RuntimeError (raised when a live _rebuild_runtime_clients aclose()s
+the client mid-request) to the integration's own error type — NOT bubble a raw
+RuntimeError as a 500. Genuine (non-closed) RuntimeErrors must still propagate.
+
+We monkeypatch the client method to raise the exact errors rather than really
+closing the client: deterministic and isolation-proof (no real event-loop/pool
+state to leak across tests).
+
+NOTE: the integration classes are imported INSIDE each test. The conftest
+subarr_env fixture calls importlib.reload(subarr.integrations.*), minting NEW
+class objects per test — a pre-reload top-level import would make
+`pytest.raises(OllamaError)` miss the post-reload class the client raises.
+(Same gotcha handled the same way in test_vision_capability.py.)"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+# The exact phrase httpx raises when a request is sent on an aclose()d client.
+_CLOSED = "Cannot send a request, as the client has been closed."
+
+
+def _async_raise(exc):
+    async def _boom(*a, **k):
+        raise exc
+
+    return _boom
+
+
+def _sync_raise(exc):
+    def _boom(*a, **k):
+        raise exc
+
+    return _boom
+
+
+# ── Plex._request (central GET path) ──────────────────────────────────────────
+
+
+async def test_plex_request_closed_client_degrades_to_integration_error():
+    from subarr.integrations import IntegrationError
+    from subarr.integrations.plex import PlexClient
+
+    c = PlexClient(base_url="http://plex:32400", token="x")
+    c._client.get = _async_raise(RuntimeError(_CLOSED))
+    with pytest.raises(IntegrationError):
+        await c._request("/status/sessions", None)
+
+
+async def test_plex_request_unexpected_runtime_error_still_propagates():
+    from subarr.integrations import IntegrationError
+    from subarr.integrations.plex import PlexClient
+
+    c = PlexClient(base_url="http://plex:32400", token="x")
+    c._client.get = _async_raise(RuntimeError("genuinely broken"))
+    with pytest.raises(RuntimeError) as ei:
+        await c._request("/x", None)
+    assert "genuinely broken" in str(ei.value)
+    assert not isinstance(ei.value, IntegrationError)
+
+
+# ── Ollama direct-client methods ──────────────────────────────────────────────
+
+
+async def test_ollama_tags_closed_client_degrades_to_ollama_error():
+    from subarr.integrations.ollama import OllamaClient, OllamaError
+
+    c = OllamaClient(base_url="http://ollama:11434", model="m")
+    c._client.get = _async_raise(RuntimeError(_CLOSED))
+    with pytest.raises(OllamaError):
+        await c.tags()
+
+
+async def test_ollama_generate_closed_client_degrades_to_ollama_error():
+    from subarr.integrations.ollama import OllamaClient, OllamaError
+
+    c = OllamaClient(base_url="http://ollama:11434", model="m")
+    c._client.post = _async_raise(RuntimeError(_CLOSED))
+    with pytest.raises(OllamaError):
+        await c.generate("hi")
+
+
+async def test_ollama_vision_describe_closed_client_degrades_to_ollama_error():
+    from subarr.integrations.ollama import OllamaClient, OllamaError
+
+    c = OllamaClient(base_url="http://ollama:11434", model="m")
+    c._client.post = _async_raise(RuntimeError(_CLOSED))
+    # pass model + image_b64 so it reaches the self._client.post (skips
+    # resolve_vision_model + the separate image-fetch client).
+    with pytest.raises(OllamaError):
+        await c.vision_describe(image_b64="Zm9v", prompt="describe", model="llava")
+
+
+async def test_ollama_version_closed_client_returns_none():
+    # version() is best-effort (returns None on any failure) — a closed client
+    # must fall into that None path, not raise.
+    from subarr.integrations.ollama import OllamaClient
+
+    c = OllamaClient(base_url="http://ollama:11434", model="m")
+    c._client.get = _async_raise(RuntimeError(_CLOSED))
+    assert await c.version() is None
+
+
+async def test_ollama_pull_model_closed_client_degrades_to_ollama_error():
+    from subarr.integrations.ollama import OllamaClient, OllamaError
+
+    c = OllamaClient(base_url="http://ollama:11434", model="m")
+    # pull_model opens `async with self._client.stream(...)`; the stream() call
+    # itself raises the closed-client error before the context is entered.
+    c._client.stream = _sync_raise(RuntimeError(_CLOSED))
+    with pytest.raises(OllamaError):
+        async for _ in c.pull_model("m"):
+            pass
+
+
+async def test_ollama_generate_unexpected_runtime_error_propagates_unwrapped():
+    # A genuine RuntimeError (e.g. "Event loop is closed") must propagate as-is,
+    # NOT be mistranslated to OllamaError (OllamaError IS a RuntimeError, so the
+    # _is_client_closed phrase match is what keeps them distinct).
+    from subarr.integrations.ollama import OllamaClient, OllamaError
+
+    c = OllamaClient(base_url="http://ollama:11434", model="m")
+    c._client.post = _async_raise(RuntimeError("Event loop is closed"))
+    with pytest.raises(RuntimeError) as ei:
+        await c.generate("hi")
+    assert "Event loop is closed" in str(ei.value)
+    assert not isinstance(ei.value, OllamaError)


### PR DESCRIPTION
Closes #392. Follow-up to the base-client closed-client fix (#393), applying the same `_is_client_closed` translation to the subclass methods that call `self._client.*` directly and caught only `httpx.HTTPError`:

- **plex.\_request** (central GET path) → IntegrationError
- **ollama** version()→None (best-effort), tags/generate/pull_model/vision_describe → OllamaError

Closed-client RuntimeError (raised when a live `_rebuild_runtime_clients` aclose()s the client mid-request) now degrades gracefully instead of bubbling a 500; the breaker is NOT tripped (our race, not an upstream flap); genuine RuntimeErrors still propagate. bazarr's broad `except Exception` was already covered.

Tests monkeypatch the client method to raise the exact errors (deterministic, isolation-proof) and re-import the integration classes inside each test (conftest reloads the modules per-test). Backend 1434✓ (8 new), ruff clean.