### PR TITLE
#359 (immune slice): subarr-side SRT re-timer

### DIFF
--- a/docs/superpowers/plans/2026-06-30-359-srt-retimer.md
+++ b/docs/superpowers/plans/2026-06-30-359-srt-retimer.md
@@ -1,0 +1,420 @@
+# #359 SRT Re-timer (immune slice) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a pure, #171-immune SRT re-timer in subarr — extend over-CPS cues into the available gap before the next cue (+ pad micro-cues), proving it measurably reduces CPS without new overlaps.
+
+**Architecture:** A new pure module `src/subarr/subtitle_retime.py` (SRT→SRT). Reuses `subtitle_readability`'s `Cue`/`parse_srt`/`Cue.cps`/`Cue.char_count` (the linter) and adds the missing serialize half (`render_srt`). The transform extends only each cue's *end* forward, clamped to the gap (`min_gap_ms`) and `max_cue_ms`; idempotent; never shortens or creates overlaps.
+
+**Tech Stack:** Python 3.11, pytest (strict pytest-asyncio — but these are sync tests), ruff. Spec: `docs/superpowers/specs/2026-06-30-359-srt-retimer-design.md`.
+
+**Branch:** `feat/359-srt-retimer` (already created, spec committed).
+
+**Conventions:**
+- TDD: failing test → run red → minimal impl → run green → commit. Run the specific test file, not the whole suite, until the final task.
+- `Cue` lives in `subtitle_readability`: `Cue(index:int, start_ms:int, end_ms:int, lines:list[str])`, with read-only properties `text`, `duration_s`, `char_count` (`sum(len(line)) + (line_count-1)`), `max_cpl`, `line_count`, `cps` (`char_count/duration_s`, `inf` if `duration_s==0`). Constants: `MAX_CPS=20.0`, `CRITICAL_CPS=25.0`, `MIN_DURATION_S=0.833`, `MAX_DURATION_S=7.0`.
+- Stay pure: `retime_cues` returns NEW `Cue`s; never mutates inputs.
+- Commit footer: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `RetimeParams` + `retime_cues` (the core transform)
+
+**Files:**
+- Create: `src/subarr/subtitle_retime.py`
+- Test: `tests/test_subtitle_retime.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""#359: pure SRT re-timer — extend over-CPS cues into the gap before the next
+cue (+ pad micro-cues), clamped to the gap and max duration; idempotent; never
+shortens or creates overlaps. Base-agnostic (operates on final cue timestamps)."""
+from __future__ import annotations
+
+from subarr.subtitle_readability import Cue
+from subarr.subtitle_retime import RetimeParams, retime_cues
+
+P = RetimeParams()  # target_cps=17, min_cue_ms=1000, min_gap_ms=100, max_cue_ms=7000
+
+
+def _cue(i, start_ms, end_ms, text="x"):
+    return Cue(index=i, start_ms=start_ms, end_ms=end_ms, lines=text.split("\n"))
+
+
+def test_hot_cue_extended_toward_target_when_gap_available():
+    # 80 chars in 2.0s = 40 cps; next cue starts at 60s (huge gap).
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "next")]
+    out = retime_cues(cues, P)
+    # target 17 cps over 80 chars → ~4706ms duration; capped by max_cue_ms=7000.
+    assert out[0].end_ms == 80 * 1000 // 17 or abs(out[0].end_ms - round(80 / 17 * 1000)) <= 1
+    assert out[0].cps <= P.target_cps + 0.5
+    assert out[0].start_ms == 0 and out[1].start_ms == 60000  # starts never move
+
+
+def test_micro_cue_padded_to_min_duration():
+    # 3 chars in 0.3s — comfortable CPS but a sub-1s micro-cue; gap is wide.
+    cues = [_cue(1, 0, 300, "ok"), _cue(2, 30000, 31000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == P.min_cue_ms  # padded to 1000ms
+
+
+def test_no_gap_leaves_cue_unchanged_as_residual():
+    # Hot cue but the next cue starts immediately (no room to extend).
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 4000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == 2000  # untouched — Aftercare monitors the residual
+
+
+def test_min_gap_always_preserved():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 3000, 5000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms <= 3000 - P.min_gap_ms  # never within min_gap of next start
+
+
+def test_never_exceeds_max_cue_ms():
+    # Huge gap + very hot cue → extension capped at max_cue_ms.
+    cues = [_cue(1, 0, 1000, "x" * 300), _cue(2, 60000, 61000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == P.max_cue_ms  # 7000
+
+
+def test_never_shortens_a_cue():
+    # Already-long comfortable cue; nothing should pull its end in.
+    cues = [_cue(1, 0, 5000, "x" * 10), _cue(2, 60000, 61000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms >= 5000
+
+
+def test_last_cue_grows_up_to_max_cue_ms():
+    cues = [_cue(1, 0, 1000, "x" * 80)]  # no successor
+    out = retime_cues(cues, P)
+    # target end ~4706 < max 7000, and no next-cue bound → take the target.
+    assert abs(out[0].end_ms - round(80 / 17 * 1000)) <= 1
+
+
+def test_overlapping_input_not_made_worse():
+    # Input already overlaps (cue1 ends after cue2 starts). Don't extend further.
+    cues = [_cue(1, 0, 5000, "x" * 80), _cue(2, 3000, 6000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == 5000  # unchanged; no new/larger overlap
+
+
+def test_idempotent():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "n")]
+    once = retime_cues(cues, P)
+    twice = retime_cues(once, P)
+    assert [(c.start_ms, c.end_ms) for c in once] == [(c.start_ms, c.end_ms) for c in twice]
+
+
+def test_inputs_not_mutated():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "n")]
+    retime_cues(cues, P)
+    assert cues[0].end_ms == 2000  # original untouched (pure)
+```
+
+- [ ] **Step 2: Run red**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'subarr.subtitle_retime'`.
+
+- [ ] **Step 3: Implement the module**
+
+`src/subarr/subtitle_retime.py`:
+```python
+"""#359: pure, base-agnostic SRT re-timer (the #171-immune CPS lever).
+
+Extends each over-CPS cue's END forward into the available gap before the next
+cue, and pads sub-min-duration micro-cues, clamped so it never overlaps the next
+cue (min_gap preserved) or exceeds max_cue_ms. Never moves a start, never
+shortens a cue, never worsens an existing overlap. Idempotent.
+
+Operates purely on cue timestamps + text, so it is independent of how the cues
+were produced (stable-ts regroup or the drop-stable-ts Netflix segmenter) — this
+is the lever that survives the #171 crossing and is the eventual Path C
+contribution. RetimeParams defaults are placeholders pending arena tuning (#359
+follow-on)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .subtitle_readability import Cue, parse_srt
+
+
+@dataclass(frozen=True)
+class RetimeParams:
+    target_cps: float = 17.0  # extend toward this CPS (below MAX_CPS=20 comfort bar)
+    min_cue_ms: int = 1000  # pad micro-cues to this (clears the 833ms too_short floor)
+    min_gap_ms: int = 100  # inter-cue gap always preserved
+    max_cue_ms: int = 7000  # never display longer than this (MAX_DURATION_S)
+
+
+def retime_cues(cues: list[Cue], params: RetimeParams = RetimeParams()) -> list[Cue]:
+    out: list[Cue] = []
+    n = len(cues)
+    for i, c in enumerate(cues):
+        hard_cap = c.start_ms + params.max_cue_ms
+        if i + 1 < n:
+            bound = min(cues[i + 1].start_ms - params.min_gap_ms, hard_cap)
+        else:
+            bound = hard_cap
+        # No room (gap too small, or the input already overlaps) → leave as-is.
+        if bound <= c.end_ms:
+            out.append(Cue(index=c.index, start_ms=c.start_ms, end_ms=c.end_ms, lines=list(c.lines)))
+            continue
+        desired = max(c.end_ms, c.start_ms + params.min_cue_ms)  # min-duration pad
+        if params.target_cps > 0 and c.cps > params.target_cps:  # cps extension
+            desired = max(desired, c.start_ms + round(c.char_count / params.target_cps * 1000))
+        new_end = max(c.end_ms, min(desired, bound))  # clamp to gap/max; never shorten
+        out.append(Cue(index=c.index, start_ms=c.start_ms, end_ms=new_end, lines=list(c.lines)))
+    return out
+
+
+def render_srt(cues: list[Cue]) -> str:
+    raise NotImplementedError  # Task 2
+
+
+def retime_srt(srt_text: str, params: RetimeParams = RetimeParams()) -> str:
+    raise NotImplementedError  # Task 3
+```
+(`render_srt`/`retime_srt` are stubbed so the module imports; filled in Tasks 2-3. `parse_srt` import is used in Task 3 — keep it.)
+
+- [ ] **Step 4: Run green**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -q`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `python -m ruff check src/subarr/subtitle_retime.py tests/test_subtitle_retime.py`
+(If ruff flags the unused `parse_srt` import (F401), it's used in Task 3 — add a `# noqa: F401` for now OR proceed to Task 2/3 first. Cleanest: keep it and accept the transient warning until Task 3, or import it in Task 3. To keep ruff green now, drop the `parse_srt` import here and add it in Task 3.)
+```bash
+git add src/subarr/subtitle_retime.py tests/test_subtitle_retime.py
+git commit -m "feat(#359): retime_cues — pure CPS re-timing transform (immune lever)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `render_srt` + `_ms_to_ts` (serialize half)
+
+**Files:**
+- Modify: `src/subarr/subtitle_retime.py`
+- Test: append to `tests/test_subtitle_retime.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_ms_to_ts_formats_correctly():
+    from subarr.subtitle_retime import _ms_to_ts
+
+    assert _ms_to_ts(0) == "00:00:00,000"
+    assert _ms_to_ts(3_661_123) == "01:01:01,123"
+    assert _ms_to_ts(-5) == "00:00:00,000"  # clamps negatives
+
+
+def test_render_srt_roundtrips_through_parse():
+    from subarr.subtitle_readability import parse_srt
+    from subarr.subtitle_retime import render_srt
+
+    cues = [_cue(1, 0, 2000, "line one\nline two"), _cue(2, 2500, 4000, "next")]
+    text = render_srt(cues)
+    back = parse_srt(text)
+    assert [(c.start_ms, c.end_ms, c.lines) for c in back] == [
+        (0, 2000, ["line one", "line two"]),
+        (2500, 4000, ["next"]),
+    ]
+
+
+def test_render_srt_reindexes_1_based():
+    cues = [_cue(7, 0, 1000, "a"), _cue(9, 2000, 3000, "b")]
+    from subarr.subtitle_retime import render_srt
+
+    text = render_srt(cues)
+    assert text.split("\n")[0] == "1"
+    assert "\n2\n" in "\n" + text  # second block re-indexed to 2
+```
+
+- [ ] **Step 2: Run red**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -k "ms_to_ts or render_srt" -q`
+Expected: FAIL — `_ms_to_ts` import error / `render_srt` raises `NotImplementedError`.
+
+- [ ] **Step 3: Implement**
+
+Replace the `render_srt` stub in `subtitle_retime.py`:
+```python
+def _ms_to_ts(ms: int) -> str:
+    ms = max(0, int(ms))
+    h, ms = divmod(ms, 3_600_000)
+    m, ms = divmod(ms, 60_000)
+    s, ms = divmod(ms, 1_000)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def render_srt(cues: list[Cue]) -> str:
+    """Serialize cues to SRT text, re-indexed 1..N (the inverse of parse_srt)."""
+    blocks = []
+    for i, c in enumerate(cues, start=1):
+        stamp = f"{_ms_to_ts(c.start_ms)} --> {_ms_to_ts(c.end_ms)}"
+        blocks.append(f"{i}\n{stamp}\n" + "\n".join(c.lines))
+    return "\n\n".join(blocks) + "\n" if blocks else ""
+```
+
+- [ ] **Step 4: Run green**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -q`
+Expected: PASS (13 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `python -m ruff check src/subarr/subtitle_retime.py`
+```bash
+git add src/subarr/subtitle_retime.py tests/test_subtitle_retime.py
+git commit -m "feat(#359): render_srt + _ms_to_ts (SRT serialize half)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `retime_srt` end-to-end + the CPS-reduction proof
+
+**Files:**
+- Modify: `src/subarr/subtitle_retime.py` (fill `retime_srt`; ensure `parse_srt` imported)
+- Test: append to `tests/test_subtitle_retime.py`
+
+- [ ] **Step 1: Write the failing proof tests**
+
+```python
+# A translate-mode-style fixture: several cramped, high-CPS cues with real gaps
+# between them (translated text overruns the speech window).
+_HOT_SRT = """1
+00:00:00,000 --> 00:00:02,000
+This is a very long translated line that crams far too many characters
+
+2
+00:00:05,000 --> 00:00:06,200
+Another dense cue with way more text than fits comfortably here now
+
+3
+00:00:20,000 --> 00:00:20,300
+hi
+"""
+
+# A comfortable transcribe-mode fixture: low CPS, adequate durations.
+_CALM_SRT = """1
+00:00:00,000 --> 00:00:03,000
+Hello there.
+
+2
+00:00:04,000 --> 00:00:07,000
+General Kenobi.
+"""
+
+
+def test_retime_srt_reduces_cps_and_zeroes_micro_cues_no_new_overlap():
+    from subarr.subtitle_readability import CRITICAL_CPS, analyze_srt, parse_srt
+    from subarr.subtitle_retime import retime_srt
+
+    before = parse_srt(_HOT_SRT)
+    after = parse_srt(retime_srt(_HOT_SRT))
+
+    def median_cps(cues):
+        vals = sorted(c.cps for c in cues if c.duration_s > 0)
+        return vals[len(vals) // 2]
+
+    def pct_over_critical(cues):
+        return sum(1 for c in cues if c.cps > CRITICAL_CPS) / len(cues)
+
+    def micro_count(cues):
+        return sum(1 for c in cues if 0 < c.duration_s < 0.833)
+
+    assert median_cps(after) < median_cps(before)
+    assert pct_over_critical(after) <= pct_over_critical(before)
+    assert micro_count(after) == 0
+    # no NEW overlaps introduced
+    rep = analyze_srt(retime_srt(_HOT_SRT))
+    assert rep.counts.get("overlap", 0) == 0
+
+
+def test_retime_srt_leaves_comfortable_input_essentially_unchanged():
+    from subarr.subtitle_readability import parse_srt
+    from subarr.subtitle_retime import retime_srt
+
+    before = parse_srt(_CALM_SRT)
+    after = parse_srt(retime_srt(_CALM_SRT))
+    # already comfortable + adequate duration → no end moved.
+    assert [c.end_ms for c in before] == [c.end_ms for c in after]
+```
+
+- [ ] **Step 2: Run red**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -k "retime_srt" -q`
+Expected: FAIL — `retime_srt` raises `NotImplementedError`.
+
+- [ ] **Step 3: Implement `retime_srt`**
+
+Replace the `retime_srt` stub:
+```python
+def retime_srt(srt_text: str, params: RetimeParams = RetimeParams()) -> str:
+    """Parse → re-time → re-render. The convenience entry point."""
+    return render_srt(retime_cues(parse_srt(srt_text), params))
+```
+(`parse_srt` is already imported at the top from Task 1; if Task 1's lint step dropped it, re-add `from .subtitle_readability import Cue, parse_srt`.)
+
+- [ ] **Step 4: Run green**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -q`
+Expected: PASS (15 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+Run: `python -m ruff check src/subarr/subtitle_retime.py tests/test_subtitle_retime.py`
+```bash
+git add src/subarr/subtitle_retime.py tests/test_subtitle_retime.py
+git commit -m "feat(#359): retime_srt entry point + CPS-reduction proof tests
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full verification + PR
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Full module test + ruff**
+
+Run: `python -m pytest tests/test_subtitle_retime.py -q && python -m ruff check src/subarr/ tests/`
+Expected: 15 passed; All checks passed.
+
+- [ ] **Step 2: Quick regression (nothing else imports the new module yet, but confirm the suite is clean)**
+
+Run: `python -m pytest tests/ -k "readability or retime or aftercare or arena" -q`
+Expected: all pass (the re-timer is standalone; this confirms no accidental coupling).
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/359-srt-retimer
+gh pr create --title "#359 (immune slice): subarr-side SRT re-timer" \
+  --body "First slice of #359 — the #171-immune CPS lever. New pure module \`subtitle_retime.py\`: extend over-CPS cues into the gap before the next cue (+ pad micro-cues), clamped to gap/max, idempotent, never shortens or creates overlaps. Operates on final cue timestamps so it's base-agnostic (survives the drop-stable-ts crossing; the eventual Path C contribution). Proven via analyze_srt: median CPS down, micro-cues→0, no new overlaps, comfortable input untouched. Deferred (follow-ons): pipeline wiring, corpus tuning, per-language defaults, the bake. Spec: docs/superpowers/specs/2026-06-30-359-srt-retimer-design.md. <N> tests, ruff clean."
+```
+
+- [ ] **Step 4: Merge (Tier-0/1 — pure self-contained module, read-diff review)**
+
+```bash
+gh pr merge --squash --admin --delete-branch
+git checkout main && git pull --ff-only
+```
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Spec coverage:** Task 1 = `retime_cues` + `RetimeParams` (spec §Components, §Algorithm, §Testing); Task 2 = `render_srt`/`_ms_to_ts` (spec §Components, §Testing render); Task 3 = `retime_srt` + the proof (spec §Proving it, §Acceptance); Task 4 = verify + ship. Deferred items (pipeline/corpus/bake/start-extension) are not tasked — correct, they're out of scope.
+- **Type consistency:** `RetimeParams(target_cps, min_cue_ms, min_gap_ms, max_cue_ms)`, `retime_cues(cues, params)`, `render_srt(cues)`, `retime_srt(text, params)`, `_ms_to_ts(ms)` — names identical across tasks. `Cue` fields (`index/start_ms/end_ms/lines`) + `char_count`/`cps`/`duration_s` match `subtitle_readability`.
+- **Watch item:** the Task-1 `parse_srt` import is only used by `retime_srt` (Task 3). To keep ruff green at Task 1, either drop it there and add in Task 3, or `# noqa: F401`. Plan calls this out in both places.

--- a/docs/superpowers/specs/2026-06-30-359-srt-retimer-design.md
+++ b/docs/superpowers/specs/2026-06-30-359-srt-retimer-design.md
@@ -1,0 +1,98 @@
+# #359 (immune slice) — subarr-side SRT re-timer
+
+**Issue:** [#359](https://github.com/coaxk/subarr/issues/359) — tighten out-of-box subtitle quality (CPS).
+**Date:** 2026-06-30
+**Scope:** the **#171-immune slice** only — build + prove a base-agnostic re-timing post-pass. Explicitly defers production-pipeline wiring, corpus-wide tuning, per-language defaults, and the eventual bake.
+
+## Problem & framing
+
+CPS (chars-per-second) is the residual readability issue surfaced in Aftercare, worst in translate mode (translated text is longer than the original speech window, so no decoding/segmentation setting fits it under a comfortable CPS without more screen time). #359 names two CPS levers:
+
+1. **Re-timing post-pass** — extend a hot cue into the available gap before the next cue. "The only thing that breaks the translate-mode floor; helps everyone, harmless for transcribe."
+2. **stable-ts word-timestamp segmentation/regroup (#171)** — the source-side lever.
+
+Lever 2 is **#171-entangled**: our entire current CPS control is `CUSTOM_REGROUP='cm_sl=84_sl=42++++++1'` ("strongpad"), a **stable-ts-only** regroup config that goes inert if/when upstream's `drop-stable-ts` is adopted. Lever 1 (re-timing) operates on **cue timestamps**, which survive the stable-ts→faster-whisper transition — it's base-agnostic and is exactly the "CPS-padding pass" Path C would contribute upstream.
+
+**This slice builds Lever 1**, the immune one. It does not touch `CUSTOM_REGROUP`.
+
+## Decision: subarr-side pure SRT→SRT transform
+
+Re-timing only needs each cue's start/end times + text length — all present in the SRT. So it's a pure SRT→SRT function in subarr, **not** a subgen change:
+
+- **100% #171-immune** — operates on the final SRT; agnostic to how cues were produced (stable-ts regroup or Netflix segmenter).
+- **Prove-first** — no image rebuilds; validated in-process against the existing readability metrics. Matches #359's "off-app, prove it, then bake" method.
+- **On-brand** — "subarr owns end-to-end quality"; reuses `subtitle_readability` instead of duplicating SRT logic in subgen.
+- The *bake* (a subgen-side default, or the upstream Path C PR) becomes an explicit follow-on once the lever is proven — not a blocker, and not a footgun.
+
+## Components — new `src/subarr/subtitle_retime.py`
+
+Reuses `Cue` / `parse_srt` / `Cue.cps` / `Cue.duration` from `subtitle_readability` (read-only linter). Adds the missing serialize-half + the transform:
+
+- `render_srt(cues: list[Cue]) -> str` — serialize cues back to SRT text (timestamps `HH:MM:SS,mmm`, blank-line separated, re-indexed 1..N).
+- `@dataclass(frozen=True) RetimeParams` — the tunable knobs with placeholder defaults (arena-tuned in the follow-on, NOT hand-tuned here):
+  - `target_cps: float = 17.0` (comfortable target)
+  - `min_cue_ms: int = 1000` (kill sub-1s micro-cues)
+  - `min_gap_ms: int = 100` (inter-cue gap always preserved)
+  - `max_cue_ms: int = 7000` (Netflix max display)
+- `retime_cues(cues: list[Cue], params: RetimeParams = RetimeParams()) -> list[Cue]` — pure transform, returns new `Cue`s with adjusted `end_ms`.
+- `retime_srt(srt_text: str, params: RetimeParams = RetimeParams()) -> str` — `parse_srt → retime_cues → render_srt`.
+
+## Algorithm (`retime_cues`)
+
+Walk cues in start order. For each cue, **extend only its end forward** — never move the start, never shorten, never create an overlap:
+
+1. **Available boundary** `bound_ms`:
+   - if there is a next cue: `next.start_ms - min_gap_ms`
+   - else (last cue): `cue.end_ms + (max_cue_ms - cue.duration_ms)` i.e. allow growth up to `max_cue_ms`.
+   - Always also cap the new end at `cue.start_ms + max_cue_ms`.
+   - If `bound_ms <= cue.end_ms` (no room, or input already overlaps), the cue is returned unchanged.
+2. **Min-duration pad:** desired_end = `max(cue.end_ms, cue.start_ms + min_cue_ms)`.
+3. **CPS extension:** if `cue.cps > target_cps`, `cps_end = cue.start_ms + round(chars / target_cps * 1000)`; `desired_end = max(desired_end, cps_end)`.
+   - `chars` = the same displayable-char count `Cue.cps` uses (reuse, don't redefine, so the decision and the target agree).
+4. **Clamp:** `new_end = min(desired_end, bound_ms, cue.start_ms + max_cue_ms)`; `new_end = max(new_end, cue.end_ms)` (never shorten).
+5. Emit the cue with `end_ms = new_end`.
+
+**Best-effort:** when the gap is too small to reach `target_cps`, the cue takes the partial extension available; the residual is what Aftercare monitors. Cues already ≤ target and ≥ min duration pass through untouched. **Idempotent:** running on already-re-timed output yields identical output (extensions are monotonic and clamped).
+
+## Proving it (this slice's deliverable)
+
+A measurement test using `subtitle_readability.analyze_srt` before/after on representative SRT fixtures (the high-CPS translate-mode sample is the key case):
+- **median CPS decreases**, **%cues >25 CPS decreases**, **sub-`min_cue_ms` micro-cue count → 0**,
+- **zero new overlaps** introduced (an overlap regression is a hard fail),
+- a transcribe-mode sample with comfortable CPS + adequate gaps is **left ~unchanged** (harmless when not needed).
+
+Full cross-clip arena corpus tuning (picking the real `RetimeParams` defaults across translate/transcribe × languages incl. JP→EN, English SDH) is the **follow-on**, using this proven mechanism.
+
+## Testing (TDD)
+
+`retime_cues` unit tests:
+- hot cue (cps>target) with a large following gap → end extended toward the target-cps end; resulting cps ≈ target.
+- micro-cue (duration < min_cue_ms) with gap → padded to `min_cue_ms`.
+- hot cue with **no** gap (next cue immediately follows) → unchanged (residual).
+- min-gap preserved: extended end ≤ `next.start_ms - min_gap_ms` always.
+- never exceeds `max_cue_ms`; never shortens a cue.
+- last cue with no successor → grows up to `max_cue_ms`.
+- overlapping input cues → not made worse (no new/!larger overlap).
+- idempotency: `retime_cues(retime_cues(x)) == retime_cues(x)`.
+
+`render_srt`: round-trips (`parse_srt(render_srt(cues))` preserves times/text); correct `HH:MM:SS,mmm` formatting; 1-based re-indexing.
+
+`retime_srt`: end-to-end on a fixture string → fewer CPS warnings via `analyze_srt`.
+
+## Acceptance (this slice)
+
+1. `retime_srt` measurably reduces median + %>25 CPS and zeroes micro-cues on the translate-mode fixture, with no new overlaps (proven via `analyze_srt`).
+2. Transcribe-mode comfortable input passes through essentially unchanged.
+3. Pure, fully unit-tested, idempotent; no `CUSTOM_REGROUP` / stable-ts coupling; ruff clean.
+
+## Out of scope (explicit follow-ons)
+
+- Production-pipeline wiring (where `retime_srt` runs in the completion/upload flow).
+- Corpus-wide arena tuning + the per-language `RetimeParams` matrix.
+- Per-language guidance docs.
+- The bake: subgen-side default, or the Path C upstream contribution.
+- Start-time extension (pulling a cue's start earlier into the preceding gap) — forward-only for v1; revisit if the corpus shows it's needed.
+
+## Risk tier
+
+**Tier-0/1** — a new, pure, self-contained module; no auth/writeback/data-model/cross-service surface. Read-diff review suffices.

--- a/src/subarr/subtitle_retime.py
+++ b/src/subarr/subtitle_retime.py
@@ -1,0 +1,55 @@
+"""#359: pure, base-agnostic SRT re-timer (the #171-immune CPS lever).
+
+Extends each over-CPS cue's END forward into the available gap before the next
+cue, and pads sub-min-duration micro-cues, clamped so it never overlaps the next
+cue (min_gap preserved) or exceeds max_cue_ms. Never moves a start, never
+shortens a cue, never worsens an existing overlap. Idempotent.
+
+Operates purely on cue timestamps + text, so it is independent of how the cues
+were produced (stable-ts regroup or the drop-stable-ts Netflix segmenter) — this
+is the lever that survives the #171 crossing and is the eventual Path C
+contribution. RetimeParams defaults are placeholders pending arena tuning (#359
+follow-on)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .subtitle_readability import Cue
+
+
+@dataclass(frozen=True)
+class RetimeParams:
+    target_cps: float = 17.0  # extend toward this CPS (below MAX_CPS=20 comfort bar)
+    min_cue_ms: int = 1000  # pad micro-cues to this (clears the 833ms too_short floor)
+    min_gap_ms: int = 100  # inter-cue gap always preserved
+    max_cue_ms: int = 7000  # never display longer than this (MAX_DURATION_S)
+
+
+def retime_cues(cues: list[Cue], params: RetimeParams = RetimeParams()) -> list[Cue]:
+    out: list[Cue] = []
+    n = len(cues)
+    for i, c in enumerate(cues):
+        hard_cap = c.start_ms + params.max_cue_ms
+        if i + 1 < n:
+            bound = min(cues[i + 1].start_ms - params.min_gap_ms, hard_cap)
+        else:
+            bound = hard_cap
+        # No room (gap too small, or the input already overlaps) → leave as-is.
+        if bound <= c.end_ms:
+            out.append(Cue(index=c.index, start_ms=c.start_ms, end_ms=c.end_ms, lines=list(c.lines)))
+            continue
+        desired = max(c.end_ms, c.start_ms + params.min_cue_ms)  # min-duration pad
+        if params.target_cps > 0 and c.cps > params.target_cps:  # cps extension
+            desired = max(desired, c.start_ms + round(c.char_count / params.target_cps * 1000))
+        new_end = max(c.end_ms, min(desired, bound))  # clamp to gap/max; never shorten
+        out.append(Cue(index=c.index, start_ms=c.start_ms, end_ms=new_end, lines=list(c.lines)))
+    return out
+
+
+def render_srt(cues: list[Cue]) -> str:
+    raise NotImplementedError  # Task 2
+
+
+def retime_srt(srt_text: str, params: RetimeParams = RetimeParams()) -> str:
+    raise NotImplementedError  # Task 3

--- a/src/subarr/subtitle_retime.py
+++ b/src/subarr/subtitle_retime.py
@@ -47,8 +47,21 @@ def retime_cues(cues: list[Cue], params: RetimeParams = RetimeParams()) -> list[
     return out
 
 
+def _ms_to_ts(ms: int) -> str:
+    ms = max(0, int(ms))
+    h, ms = divmod(ms, 3_600_000)
+    m, ms = divmod(ms, 60_000)
+    s, ms = divmod(ms, 1_000)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
 def render_srt(cues: list[Cue]) -> str:
-    raise NotImplementedError  # Task 2
+    """Serialize cues to SRT text, re-indexed 1..N (the inverse of parse_srt)."""
+    blocks = []
+    for i, c in enumerate(cues, start=1):
+        stamp = f"{_ms_to_ts(c.start_ms)} --> {_ms_to_ts(c.end_ms)}"
+        blocks.append(f"{i}\n{stamp}\n" + "\n".join(c.lines))
+    return "\n\n".join(blocks) + "\n" if blocks else ""
 
 
 def retime_srt(srt_text: str, params: RetimeParams = RetimeParams()) -> str:

--- a/src/subarr/subtitle_retime.py
+++ b/src/subarr/subtitle_retime.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .subtitle_readability import Cue
+from .subtitle_readability import Cue, parse_srt
 
 
 @dataclass(frozen=True)
@@ -65,4 +65,5 @@ def render_srt(cues: list[Cue]) -> str:
 
 
 def retime_srt(srt_text: str, params: RetimeParams = RetimeParams()) -> str:
-    raise NotImplementedError  # Task 3
+    """Parse → re-time → re-render. The convenience entry point."""
+    return render_srt(retime_cues(parse_srt(srt_text), params))

--- a/tests/test_subtitle_retime.py
+++ b/tests/test_subtitle_retime.py
@@ -83,3 +83,33 @@ def test_inputs_not_mutated():
     cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "n")]
     retime_cues(cues, P)
     assert cues[0].end_ms == 2000  # original untouched (pure)
+
+
+def test_ms_to_ts_formats_correctly():
+    from subarr.subtitle_retime import _ms_to_ts
+
+    assert _ms_to_ts(0) == "00:00:00,000"
+    assert _ms_to_ts(3_661_123) == "01:01:01,123"
+    assert _ms_to_ts(-5) == "00:00:00,000"  # clamps negatives
+
+
+def test_render_srt_roundtrips_through_parse():
+    from subarr.subtitle_readability import parse_srt
+    from subarr.subtitle_retime import render_srt
+
+    cues = [_cue(1, 0, 2000, "line one\nline two"), _cue(2, 2500, 4000, "next")]
+    text = render_srt(cues)
+    back = parse_srt(text)
+    assert [(c.start_ms, c.end_ms, c.lines) for c in back] == [
+        (0, 2000, ["line one", "line two"]),
+        (2500, 4000, ["next"]),
+    ]
+
+
+def test_render_srt_reindexes_1_based():
+    cues = [_cue(7, 0, 1000, "a"), _cue(9, 2000, 3000, "b")]
+    from subarr.subtitle_retime import render_srt
+
+    text = render_srt(cues)
+    assert text.split("\n")[0] == "1"
+    assert "\n2\n" in "\n" + text  # second block re-indexed to 2

--- a/tests/test_subtitle_retime.py
+++ b/tests/test_subtitle_retime.py
@@ -1,0 +1,85 @@
+"""#359: pure SRT re-timer — extend over-CPS cues into the gap before the next
+cue (+ pad micro-cues), clamped to the gap and max duration; idempotent; never
+shortens or creates overlaps. Base-agnostic (operates on final cue timestamps)."""
+
+from __future__ import annotations
+
+from subarr.subtitle_readability import Cue
+from subarr.subtitle_retime import RetimeParams, retime_cues
+
+P = RetimeParams()  # target_cps=17, min_cue_ms=1000, min_gap_ms=100, max_cue_ms=7000
+
+
+def _cue(i, start_ms, end_ms, text="x"):
+    return Cue(index=i, start_ms=start_ms, end_ms=end_ms, lines=text.split("\n"))
+
+
+def test_hot_cue_extended_toward_target_when_gap_available():
+    # 80 chars in 2.0s = 40 cps; next cue starts at 60s (huge gap).
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "next")]
+    out = retime_cues(cues, P)
+    # target 17 cps over 80 chars → ~4706ms duration; capped by max_cue_ms=7000.
+    assert out[0].end_ms == 80 * 1000 // 17 or abs(out[0].end_ms - round(80 / 17 * 1000)) <= 1
+    assert out[0].cps <= P.target_cps + 0.5
+    assert out[0].start_ms == 0 and out[1].start_ms == 60000  # starts never move
+
+
+def test_micro_cue_padded_to_min_duration():
+    # 3 chars in 0.3s — comfortable CPS but a sub-1s micro-cue; gap is wide.
+    cues = [_cue(1, 0, 300, "ok"), _cue(2, 30000, 31000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == P.min_cue_ms  # padded to 1000ms
+
+
+def test_no_gap_leaves_cue_unchanged_as_residual():
+    # Hot cue but the next cue starts immediately (no room to extend).
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 4000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == 2000  # untouched — Aftercare monitors the residual
+
+
+def test_min_gap_always_preserved():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 3000, 5000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms <= 3000 - P.min_gap_ms  # never within min_gap of next start
+
+
+def test_never_exceeds_max_cue_ms():
+    # Huge gap + very hot cue → extension capped at max_cue_ms.
+    cues = [_cue(1, 0, 1000, "x" * 300), _cue(2, 60000, 61000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == P.max_cue_ms  # 7000
+
+
+def test_never_shortens_a_cue():
+    # Already-long comfortable cue; nothing should pull its end in.
+    cues = [_cue(1, 0, 5000, "x" * 10), _cue(2, 60000, 61000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms >= 5000
+
+
+def test_last_cue_grows_up_to_max_cue_ms():
+    cues = [_cue(1, 0, 1000, "x" * 80)]  # no successor
+    out = retime_cues(cues, P)
+    # target end ~4706 < max 7000, and no next-cue bound → take the target.
+    assert abs(out[0].end_ms - round(80 / 17 * 1000)) <= 1
+
+
+def test_overlapping_input_not_made_worse():
+    # Input already overlaps (cue1 ends after cue2 starts). Don't extend further.
+    cues = [_cue(1, 0, 5000, "x" * 80), _cue(2, 3000, 6000, "next")]
+    out = retime_cues(cues, P)
+    assert out[0].end_ms == 5000  # unchanged; no new/larger overlap
+
+
+def test_idempotent():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "n")]
+    once = retime_cues(cues, P)
+    twice = retime_cues(once, P)
+    assert [(c.start_ms, c.end_ms) for c in once] == [(c.start_ms, c.end_ms) for c in twice]
+
+
+def test_inputs_not_mutated():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "n")]
+    retime_cues(cues, P)
+    assert cues[0].end_ms == 2000  # original untouched (pure)

--- a/tests/test_subtitle_retime.py
+++ b/tests/test_subtitle_retime.py
@@ -18,8 +18,8 @@ def test_hot_cue_extended_toward_target_when_gap_available():
     # 80 chars in 2.0s = 40 cps; next cue starts at 60s (huge gap).
     cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 60000, 61000, "next")]
     out = retime_cues(cues, P)
-    # target 17 cps over 80 chars → ~4706ms duration; capped by max_cue_ms=7000.
-    assert out[0].end_ms == 80 * 1000 // 17 or abs(out[0].end_ms - round(80 / 17 * 1000)) <= 1
+    # target 17 cps over 80 chars → ~4706ms duration (well under the 7000ms cap).
+    assert abs(out[0].end_ms - round(80 / 17 * 1000)) <= 1
     assert out[0].cps <= P.target_cps + 0.5
     assert out[0].start_ms == 0 and out[1].start_ms == 60000  # starts never move
 

--- a/tests/test_subtitle_retime.py
+++ b/tests/test_subtitle_retime.py
@@ -113,3 +113,64 @@ def test_render_srt_reindexes_1_based():
     text = render_srt(cues)
     assert text.split("\n")[0] == "1"
     assert "\n2\n" in "\n" + text  # second block re-indexed to 2
+
+
+# A translate-mode-style fixture: several cramped, high-CPS cues with real gaps
+# between them (translated text overruns the speech window).
+_HOT_SRT = """1
+00:00:00,000 --> 00:00:02,000
+This is a very long translated line that crams far too many characters
+
+2
+00:00:05,000 --> 00:00:06,200
+Another dense cue with way more text than fits comfortably here now
+
+3
+00:00:20,000 --> 00:00:20,300
+hi
+"""
+
+# A comfortable transcribe-mode fixture: low CPS, adequate durations.
+_CALM_SRT = """1
+00:00:00,000 --> 00:00:03,000
+Hello there.
+
+2
+00:00:04,000 --> 00:00:07,000
+General Kenobi.
+"""
+
+
+def test_retime_srt_reduces_cps_and_zeroes_micro_cues_no_new_overlap():
+    from subarr.subtitle_readability import CRITICAL_CPS, analyze_srt, parse_srt
+    from subarr.subtitle_retime import retime_srt
+
+    before = parse_srt(_HOT_SRT)
+    after = parse_srt(retime_srt(_HOT_SRT))
+
+    def median_cps(cues):
+        vals = sorted(c.cps for c in cues if c.duration_s > 0)
+        return vals[len(vals) // 2]
+
+    def pct_over_critical(cues):
+        return sum(1 for c in cues if c.cps > CRITICAL_CPS) / len(cues)
+
+    def micro_count(cues):
+        return sum(1 for c in cues if 0 < c.duration_s < 0.833)
+
+    assert median_cps(after) < median_cps(before)
+    assert pct_over_critical(after) <= pct_over_critical(before)
+    assert micro_count(after) == 0
+    # no NEW overlaps introduced
+    rep = analyze_srt(retime_srt(_HOT_SRT))
+    assert rep.counts.get("overlap", 0) == 0
+
+
+def test_retime_srt_leaves_comfortable_input_essentially_unchanged():
+    from subarr.subtitle_readability import parse_srt
+    from subarr.subtitle_retime import retime_srt
+
+    before = parse_srt(_CALM_SRT)
+    after = parse_srt(retime_srt(_CALM_SRT))
+    # already comfortable + adequate duration → no end moved.
+    assert [c.end_ms for c in before] == [c.end_ms for c in after]


### PR DESCRIPTION
First slice of #359 — the **#171-immune** CPS lever (the segmentation half stays deferred until #171 resolves).

New pure module `src/subarr/subtitle_retime.py`: extend over-CPS cues into the gap before the next cue (+ pad micro-cues), clamped to gap/`max_cue_ms`, idempotent, never shortens or creates overlaps. Operates purely on final cue timestamps → **base-agnostic** (survives the drop-stable-ts crossing; the eventual Path C contribution).

Proven via `analyze_srt` before/after: median CPS ↓, %>25 CPS ↓, micro-cues → 0, zero new overlaps; comfortable transcribe-mode input left untouched.

**Deferred follow-ons (separate slices, ungated):** pipeline wiring, corpus-wide arena tuning of `RetimeParams`, per-language matrix, the bake.

Spec/plan: `docs/superpowers/specs/2026-06-30-359-srt-retimer-design.md`. Built subagent-driven (spec ✅ + code-quality APPROVED). Backend 1449✓ (15 new), ruff clean.