### PR TITLE
#359: bake the SRT re-timer ON by default

### DIFF
--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -446,8 +446,9 @@ class CompletionWatcher:
     def _run_retime(self, entry) -> None:
         """#359: re-time the produced .srt in place (extend over-CPS cues into
         the gap before the next cue) BEFORE aftercare + upload, so both see the
-        improved sub. Off by default (SUBARR_RETIME_ENABLED). Best-effort — a
-        failure here must NEVER block completion. Writes only if changed."""
+        improved sub. On by default; opt out with SUBARR_RETIME_ENABLED=0.
+        Best-effort — a failure here must NEVER block completion. Writes only if
+        changed."""
         from .config import settings as _settings
 
         if not _settings.retime_enabled:

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -268,7 +268,10 @@ def load() -> Settings:
         not in ("0", "false", "no", "off"),
         sonarr_propagate_audio_lang=os.environ.get("SONARR_PROPAGATE_AUDIO_LANG", "0").strip().lower()
         in ("1", "true", "yes", "on"),
-        retime_enabled=os.environ.get("SUBARR_RETIME_ENABLED", "0").strip().lower()
+        # #359 bake: on by default after the corpus sweep proved it (target_cps=17,
+        # min_cue_ms=1000) cuts critical-CPS cues 22.9%->5.2% with zero new overlaps.
+        # Opt out with SUBARR_RETIME_ENABLED=0.
+        retime_enabled=os.environ.get("SUBARR_RETIME_ENABLED", "1").strip().lower()
         in ("1", "true", "yes", "on"),
         plex_audio_hints=os.environ.get("PLEX_AUDIO_HINTS", "0").strip().lower()
         in ("1", "true", "yes", "on"),

--- a/tests/test_config_retime.py
+++ b/tests/test_config_retime.py
@@ -1,5 +1,8 @@
-"""#359: SUBARR_RETIME_ENABLED flag — default off, opt-in until the params are
-arena-proven (then the tuning slice flips the default)."""
+"""#359: SUBARR_RETIME_ENABLED flag. The bake — a sweep over the live 1801-sub
+corpus proved the re-timer (target_cps=17, min_cue_ms=1000) cuts critical-CPS
+cues 22.9%->5.2% and unreadable micro-cues 122739->27824 with zero new overlaps
+(all gap-clamped) — so it now ships ON by default. Opt out with
+SUBARR_RETIME_ENABLED=0."""
 
 from __future__ import annotations
 
@@ -8,8 +11,17 @@ import importlib
 from subarr import config
 
 
-def test_retime_enabled_defaults_off(monkeypatch):
+def test_retime_enabled_defaults_on(monkeypatch):
     monkeypatch.delenv("SUBARR_RETIME_ENABLED", raising=False)
+    importlib.reload(config)
+    assert config.settings.retime_enabled is True
+
+
+def test_retime_enabled_off_via_env(monkeypatch):
+    monkeypatch.setenv("SUBARR_RETIME_ENABLED", "0")
+    importlib.reload(config)
+    assert config.settings.retime_enabled is False
+    monkeypatch.setenv("SUBARR_RETIME_ENABLED", "false")
     importlib.reload(config)
     assert config.settings.retime_enabled is False
 


### PR DESCRIPTION
## Summary

Final slice of #359. The tuning harness (#403) swept `RetimeParams` over the install's real corpus — **1801 subs / 874,892 cues** from the `subs_generated` ledger. Result:

| | median CPS | %>25 (crit) | %>20 (comf) | micro (<0.833s) |
|---|---|---|---|---|
| **baseline** | 17.9 | 22.9% | 41.1% | 122,739 |
| **re-timed** (17/1000) | 17.0 | **5.2%** | **13.6%** | **27,824** |

The quality counts were **identical across all 9 swept combos** — target_cps/min_cue_ms only move the median and added screen-time, not what gets fixed. The residual (5.2% crit, 27,824 micro) is a **gap-constrained floor**: back-to-back cues with no room to extend, which only merging (segmentation/regroup, #171) can break. So the win is free and maximal at every setting, and the placeholder defaults (`target_cps=17`, `min_cue_ms=1000`) were already the right pick (17 CPS = the Netflix/BBC comfort target; 1000ms = 1s min-display convention).

This PR flips **only** the enable flag default: `SUBARR_RETIME_ENABLED` `"0"` → `"1"`. Every completed sub now gets its over-CPS cues extended into available gaps (idempotent, write-only-if-changed, gap-clamped so **zero new overlaps**, best-effort so it never blocks completion). Opt out with `SUBARR_RETIME_ENABLED=0`.

## Changes
- `config.py` — `SUBARR_RETIME_ENABLED` default `"0"` → `"1"`.
- `tests/test_config_retime.py` — default-on + opt-out-via-env coverage.
- `completion_watcher.py` — `_run_retime` docstring (off → on by default).

## Test plan
- [x] `pytest tests/test_config_retime.py -q` → 3 passed (default-on, off-via-env, on-via-env)
- [x] Full suite → **1472 passed, 6 skipped**
- [x] ruff clean

## Follow-on (out of scope)
Per-language `RetimeParams` guidance; the #171-gated segmentation/regroup that breaks the gap-constrained floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)