### PR TITLE
fix(#416): make eager-probe failures diagnosable (surface the reason)

### DIFF
--- a/src/subarr/probe_walker.py
+++ b/src/subarr/probe_walker.py
@@ -29,6 +29,56 @@ log = logging.getLogger(__name__)
 WALK_CONCURRENCY = 4
 
 
+def _error_category(msg: str) -> str:
+    """Bucket a probe error string into a short, log-friendly category so a
+    100%-failure is diagnosable at a glance (#416)."""
+    m = (msg or "").lower()
+    if "outside media root" in m or "unknown library" in m:
+        return "outside-media-root"
+    if m.startswith("stat:") or "no such file" in m:
+        return "path-not-found"
+    if m.startswith("ffprobe") or "probe" in m:
+        return "ffprobe-failed"
+    return "other"
+
+
+def _summarize_probe_errors(errors: list[dict]) -> str:
+    """Compact breakdown of probe failures by reason + a small concrete sample,
+    for the run-summary log. Empty list -> "" (#416: the count alone was
+    undiagnosable — a user saw '400 errors' with no why)."""
+    if not errors:
+        return ""
+    from collections import Counter
+
+    cats = Counter(_error_category(e.get("error", "")) for e in errors)
+    breakdown = ", ".join(f"{n} {cat}" for cat, n in cats.most_common())
+    sample = "; ".join(f"{e.get('path', '?')}: {e.get('error', '?')}" for e in errors[:3])
+    return f"{breakdown} — e.g. {sample}"
+
+
+def _log_probe_error_summary(label: str, state: "WalkState") -> None:
+    """#416: surface WHY files errored (not just the count). Escalates to WARNING
+    when the failure is systemic (all/most files) — the signature of a config
+    problem like a path-prefix/mount mismatch or an unconfigured library — so it
+    is loud in the log instead of a silent 100%-failure."""
+    n = len(state.errors)
+    if not n:
+        return
+    detail = _summarize_probe_errors(state.errors)
+    if n >= max(1, state.total_files // 2):
+        log.warning(
+            "%s %s: %d/%d files errored (systemic — likely a media-root / arr path-prefix "
+            "mismatch or unconfigured library) — %s",
+            label,
+            state.id,
+            n,
+            state.total_files,
+            detail,
+        )
+    else:
+        log.info("%s %s: %d files errored — %s", label, state.id, n, detail)
+
+
 class WalkState:
     def __init__(self, walk_id: str, root_canonical: str):
         self.id = walk_id
@@ -183,6 +233,7 @@ class ProbeWalker:
                 state.probed,
                 len(state.errors),
             )
+            _log_probe_error_summary("probe walk", state)
         except asyncio.CancelledError:
             state.status = "cancelled"
             state.finished_at = time.time()
@@ -296,6 +347,7 @@ class ProbeWalker:
                 state.probed,
                 len(state.errors),
             )
+            _log_probe_error_summary("eager probe", state)
         except asyncio.CancelledError:
             state.status = "cancelled"
             state.finished_at = time.time()

--- a/tests/test_probe_failures.py
+++ b/tests/test_probe_failures.py
@@ -45,3 +45,58 @@ def test_successful_probe_clears_failure(tmp_path):
         canonical_path="TV/X/a.mkv", mtime=1.0, size=100, result=ProbeResult(canonical_path="TV/X/a.mkv")
     )
     assert "TV/X/a.mkv" not in s.failed_paths()  # recovered → no longer failed
+
+
+# --- #416: eager-probe must surface WHY files errored, not just a count ---
+
+
+def test_summarize_probe_errors_categorizes_and_samples():
+    from subarr.probe_walker import _summarize_probe_errors
+
+    errs = [
+        {"path": "TV/A/e1.mkv", "error": "outside media root"},
+        {"path": "TV/A/e2.mkv", "error": "outside media root"},
+        {"path": "Movies/B.mkv", "error": "stat: [Errno 2] No such file or directory: '/x'"},
+    ]
+    s = _summarize_probe_errors(errs)
+    assert "2 outside-media-root" in s
+    assert "1 path-not-found" in s
+    assert "TV/A/e1.mkv" in s  # carries a concrete sample so it is diagnosable
+
+
+def test_summarize_probe_errors_empty():
+    from subarr.probe_walker import _summarize_probe_errors
+
+    assert _summarize_probe_errors([]) == ""
+
+
+def test_log_probe_error_summary_escalates_when_systemic(caplog):
+    import logging as _l
+
+    from subarr.probe_walker import WalkState, _log_probe_error_summary
+
+    st = WalkState("w1", "eager")
+    st.total_files = 4
+    st.errors = [{"path": f"p{i}.mkv", "error": "outside media root"} for i in range(4)]
+    with caplog.at_level(_l.WARNING, logger="subarr.probe_walker"):
+        _log_probe_error_summary("eager probe", st)
+    assert any(
+        r.levelno == _l.WARNING and "systemic" in r.getMessage() and "outside-media-root" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_log_probe_error_summary_info_when_sparse(caplog):
+    import logging as _l
+
+    from subarr.probe_walker import WalkState, _log_probe_error_summary
+
+    st = WalkState("w2", "eager")
+    st.total_files = 100
+    st.errors = [{"path": "p.mkv", "error": "stat: nope"}]
+    with caplog.at_level(_l.INFO, logger="subarr.probe_walker"):
+        _log_probe_error_summary("eager probe", st)
+    assert any(
+        "1 files errored" in r.getMessage() and "path-not-found" in r.getMessage() for r in caplog.records
+    )
+    assert not any(r.levelno >= _l.WARNING for r in caplog.records)


### PR DESCRIPTION
Addresses #416, where a user saw the eager-probe report `400 files, 0 probed, 400 errors` in ~36ms with no way to tell why.

## Root cause
The 36ms/no-ffprobe timing is the tell: every file fails at **path resolution, before ffprobe is spawned** — either `canonical_to_fs()` raises `PathOutsideRootError` ("outside media root") or `p.stat()` raises `OSError` ("stat: …"). Both are recorded in `state.errors` (and exposed at `GET /api/probe/walks`), but the INFO run-summary only logged the **count**, so a 100%-failure was completely opaque in container logs.

Not a 2.4.0 regression — `probe_walker.py`/`paths.py`/`libraries.py` are unchanged since v2.3.1. The user's underlying cause is almost certainly a config path mismatch (arr↔subarr path-prefix / media mount, or an unconfigured library), which this makes visible.

## Fix
The run summary now logs a breakdown **by reason category** + a concrete sample, and escalates to **WARNING** when the failure is systemic (all/most files) — the signature of a config problem:

`eager probe X: 400/400 files errored (systemic — likely a media-root / arr path-prefix mismatch or unconfigured library) — 400 outside-media-root — e.g. TV/Show/ep.mkv: outside media root`

Applied to both the eager-probe and full-walk summaries (same opacity). Pure `_summarize_probe_errors` / `_error_category` helpers, unit-tested; escalation logic tested via caplog.

## Test plan
- [x] `tests/test_probe_failures.py` — summarizer categorises + samples; escalation is WARNING-when-systemic / INFO-when-sparse (7 passed)
- [x] probe suite regression (16 passed); ruff clean

Follow-up on the issue: ask the reporter to read `GET /api/probe/walks` for the exact per-file reason to confirm their specific config cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)