### PR TITLE
fix(#411): stop cross-copy forced logout (instance-distinct session cookie)

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -972,7 +972,7 @@ import secrets as _secrets  # noqa: E402
 from starlette.middleware.sessions import SessionMiddleware  # noqa: E402
 
 from .security_headers import SecurityHeadersMiddleware  # noqa: E402
-from .auth import AuthGateMiddleware  # noqa: E402
+from .auth import AuthGateMiddleware, session_cookie_name as _session_cookie_name  # noqa: E402
 from .api_security import CsrfOriginMiddleware  # noqa: E402
 from .request_crash_capture import RequestCrashCaptureMiddleware  # noqa: E402
 
@@ -1016,7 +1016,9 @@ app.add_middleware(
 app.add_middleware(
     SessionMiddleware,
     secret_key=_session_secret,
-    session_cookie="subarr_session",
+    # #411: instance-distinct cookie name (derived from the secret) so two subarr
+    # copies on the same host don't clobber each other's login cookie.
+    session_cookie=_session_cookie_name(_session_secret),
     same_site=settings.cookie_samesite,
     https_only=(settings.cookie_samesite == "none"),
     max_age=14 * 24 * 3600,

--- a/src/subarr/auth.py
+++ b/src/subarr/auth.py
@@ -40,6 +40,23 @@ import secrets
 log = logging.getLogger(__name__)
 
 
+def session_cookie_name(secret: str) -> str:
+    """#411: an instance-distinct session-cookie name, derived from the session
+    secret.
+
+    Browsers scope cookies by host, NOT by port (RFC 6265), so two subarr copies
+    on the same host (e.g. a TV stack and an Anime stack on one Unraid box,
+    different ports) share a cookie domain. With a fixed cookie name, logging into
+    the second copy overwrites the first copy's cookie, and the first then can't
+    verify it (different secret) and logs you out. Deriving the name from the
+    secret means separate copies (which have separate secrets) use separate
+    cookies and both stay logged in; copies that deliberately share
+    SUBARR_SESSION_SECRET share a login, which is fine. Stable for a given secret,
+    so restarts don't churn it."""
+    disc = hashlib.sha256((secret or "").encode()).hexdigest()[:8]
+    return f"subarr_session_{disc}"
+
+
 # Allowlist — paths that always bypass auth. Keep tight: just the
 # monitoring path. /static/* is allowlisted because the index.html
 # already requires auth, so static assets need to be reachable to

--- a/tests/test_session_secret.py
+++ b/tests/test_session_secret.py
@@ -37,3 +37,40 @@ def test_matches_authstore_secret(tmp_path):
     store = AuthStore(db)
     assert store.get_or_create_secret() == boot
     store.close()
+
+
+# --- #411: session cookie name must be instance-distinct so two subarr copies
+# on the same host (browsers ignore the port) don't clobber each other's cookie ---
+
+
+def test_session_cookie_name_is_instance_distinct():
+    from subarr.auth import session_cookie_name
+
+    a = session_cookie_name("secret-A")
+    b = session_cookie_name("secret-B")
+    assert a.startswith("subarr_session_")
+    assert a != b  # separate copies (separate secrets) -> separate cookies, no clobber
+    assert session_cookie_name("secret-A") == a  # stable for a given secret
+
+
+def test_session_cookie_name_handles_empty_secret():
+    from subarr.auth import session_cookie_name
+
+    assert session_cookie_name("").startswith("subarr_session_")
+
+
+def test_app_wires_instance_distinct_session_cookie():
+    # The real app must configure SessionMiddleware with the derived name, not
+    # the old fixed "subarr_session" (guards the wire-in, #411).
+    import subarr.app as app_mod
+    from subarr.auth import session_cookie_name
+
+    names = [
+        mw.kwargs.get("session_cookie")
+        for mw in app_mod.app.user_middleware
+        if "Session" in mw.cls.__name__ and getattr(mw, "kwargs", None)
+    ]
+    assert names, "SessionMiddleware not found on the app"
+    assert names[0] == session_cookie_name(app_mod._session_secret)
+    assert names[0].startswith("subarr_session_")
+    assert names[0] != "subarr_session"


### PR DESCRIPTION
Fixes #411. A user running two subarr copies on one Unraid box (a TV stack and an Anime stack, different ports) gets logged out of the first when they log into the second.

## Root cause
Browsers scope cookies by **host, not port** (RFC 6265), so two subarr copies on the same host share a cookie domain. Both used the fixed cookie name `subarr_session` (app.py), so logging into copy B overwrote copy A's cookie in the browser. Requests to A then carried B's cookie, which A couldn't verify against its own (different) session secret, so A saw no session and treated you as logged out. The reporter's "I assume this is cookie handling" guess was correct.

## Fix
The session cookie name is now derived from the session secret: `subarr_session_<sha256(secret)[:8]>` (`auth.session_cookie_name`). Separate copies have separate secrets (each persists its own, or an ephemeral one), so they get **separate cookie names** and both stay logged in. Copies that deliberately share `SUBARR_SESSION_SECRET` share a login (fine). Stable for a given secret, so restarts don't churn it.

**Upgrade note:** the cookie name changes, so everyone re-logs-in once after upgrading. No data impact.

## Test plan
- [x] `session_cookie_name` is instance-distinct + stable; handles empty secret
- [x] the real app wires the derived name (not the old fixed `subarr_session`) — integration assertion over `app.user_middleware`
- [x] auth suite regression (42 passed); ruff clean; `import subarr.app` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)