### PR TITLE
fix(#16): choose SQLite journal mode by filesystem (WAL local, TRUNCATE on network FS)

### DIFF
--- a/src/subarr/aftercare_store.py
+++ b/src/subarr/aftercare_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .aftercare import AftercareEvaluation
+from .data_persistence import apply_journal_mode
 
 # Latest-per-path: the most recently INSERTED row for a path (monotonic id
 # avoids the equal-timestamp ambiguity MAX(completed_at) had). The full query
@@ -43,7 +44,7 @@ class AfterCareStore:
             isolation_level=None,
         )
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def prune(self, days: int = 365) -> int:

--- a/src/subarr/arena_store.py
+++ b/src/subarr/arena_store.py
@@ -22,6 +22,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 # [#146] How many distinct *real* spoken languages a recipe must have data in
@@ -133,7 +135,7 @@ class ArenaStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def save(self, run: ArenaRun) -> None:

--- a/src/subarr/audio_audit_store.py
+++ b/src/subarr/audio_audit_store.py
@@ -20,6 +20,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
+
 # The actionable buckets — the ones a user can do something about. `agrees`
 # (tag matches what was heard), `confused` (Whisper couldn't agree with itself),
 # and `undetermined` (no detection) are informational, not surfaced as findings.
@@ -62,7 +64,7 @@ class AudioAuditStore:
             check_same_thread=False,
             isolation_level=None,
         )
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._conn.row_factory = sqlite3.Row
         self._lock = threading.Lock()
 

--- a/src/subarr/audio_lang_store.py
+++ b/src/subarr/audio_lang_store.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
 from .langs import normalize_lang
 from .log_safe import scrub
 
@@ -95,7 +96,7 @@ class AudioLangStore:
             check_same_thread=False,
             isolation_level=None,
         )
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def upsert(

--- a/src/subarr/auth_store.py
+++ b/src/subarr/auth_store.py
@@ -14,6 +14,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 
 # DDL for the session-secret table, duplicated from migration 021 so the
 # import-time bootstrap below can run BEFORE run_migrations (the SessionMiddleware
@@ -34,7 +36,7 @@ def load_or_create_session_secret(db_path) -> str | None:
     try:
         conn = sqlite3.connect(str(db_path))
         try:
-            conn.execute("PRAGMA journal_mode=WAL")
+            apply_journal_mode(conn, db_path)
             conn.execute(_AUTH_SECRET_DDL)
             row = conn.execute("SELECT secret FROM auth_secret WHERE id = 1").fetchone()
             if row is not None:
@@ -56,7 +58,7 @@ class AuthStore:
         self._lock = threading.Lock()
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
 
     def get_or_create_secret(self) -> str:
         """The session-signing secret, generated once and persisted so sessions

--- a/src/subarr/coverage_cache.py
+++ b/src/subarr/coverage_cache.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
 from .paths import VIDEO_EXTS
 
 log = logging.getLogger(__name__)
@@ -148,7 +149,7 @@ class CoverageCache:
             check_same_thread=False,
             isolation_level=None,
         )
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
         self._cached: CachedSnapshot | None = None
         # Coordination flags: tells the refresh task whether a manual

--- a/src/subarr/crash_store.py
+++ b/src/subarr/crash_store.py
@@ -19,6 +19,8 @@ import threading
 import time
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 # Worker contract: object keys are validated strings, max 64 chars, max 64
@@ -67,7 +69,7 @@ class CrashStore:
     def _connect(self) -> sqlite3.Connection:
         # #291: WAL is persistent but re-issue so this store is boot-order-independent.
         conn = sqlite3.connect(str(self._path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(conn, self._path)
         return conn
 
     def record(self, exc: BaseException, when: float | None = None) -> None:

--- a/src/subarr/data_persistence.py
+++ b/src/subarr/data_persistence.py
@@ -86,6 +86,21 @@ def data_dir_network_fs(db_path: Path) -> str | None:
         return None
 
 
+def apply_journal_mode(conn, db_path) -> str:
+    """Set the SQLite journal mode appropriate to where `/data` lives: WAL on
+    local disk (fast, allows concurrent readers), but a rollback journal
+    (TRUNCATE) on a network filesystem, where WAL's shared-memory index is a
+    known corruption vector (#291). Container-gated via `data_dir_network_fs`,
+    so local and dev installs (and anything not in a container) keep WAL exactly
+    as before — only a network-FS `/data` flips to TRUNCATE. Returns the mode
+    applied. Two literal PRAGMAs, no interpolation."""
+    if data_dir_network_fs(Path(db_path)):
+        conn.execute("PRAGMA journal_mode=TRUNCATE")
+        return "TRUNCATE"
+    conn.execute("PRAGMA journal_mode=WAL")
+    return "WAL"
+
+
 def data_dir_is_ephemeral(db_path: Path) -> bool | None:
     """True  → /data is the container's writable layer (NOT persisted).
     False → /data is a real mount (safe).

--- a/src/subarr/enrichment.py
+++ b/src/subarr/enrichment.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
 from .integrations.ollama import OllamaClient, OllamaError
 
 log = logging.getLogger(__name__)
@@ -105,7 +106,7 @@ class EnrichmentStore:
 
     def __init__(self, db_path: Path):
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def close(self) -> None:

--- a/src/subarr/error_store.py
+++ b/src/subarr/error_store.py
@@ -14,6 +14,8 @@ import threading
 import time
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 
@@ -24,7 +26,7 @@ class ErrorStore:
         self._path = db_path
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def record(self, exc_class: str, *, when: float | None = None) -> None:

--- a/src/subarr/forced_segment_store.py
+++ b/src/subarr/forced_segment_store.py
@@ -16,6 +16,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
+
 
 @dataclass(frozen=True)
 class ForcedSegmentScan:
@@ -41,7 +43,7 @@ class ForcedSegmentScanStore:
     def __init__(self, db_path: Path):
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._conn.row_factory = sqlite3.Row
         self._lock = threading.Lock()
 

--- a/src/subarr/migrate.py
+++ b/src/subarr/migrate.py
@@ -37,6 +37,8 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 
@@ -73,8 +75,8 @@ class MigrationRunner:
             conn.execute(
                 "PRAGMA busy_timeout=5000"
             )  # #291: a concurrent migrator (dev --reload) WAITS for the lock instead of erroring "database is locked"
-            conn.execute(
-                "PRAGMA journal_mode=WAL"
+            apply_journal_mode(
+                conn, self._db_path
             )  # #291 NIT: we rely on WAL's default synchronous=NORMAL — do NOT set synchronous=OFF (permits corruption on power loss)
             conn.execute("PRAGMA foreign_keys=ON")
             self._ensure_version_table(conn)

--- a/src/subarr/pending_queue.py
+++ b/src/subarr/pending_queue.py
@@ -26,6 +26,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 # ── statuses ────────────────────────────────────────────────────────
 STATUS_PENDING = "pending"  # in subarr's queue, not yet sent to subgen
 STATUS_SUBMITTED = "submitted"  # handed to subgen; cancel-only from here
@@ -148,7 +150,7 @@ class PendingQueueStore:
             check_same_thread=False,
             isolation_level=None,
         )
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def close(self) -> None:

--- a/src/subarr/pending_store.py
+++ b/src/subarr/pending_store.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 
 STATUS_PENDING = "pending"
 STATUS_APPROVED_ALL = "approved_all"
@@ -87,7 +89,7 @@ class PendingStore:
     def __init__(self, db_path: Path):
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._conn.execute("PRAGMA foreign_keys=ON")
         self._lock = threading.Lock()
 

--- a/src/subarr/probe_store.py
+++ b/src/subarr/probe_store.py
@@ -19,6 +19,7 @@ import threading
 import time
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
 from .media_probe import AudioStream, ProbeResult, SubtitleStream
 
 
@@ -33,7 +34,7 @@ class ProbeStore:
     def __init__(self, db_path: Path):
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def close(self) -> None:

--- a/src/subarr/provenance.py
+++ b/src/subarr/provenance.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 
@@ -81,7 +83,7 @@ class ProvenanceStore:
         self._path = db_path
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def close(self) -> None:

--- a/src/subarr/scan_store.py
+++ b/src/subarr/scan_store.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 
 SCAN_STATUS_PENDING = "pending"
 SCAN_STATUS_RUNNING = "running"
@@ -102,7 +104,7 @@ class ScanStore:
         self._path = db_path
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def close(self) -> None:

--- a/src/subarr/schedule_store.py
+++ b/src/subarr/schedule_store.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .data_persistence import apply_journal_mode
+
 
 # Schedule kinds:
 KIND_INTERVAL = "interval"  # fires every interval_minutes
@@ -132,7 +134,7 @@ class ScheduleStore:
     def __init__(self, db_path: Path):
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
 
     def close(self) -> None:

--- a/src/subarr/task_health.py
+++ b/src/subarr/task_health.py
@@ -22,6 +22,8 @@ import traceback
 from dataclasses import dataclass
 from pathlib import Path
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 # Security: tracebacks are served (unauth-reachable on a no-auth install) via
@@ -108,7 +110,7 @@ class TaskHealthStore:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False, isolation_level=None)
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(self._conn, db_path)
         self._lock = threading.Lock()
         # #157 P2: optional callable(exc) -> None. record_failure feeds every
         # supervised-loop exception to it (CrashStore.record), making this the

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -56,6 +56,8 @@ from typing import Any
 
 import httpx
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 
@@ -209,7 +211,7 @@ class TelemetryCollector:
 
     def state(self) -> TelemetryState:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             row = conn.execute(
                 "SELECT install_id, opted_in, last_ping_at, "
@@ -232,7 +234,7 @@ class TelemetryCollector:
 
     def set_opt_in(self, opted_in: bool) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             conn.execute(
                 "UPDATE telemetry_state SET opted_in = ? WHERE id = 1",
@@ -335,7 +337,7 @@ class TelemetryCollector:
 
     def _ensure_row(self) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             existing = conn.execute("SELECT 1 FROM telemetry_state WHERE id = 1").fetchone()
             if not existing:
@@ -350,7 +352,7 @@ class TelemetryCollector:
 
     def _record_attempt(self, payload_json: str, error: str | None, transmit: bool) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             # #11: stamp last_error_at when error is set; clear it on
             # successful sends so the panel can show "healthy now" the

--- a/src/subarr/update_checker.py
+++ b/src/subarr/update_checker.py
@@ -52,6 +52,8 @@ from typing import Any
 
 import httpx
 
+from .data_persistence import apply_journal_mode
+
 log = logging.getLogger(__name__)
 
 _ATOM_NS = "{http://www.w3.org/2005/Atom}"
@@ -328,7 +330,7 @@ class UpdateChecker:
     def states(self) -> list[UpdateState]:
         """All cached product states, sorted by product name."""
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             rows = conn.execute(
                 "SELECT product, repo, current_version, latest_version, "
@@ -364,7 +366,7 @@ class UpdateChecker:
         set keeps the page honest. Returns the count of orphan rows removed."""
         keep = set(self._products.keys())
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")
+        apply_journal_mode(conn, self._db_path)
         try:
             # Resolve orphans in Python and delete each by exact product = ? —
             # fully parameterized, no dynamic IN-clause SQL. The tracked set is
@@ -525,7 +527,7 @@ class UpdateChecker:
         missed: list[dict[str, Any]] | None = None,
     ) -> None:
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             conn.execute(
                 "INSERT INTO update_checks "
@@ -562,7 +564,7 @@ class UpdateChecker:
     def _write_error(self, product: str, repo: str, error: str) -> None:
         """Update last_error WITHOUT clearing prior successful poll data."""
         conn = sqlite3.connect(str(self._db_path), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")  # #291: boot-order-independent WAL
+        apply_journal_mode(conn, self._db_path)  # #291: boot-order-independent WAL
         try:
             existing = conn.execute(
                 "SELECT 1 FROM update_checks WHERE product = ?",

--- a/tests/test_data_persistence.py
+++ b/tests/test_data_persistence.py
@@ -143,3 +143,31 @@ def test_check_network_fs_success_when_local(subarr_env, tmp_path, monkeypatch):
     states = {s.task_name: s for s in health.states()}
     assert states["data-network-fs"].last_success_at is not None
     assert states["data-network-fs"].last_error_type is None
+
+
+def test_apply_journal_mode_wal_on_local(monkeypatch):
+    from subarr import data_persistence
+
+    monkeypatch.setattr(data_persistence, "data_dir_network_fs", lambda p: None)
+    calls = []
+
+    class _C:
+        def execute(self, sql):
+            calls.append(sql)
+
+    assert data_persistence.apply_journal_mode(_C(), "/data/x.db") == "WAL"
+    assert calls == ["PRAGMA journal_mode=WAL"]
+
+
+def test_apply_journal_mode_truncate_on_network(monkeypatch):
+    from subarr import data_persistence
+
+    monkeypatch.setattr(data_persistence, "data_dir_network_fs", lambda p: "nfs4")
+    calls = []
+
+    class _C:
+        def execute(self, sql):
+            calls.append(sql)
+
+    assert data_persistence.apply_journal_mode(_C(), "/mnt/nas/x.db") == "TRUNCATE"
+    assert calls == ["PRAGMA journal_mode=TRUNCATE"]


### PR DESCRIPTION
## Summary

Closes #16. Follow-up to the v2.4.2 network-FS Health warning: instead of only *warning* when `/data` sits on a network filesystem, subarr now picks a safe SQLite journal mode automatically.

- New `apply_journal_mode(conn, db_path)` in `data_persistence.py`: **WAL** on local disk (the fast, crash-safe default), **TRUNCATE** when `/data` is on a network FS (NFS/SMB/CIFS/glusterfs/rclone), where WAL's shared-memory index is a known corruption vector.
- Swept all **20 store modules** (27 call sites) from a hardcoded `PRAGMA journal_mode=WAL` to `apply_journal_mode(conn, db_path)`, so every SQLite connection subarr opens honours the filesystem verdict, not just the main DB.
- Reuses the existing container-gated `data_dir_network_fs()` detection, so dev hosts and bare-metal runs are never affected (returns WAL).

## Test Plan
- [x] `tests/test_data_persistence.py` - 12 passed (covers WAL-local / TRUNCATE-network selection and the container gate)
- [x] Full suite green at these commits (1640 passed, 6 skipped) prior to a conflict-free rebase onto main
- [ ] CI full suite + trivy on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)