### PR TITLE
ci: fix zizmor ref-version-mismatch on setup-node pins

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -72,7 +72,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # release.yml runs only on trusted push/tags (never PRs), so there is no
       # PR→privileged-cache poisoning vector; setup-node isn't configured to
       # cache here anyway (no `cache:` input).
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 # zizmor: ignore[cache-poisoning]
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '20'
       - run: npm ci || npm install


### PR DESCRIPTION
## Summary

zizmor's online `ref-version-mismatch` audit went red repo-wide (surfacing on unrelated PRs like #428): the `actions/setup-node` hash `48b55a0` fell off the moving `v6` tag as it advanced, so the `# v6` comment no longer matched. The immutable tag on that commit is `v6.4.0`.

Comment-only fix on all three pins (frontend.yml x2, release.yml x1): `# v6` → `# v6.4.0`. **The pinned hash is unchanged** — the supply-chain pin is intact; only the human-readable version comment is corrected. release.yml keeps its deliberate `# zizmor: ignore[cache-poisoning]` suppression (the auto-fix stripped it; restored by hand).

Same external-drift class as #417. Verified locally with `GH_TOKEN=... zizmor --persona=regular .github/workflows/` → "No findings to report."

## Test plan
- [x] `zizmor` clean locally (0 findings, same 1 ignored + 18 suppressed as before).
- [x] Diff is comment-only; hashes byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)