### PR TITLE
feat(#71): media-server abstraction + Jellyfin research (Slice 1)

### DIFF
--- a/docs/jellyfin-api-research-2026-07-15.md
+++ b/docs/jellyfin-api-research-2026-07-15.md
@@ -1,0 +1,120 @@
+# Jellyfin / Emby Media-Server Integration — API Research (#71 / #72)
+
+RTFM pass before any code. Maps every Plex call subarr makes to its Jellyfin
+equivalent, surfaces the architectural gaps, and lists what must be verified
+against a live Jellyfin instance. Source: Jellyfin stable OpenAPI spec
+(api.jellyfin.org/openapi/jellyfin-openapi-stable.json) via Context7.
+
+## subarr's actual media-server surface (from `integrations/plex.py`)
+
+subarr's media-server usage is **narrow and sidecar-based**. It writes `.srt`
+sidecar files to disk, then tells the server to rescan so it picks them up. It
+does **not** upload subtitles through the Plex API.
+
+| Plex method | Purpose | HTTP |
+|---|---|---|
+| `is_configured` / auth | connectivity | `X-Plex-Token` query param |
+| `translate_path` | subarr path → server path | (client-side) |
+| `sections()` | list libraries + filesystem Locations | `GET /library/sections` |
+| `_section_for_path` | match a file path → its library section | (client-side, over Locations) |
+| `full_scan` | full library refresh | `POST /library/sections/{id}/refresh` |
+| `partial_scan(file)` | **targeted folder refresh** after a sub lands | `POST /library/sections/{id}/refresh?path=<dir>` |
+| `status()` | health / reachability | `GET /` (identity) |
+| `audio_lang_hints(titles)` | read audio-track languages | Plex library metadata |
+
+The load-bearing call is `partial_scan` — fired by `completion_watcher` right
+after a sidecar is written.
+
+## Plex → Jellyfin mapping
+
+| subarr need | Plex | Jellyfin | Notes |
+|---|---|---|---|
+| **Auth** | `X-Plex-Token` (query) | API key via `Authorization: MediaBrowser Token="<key>"` header (also accepts `X-Emby-Token: <key>` and `?api_key=`) | API keys are created in Dashboard → API Keys. **Verify exact header on live instance.** |
+| **List libraries + paths** | `GET /library/sections` → `<Location>` | `GET /Library/VirtualFolders` → `VirtualFolderInfo.Locations[]` | Near-perfect analog: `Name`, `Locations[]` (fs paths), `CollectionType`, `ItemId`. Path→library matching works identically (prefix-match over `Locations`). |
+| **Full refresh** | `POST /library/sections/{id}/refresh` | `POST /Library/Refresh` | Jellyfin refreshes **all** libraries; no section id. Simpler, but coarser. **Verify** whether a single-library scan trigger exists. |
+| **Targeted refresh** | `POST /library/sections/{id}/refresh?path=<dir>` (one shot, by path) | **No path-based refresh.** Two-step: (1) resolve file → itemId, (2) `POST /Items/{itemId}/Refresh?metadataRefreshMode=Default` | **The key gap** — see below. |
+| **Read audio-track langs** | Plex metadata | `GET /Items?fields=MediaStreams&recursive=true&includeItemTypes=Episode,Movie` → `MediaStreams[]` where `Type=Audio`, read `Language` | Direct analog; richer (per-stream `IsExternal`/`IsForced`/`Path`/`DisplayTitle`). |
+| **Health** | `GET /` | `GET /System/Info/Public` (no auth) or `GET /System/Ping` | Standard. |
+| **(new) Direct sub upload** | — (Plex has none) | `POST /Videos/{itemId}/Subtitles` with `UploadSubtitleDto {Language, Format, IsForced, IsHearingImpaired, Data(base64)}`; `DELETE /Videos/{itemId}/Subtitles/{index}` | Jellyfin-only capability. Probably **not** adopted — see below. |
+
+## The one real architectural gap: targeted refresh
+
+Plex's `partial_scan` is a single path-scoped call. Jellyfin has **no path-based
+refresh** and refreshes by **item UUID**. So the Jellyfin equivalent is:
+
+1. **Resolve the video file → itemId.** `GET /Items` has **no server-side path
+   filter** (only `searchTerm` name-search). So subarr must query
+   (`searchTerm=<filename-stem>&recursive=true&includeItemTypes=Episode,Movie&fields=Path`)
+   and **match `Path` client-side**, or walk the containing library.
+2. **`POST /Items/{itemId}/Refresh`** (`metadataRefreshMode=Default`) — Jellyfin
+   re-scans the item and picks up the freshly-written external sidecar.
+
+Implications:
+- The lookup adds a round-trip and can be imprecise (name collisions across
+  seasons/versions → match on full `Path`, not just name).
+- **Fallback:** if the lookup fails, `POST /Library/Refresh` (full) still works,
+  just heavier. The abstraction should degrade to this.
+- This is the single biggest reason the `MediaServer` interface (#71) must model
+  `refresh_for_file(path)` as a capability with **very different** Plex vs
+  Jellyfin implementations, not a thin URL swap.
+
+## Why keep the sidecar model on Jellyfin (not the upload API)
+
+Jellyfin *can* take a subtitle via `POST /Videos/{itemId}/Subtitles` (base64).
+Tempting, but the sidecar-write + refresh model is still the right one:
+- subarr's whole pipeline produces `.srt` **files** on disk; other tools (Bazarr,
+  the user, subsyncarr) see and manage those sidecars. An API-uploaded sub lives
+  in Jellyfin's own store, invisible to that ecosystem.
+- It keeps Plex and Jellyfin behaviourally identical (write sidecar → refresh),
+  which is exactly what an abstraction wants.
+- The upload API still needs the itemId anyway, so it saves nothing on the lookup.
+
+Note the upload path as a **future option** (e.g. servers with a read-only media
+mount), not the default.
+
+## Emby (#72 also covers Emby)
+
+Jellyfin forked from Emby, so the API is largely shared (`/Library/VirtualFolders`,
+`/Items`, `/Items/{id}/Refresh`, `X-Emby-Token`). Expect the same abstraction to
+cover Emby with minor auth/endpoint deltas. **Verify against a live Emby only if a
+user actually asks;** Jellyfin is the demand driver.
+
+## Proposed `MediaServer` abstraction shape (#71) — for the design phase
+
+A protocol the current Plex client already nearly satisfies:
+
+```
+class MediaServer(Protocol):
+    def is_configured(self) -> bool: ...
+    def translate_path(self, subarr_path: str) -> str: ...
+    async def libraries(self) -> list[Library]:        # name + fs locations + type
+    async def refresh_for_file(self, subarr_file: str) -> RefreshResult:  # the core hook
+    async def full_refresh(self) -> RefreshResult:
+    async def status(self) -> ServerStatus:
+    async def audio_lang_hints(self, titles) -> dict[str, str]:
+```
+
+- Plex impl = today's `plex.py` (path refresh).
+- Jellyfin impl = auth header + VirtualFolders + the two-step `refresh_for_file`
+  (item lookup → item refresh, full-refresh fallback).
+- `completion_watcher`, `admin`, `coverage_engine` depend on the protocol, not on
+  `plex` concretely. A `media_server` factory selects the backend from config.
+
+## Must-verify on a live Jellyfin (RTFM → then TEST)
+
+Install Jellyfin locally, point it at the same NAS library, and confirm by hand:
+1. Exact **auth header** that works (`Authorization: MediaBrowser Token=` vs `X-Emby-Token`).
+2. `GET /Library/VirtualFolders` returns the library `Locations[]` as real fs paths.
+3. **The core loop:** write a `<video>.en.srt` sidecar → resolve itemId by path →
+   `POST /Items/{itemId}/Refresh` → confirm Jellyfin lists the new external
+   subtitle (`MediaStreams[].IsExternal=true`). This is subarr's whole value prop;
+   it must work end-to-end before we design further.
+4. Whether a **single-library** refresh exists (vs all-libraries `POST /Library/Refresh`).
+5. Item-lookup-by-path reliability + latency on a real library.
+
+## Next steps
+
+1. Install Jellyfin (`jellyfin/` compose in DockerStacks, same NAS mount).
+2. Hand-validate the 5 items above with curl against the live instance.
+3. Brainstorm the `MediaServer` abstraction design (#71), then slice: abstraction
+   + Plex-behind-interface first (no behaviour change), Jellyfin backend second.

--- a/docs/superpowers/plans/2026-07-15-71-slice1-media-server-abstraction.md
+++ b/docs/superpowers/plans/2026-07-15-71-slice1-media-server-abstraction.md
@@ -1,0 +1,251 @@
+# #71 Slice 1 — MediaServer abstraction + Plex behind it (zero behavior change)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** Introduce a `MediaServer` protocol, make the existing Plex client conform, and route the core sidecar-refresh hook (`completion_watcher`) through a fan-out over a `media_servers` list — with **zero user-visible behavior change** (single Plex behaves exactly as today). This lays the seam Slice 2 plugs Jellyfin into.
+
+**Architecture:** Protocol + delegation (no logic moves). `PlexClient` gains `type` + protocol-named `refresh_for_file`/`full_refresh` that delegate to its existing `partial_scan`/`full_scan`. `IntegrationBundle` gains a `media_servers` list (`[plex]`). A best-effort `refresh_file_on_all` fan-out helper replaces the direct `partial_scan` call in `completion_watcher`.
+
+**Scope boundary:** admin scan/sections endpoints, health probes, and coverage audio-hints stay on `bundle.plex` for this slice (single-Plex, unchanged). They generalize in Slice 2 alongside the Jellyfin UI — generalizing them now, with no second server to show, is churn with no behavior change.
+
+**Tech stack:** Python 3.11, `typing.Protocol` (`runtime_checkable`), pytest (async).
+
+---
+
+## Reference facts (verified)
+
+- `PlexClient` (`integrations/plex.py`) already has: `is_configured()`, `translate_path()`, `partial_scan(subarr_file)->dict`, `full_scan(section_id=None)->dict`, `status()->dict`, `audio_lang_hints(titles)->dict`, `sections()`, `aclose()`. `partial_scan`/`full_scan` raise `IntegrationError` when unconfigured; return dicts with `triggered`/`scope` (+ plex-specific `section`/`plex_path`).
+- `IntegrationBundle` (`coverage_engine.py:~230`) builds `self.plex = PlexClient(base_url=…, token=…, default_section=…, path_prefix=…, media_root=…)` and closes it in `aclose()`.
+- `completion_watcher` reaches Plex via `self._plex` property (`completion_watcher.py:120` = `self._bundle_provider().plex if self._bundle_provider else self._plex_direct`); the refresh method (`~400`) checks `_settings.plex_partial_scan_enabled` + `self._plex.is_configured()`, resolves `canonical_to_fs`, then `await self._plex.partial_scan(subarr_full)`.
+
+---
+
+### Task 1: `MediaServer` protocol + `PlexClient` conformance
+
+**Files:** Create `src/subarr/integrations/media_server.py`; Modify `src/subarr/integrations/plex.py`; Test `tests/test_media_server.py`.
+
+- [ ] **Step 1 — write the failing test** (`tests/test_media_server.py`):
+
+```python
+from subarr.integrations.media_server import MediaServer
+from subarr.integrations.plex import PlexClient
+
+
+def test_plex_client_satisfies_media_server_protocol():
+    c = PlexClient(base_url="http://plex:32400", token="t", default_section="all", path_prefix="", media_root="/media/library")
+    assert isinstance(c, MediaServer)  # runtime_checkable structural check
+    assert c.type == "plex"
+
+
+async def test_refresh_for_file_delegates_to_partial_scan(monkeypatch):
+    c = PlexClient(base_url="http://plex:32400", token="t", default_section="all", path_prefix="", media_root="/media/library")
+    calls = {}
+
+    async def fake_partial(p):
+        calls["path"] = p
+        return {"triggered": True, "scope": "partial"}
+
+    monkeypatch.setattr(c, "partial_scan", fake_partial)
+    out = await c.refresh_for_file("/media/library/TV/x.mkv")
+    assert calls["path"] == "/media/library/TV/x.mkv" and out["triggered"] is True
+
+
+async def test_full_refresh_delegates_to_full_scan(monkeypatch):
+    c = PlexClient(base_url="http://plex:32400", token="t", default_section="all", path_prefix="", media_root="/media/library")
+
+    async def fake_full():
+        return {"triggered": True, "scope": "full"}
+
+    monkeypatch.setattr(c, "full_scan", fake_full)
+    out = await c.full_refresh()
+    assert out["scope"] == "full"
+```
+
+(Add `pytestmark = pytest.mark.asyncio` per the repo's strict-asyncio convention; see an existing async test file.)
+
+- [ ] **Step 2 — run, confirm fail:** `python -m pytest tests/test_media_server.py -q` (ImportError: no `media_server` module).
+
+- [ ] **Step 3 — implement the protocol** (`src/subarr/integrations/media_server.py`):
+
+```python
+"""#71 — the media-server abstraction. Plex, Jellyfin (slice 2), and Emby
+(deferred) implement this. subarr writes subtitle sidecars to disk, then asks
+every configured media server to pick them up; the protocol is that contract."""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class MediaServer(Protocol):
+    """Structural interface for a media server subarr can drive. `type` is a
+    stable discriminator ("plex" | "jellyfin" | "emby")."""
+
+    type: str
+
+    def is_configured(self) -> bool: ...
+    def translate_path(self, subarr_path: str) -> str: ...
+    async def refresh_for_file(self, subarr_file: str) -> dict: ...
+    async def full_refresh(self) -> dict: ...
+    async def status(self) -> dict: ...
+    async def audio_lang_hints(self, titles) -> dict: ...
+    async def aclose(self) -> None: ...
+
+
+async def refresh_file_on_all(servers, subarr_file: str) -> list[dict]:
+    """Fan a per-file refresh out to every CONFIGURED server, best-effort: one
+    server erroring or being unconfigured never blocks the others. Returns the
+    per-server result dicts (skipped servers omitted)."""
+    results: list[dict] = []
+    for srv in servers:
+        try:
+            if not srv.is_configured():
+                continue
+            results.append(await srv.refresh_for_file(subarr_file))
+        except Exception as e:  # noqa: BLE001 — a failing server must not abort the loop
+            log.warning("media-server refresh failed on %s: %s", getattr(srv, "type", "?"), e)
+    return results
+```
+
+- [ ] **Step 4 — make PlexClient conform** (`src/subarr/integrations/plex.py`): add a class attribute `type = "plex"` on `PlexClient`, and two delegating methods (place next to `partial_scan`/`full_scan`):
+
+```python
+    type = "plex"
+
+    async def refresh_for_file(self, subarr_file: str) -> dict:
+        """MediaServer protocol name for the per-file targeted refresh."""
+        return await self.partial_scan(subarr_file)
+
+    async def full_refresh(self) -> dict:
+        """MediaServer protocol name for the full library refresh."""
+        return await self.full_scan()
+```
+
+- [ ] **Step 5 — run, confirm pass:** `python -m pytest tests/test_media_server.py -q` (3 pass).
+
+- [ ] **Step 6 — commit:**
+```
+git add src/subarr/integrations/media_server.py src/subarr/integrations/plex.py tests/test_media_server.py
+git commit -m "feat(#71): MediaServer protocol + PlexClient conformance + fan-out helper"
+```
+
+---
+
+### Task 2: `IntegrationBundle.media_servers`
+
+**Files:** Modify `src/subarr/coverage_engine.py`; Test `tests/test_media_server_bundle.py`.
+
+- [ ] **Step 1 — failing test** (`tests/test_media_server_bundle.py`):
+
+```python
+from subarr.coverage_engine import IntegrationBundle
+from subarr.integrations.media_server import MediaServer
+
+
+def test_bundle_media_servers_lists_plex(subarr_env):
+    b = IntegrationBundle()
+    servers = b.media_servers
+    assert isinstance(servers, list) and len(servers) == 1
+    assert servers[0] is b.plex
+    assert isinstance(servers[0], MediaServer)
+```
+
+(Use whatever fixture existing bundle tests use to construct `IntegrationBundle` under a seeded env — grep `tests/` for `IntegrationBundle()` to match the idiom.)
+
+- [ ] **Step 2 — run, confirm fail** (`AttributeError: media_servers`).
+
+- [ ] **Step 3 — implement** — add to `IntegrationBundle` (next to the `bazarr` alias property):
+
+```python
+    @property
+    def media_servers(self) -> list:
+        """All constructed media-server clients (currently just Plex). Callers
+        fan out over this and filter on is_configured(). Slice 2 appends
+        Jellyfin when JELLYFIN_* is set."""
+        return [self.plex]
+```
+
+- [ ] **Step 4 — run, confirm pass.**
+
+- [ ] **Step 5 — commit:**
+```
+git add src/subarr/coverage_engine.py tests/test_media_server_bundle.py
+git commit -m "feat(#71): IntegrationBundle.media_servers list (currently [plex])"
+```
+
+---
+
+### Task 3: route `completion_watcher` refresh through the fan-out
+
+**Files:** Modify `src/subarr/completion_watcher.py`; Test the existing completion/plex test file.
+
+- [ ] **Step 1 — write the failing test.** Find the existing test that exercises the partial-scan hook: `grep -rl "partial_scan\|_maybe_plex" tests/`. Add a test asserting the hook now fans out over `media_servers` and isolates a failing server. Sketch (adapt to the file's fixtures):
+
+```python
+async def test_completion_refresh_fans_out_and_isolates_failure(monkeypatch, ...):
+    # two fake servers: one raises, one records — the raise must not stop the other
+    class Srv:
+        type = "x"
+        def __init__(self, boom): self.boom = boom; self.got = None
+        def is_configured(self): return True
+        async def refresh_for_file(self, p):
+            if self.boom: raise RuntimeError("down")
+            self.got = p; return {"triggered": True}
+    bad, good = Srv(True), Srv(False)
+    # wire a watcher whose bundle.media_servers == [bad, good]; call the refresh hook
+    # assert good.got == <resolved fs path> despite bad raising
+```
+
+- [ ] **Step 2 — run, confirm fail.**
+
+- [ ] **Step 3 — implement.** In `completion_watcher.py`:
+  - Add a `_media_servers` property mirroring `_plex` so test injection still works:
+    ```python
+        @property
+        def _media_servers(self):
+            if self._bundle_provider:
+                return self._bundle_provider().media_servers
+            return [self._plex_direct] if self._plex_direct else []
+    ```
+  - In the refresh method (`~400`), replace the single `partial_scan` call with the fan-out. Keep the existing gate (`_settings.plex_partial_scan_enabled`), the `canonical_to_fs` resolve, and the per-file skip. Replace the `if self._plex is None / is_configured()` guard with a `media_servers`-based one and call the helper:
+    ```python
+    from .integrations.media_server import refresh_file_on_all
+    servers = [s for s in self._media_servers if s and s.is_configured()]
+    if not servers:
+        return
+    # ... existing plex_partial_scan_enabled gate + canonical_to_fs resolve ...
+    results = await refresh_file_on_all(servers, subarr_full)
+    for r in results:
+        log.info("media-server refresh fired: %s (ledger entry: %s)", r, video_canonical)
+    ```
+  Preserve the `plex_partial_scan_enabled` gate name for now (Slice 2 generalizes it). Do not change what happens when unconfigured/disabled.
+
+- [ ] **Step 4 — run the affected test file + confirm pass.**
+
+- [ ] **Step 5 — commit:**
+```
+git add src/subarr/completion_watcher.py tests/<affected_test>.py
+git commit -m "feat(#71): route completion-watcher refresh through media_servers fan-out"
+```
+
+---
+
+### Task 4: full verification (behavior-preserving)
+
+- [ ] **Step 1 — targeted suites:** `python -m pytest tests/test_media_server.py tests/test_media_server_bundle.py $(grep -rl "partial_scan\|completion" tests/ | tr '\n' ' ') -q` — all green.
+- [ ] **Step 2 — lint:** `ruff check src/subarr/integrations/media_server.py src/subarr/integrations/plex.py src/subarr/completion_watcher.py src/subarr/coverage_engine.py && ruff format --check <those + new tests>`.
+- [ ] **Step 3 — regression:** the full backend suite must pass unchanged — Slice 1 adds an abstraction with no behavior change. Push the branch and let CI run the full suite (matches the repo's CI-gated workflow).
+- [ ] **Step 4 — confirm zero behavior change:** existing Plex partial-scan/full-scan tests pass untouched; a single configured Plex still refreshes exactly as before (fan-out over `[plex]`).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** delivers the spec's Slice 1 core (protocol + Plex behind it + fan-out through `media_servers`). Deliberate refinement: admin/health/coverage-audio-hints generalization is deferred to Slice 2 (documented above) — no behavior change is lost, and it's more coherent beside the Jellyfin surfacing.
+- **Type consistency:** `refresh_for_file`/`full_refresh` return the same dicts `partial_scan`/`full_scan` already return; `media_servers` is a `list`; the fan-out helper filters on `is_configured()`.
+- **No placeholders:** protocol + helper + delegators are shown in full; test sketches for Task 3 are marked to adapt to existing fixtures (the only non-literal steps, because they must match the current watcher test harness).
+- **Zero-behavior-change guard:** the `plex_partial_scan_enabled` gate, `canonical_to_fs` resolve, and unconfigured/disabled short-circuits are all preserved.

--- a/docs/superpowers/specs/2026-07-15-71-media-server-abstraction-design.md
+++ b/docs/superpowers/specs/2026-07-15-71-media-server-abstraction-design.md
@@ -1,0 +1,160 @@
+# Media-Server Abstraction + Jellyfin Backend — Design (#71 / #72)
+
+**Issues:** #71 (first-class media-server integration + `MediaServer` abstraction),
+#72 (Jellyfin/Emby backend).
+**Date:** 2026-07-15
+**Status:** approved for planning (RTFM + live validation done; Model B chosen).
+
+## Goal
+
+Generalize subarr's Plex-only media-server integration into a `MediaServer`
+abstraction and add a **Jellyfin** backend, so users can run Plex and Jellyfin
+**side by side** (Model B). Emby is stubbed in the abstraction but its backend is
+deferred until demand. The user-facing job is unchanged: after subarr writes a
+subtitle sidecar, tell every configured media server to pick it up.
+
+## Grounding — validated live against Jellyfin 10.11.11
+
+RTFM against the stable OpenAPI spec + a hands-on run on a real instance
+(`docs/jellyfin-api-research-2026-07-15.md`). Confirmed on real media:
+
+- **Auth:** `X-Emby-Token: <api_key>` header works (simplest of the accepted forms).
+- **Libraries:** `GET /Library/VirtualFolders` → `Name` + `Locations[]` (fs paths).
+- **Core loop (proven):** write `<video>.en.srt` → `POST /Items/{id}/Refresh?metadataRefreshMode=Default` → Jellyfin lists the external subtitle (`MediaStreams[]` `Type=Subtitle IsExternal=true lang=eng`).
+- **Path→itemId lookup:** `GET /Items` has **no server-side path filter**, so resolve via `searchTerm=<name>` + client-side `Path` match (validated: 23 candidates → exact match). Full-refresh is the fallback.
+- **Audio hints:** `GET /Items?fields=MediaStreams` exposes per-stream `Language`.
+- Sidecar model works unchanged: Jellyfin picks up external `.srt` on item refresh.
+
+## The `MediaServer` abstraction
+
+A protocol the current `plex.py` already nearly satisfies:
+
+```python
+class MediaServer(Protocol):
+    type: str  # "plex" | "jellyfin" | "emby"
+    def is_configured(self) -> bool: ...
+    def translate_path(self, subarr_path: str) -> str: ...       # subarr fs path → this server's mount
+    async def libraries(self) -> list[Library]: ...              # name + fs locations
+    async def refresh_for_file(self, subarr_file: str) -> RefreshResult: ...  # the core hook
+    async def full_refresh(self) -> RefreshResult: ...
+    async def status(self) -> ServerStatus: ...
+    async def audio_lang_hints(self, titles) -> dict[str, str]: ...
+```
+
+- **PlexServer** = today's `plex.py` (one-shot path refresh `/library/sections/{id}/refresh?path=`).
+- **JellyfinServer** = the validated flow: `X-Emby-Token`; `libraries` from
+  `/Library/VirtualFolders`; `refresh_for_file` = searchTerm + `Path`-match →
+  `POST /Items/{id}/Refresh`, falling back to `full_refresh` (`POST /Library/Refresh`)
+  when no item matches; `audio_lang_hints` from `/Items?fields=MediaStreams`.
+- **EmbyServer** = deferred. The abstraction leaves room (it's a thin Jellyfin
+  subclass — same fork), but no backend ships in this epic.
+- A factory builds each configured server from config; the app holds the **list**
+  of active servers.
+
+## Config model + back-compat
+
+Per-type env blocks, each independent; a server is **active** when its URL + secret
+are set:
+
+- `PLEX_URL` / `PLEX_TOKEN` / `PLEX_SECTION` / `PLEX_PATH_PREFIX` / … — **unchanged**.
+  Existing Plex installs upgrade with zero edits.
+- `JELLYFIN_URL` / `JELLYFIN_API_KEY` / `JELLYFIN_PATH_PREFIX` — new.
+- (`EMBY_*` reserved, not wired until the backend ships.)
+
+Persisted via `config_store` like every other integration (honoring the env
+clobber-guard). **Per-server path prefix** is required: each server may mount the
+library at a different root (observed: Plex `/media`, subarr `/media/library`,
+Jellyfin `/media`). Path matching on the server side (section/library auto-discovery)
+covers multi-library layouts; the prefix only converts subarr's fs view to the
+server's view.
+
+## Fan-out + audio hints
+
+- `refresh_for_file` and `full_refresh` **fan out to every configured server**,
+  independently and **best-effort** — one server erroring or being down never
+  blocks the others (mirrors `completion_watcher`'s current best-effort
+  `partial_scan`; each result logged). "Configured" == "active"; no separate
+  per-server enable toggle.
+- `audio_lang_hints`: query the **first configured server** that supports it. All
+  servers index the same files, so one source suffices — no merging.
+
+## Multi-instance arr interaction (#161) — covered, no coupling
+
+The media-server layer is **orthogonal to arr instances** because it operates on
+resolved file paths, not on which Sonarr/Radarr owns a file:
+
+- arr instances (#161) → subarr libraries (media roots) → `canonical_to_fs`
+  resolves any file to an fs path (already library/instance-aware via #134
+  `@slug` heads) → the media server matches that path to **its own** libraries.
+- Plex has **no** per-instance/per-library binding today (`plex_section` is a
+  global fallback; the client auto-discovers the section per file by path).
+  Jellyfin's searchTerm + `Path`-match is the same auto-discovery.
+- With multiple arr instances → multiple libraries → the fan-out refreshes each
+  server, and each refreshes only the content **it** hosts (a no-op on the rest:
+  Plex matches no section, Jellyfin matches no item). No arr↔media-server mapping
+  is needed, and none will be added.
+
+## Surfacing (Model B — one-per-type, coexisting)
+
+The integration registry gains `jellyfin` (and reserves `emby`) beside `plex`:
+
+- **Settings:** independent integration cards per configured server. Reuse the
+  existing `CREDENTIAL_SCHEMA` / `CredentialEditor` /
+  `GET|PUT /api/integrations/{name}/…` machinery:
+  `CREDENTIAL_SCHEMA.jellyfin = [url, api_key(secret)]`. Add `_test_jellyfin`
+  (probe `/System/Info/Public`, then an authed `/Library/VirtualFolders` to
+  confirm the key).
+- **Onboarding:** a "Media Servers" step listing Plex / Jellyfin, each optional —
+  add any or all. Reuses the wizard's per-service test + the (now-fixed) persist
+  path.
+- **Health:** one dot per configured server (`status()` per backend). **System
+  actions:** "scan" fans out `full_refresh` to all configured servers.
+
+## Emby — deferred
+
+The `MediaServer` protocol and the factory account for `type="emby"`, but no Emby
+backend, config wiring, or UI ships in this epic. Add it as a thin `JellyfinServer`
+subclass + surfacing when a user asks. Jellyfin is the demand driver.
+
+## Slicing (de-risk the refactor first)
+
+- **Slice 1 — abstraction + Plex behind it. Zero behavior/UX change.** Extract
+  `MediaServer`, make `PlexServer` implement it, route `completion_watcher` /
+  `admin` / `coverage_engine` through the protocol (single-server list = `[plex]`).
+  Fully covered by existing Plex tests; nothing new is user-visible. This lands the
+  risky refactor invisibly.
+- **Slice 2 — Jellyfin backend + surfacing.** `JellyfinServer` (validated flow),
+  config (`JELLYFIN_*` + back-compat), the fan-out list, the registry/onboarding/
+  settings/health surfacing, and the `_test_jellyfin` probe.
+- (**Slice 3 — Emby** — deferred, not scheduled.)
+
+## Testing
+
+- **Slice 1:** existing Plex integration tests must pass unchanged (the refactor is
+  behavior-preserving); add a thin `MediaServer` protocol-conformance test for
+  `PlexServer`. The fan-out list with a single Plex behaves exactly as today.
+- **Slice 2:** unit-test `JellyfinServer` against recorded/faked HTTP responses
+  (VirtualFolders parse; `refresh_for_file` = searchTerm + Path-match → item
+  refresh; full-refresh fallback when no match; `audio_lang_hints` from
+  MediaStreams; `X-Emby-Token` header). Fan-out best-effort: one server raising
+  never suppresses the other. Config back-compat: `PLEX_*`-only still yields a
+  single Plex server; adding `JELLYFIN_*` yields both. A live smoke against the
+  test Jellyfin (the proven core loop) before merge.
+- **Frontend:** pure helpers for the new integration cards, per the `__tests__/`
+  convention. Rebuild the bundle (drift check).
+
+## Acceptance criteria
+
+1. Existing Plex-only installs behave identically after Slice 1 (zero change).
+2. A user can configure Plex **and** Jellyfin; a landed sub refreshes **both**.
+3. A server being down/erroring does not block refresh on the other.
+4. Multi-instance arr content refreshes on whichever server(s) host it, with no
+   arr↔server configuration.
+5. `PLEX_*` env unchanged; `JELLYFIN_*` adds the second server.
+6. Full suite + vitest + bundle-drift green; live core-loop smoke passes.
+
+## Out of scope
+
+Emby backend; multiple servers of the same type (arbitrary instance list — deferred
+edge case); direct subtitle upload via the Jellyfin API (sidecar model retained);
+any change to the subtitle pipeline itself.

--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -121,6 +121,12 @@ class CompletionWatcher:
     def _plex(self):
         return self._bundle_provider().plex if self._bundle_provider else self._plex_direct
 
+    @property
+    def _media_servers(self):
+        if self._bundle_provider:
+            return self._bundle_provider().media_servers
+        return [self._plex_direct] if self._plex_direct else []
+
     def _bazarr_for(self, canonical_path: str):
         """#161 P3: the Bazarr client for the instance that owns this row's
         library (instance 0 when single-stack / unbound). Falls back to the
@@ -394,42 +400,34 @@ class CompletionWatcher:
             return False
 
     async def _maybe_plex_partial_scan(self, video_canonical: str) -> None:
-        """v1.1.1: best-effort Plex partial-scan trigger. Plex sees the file
-        at its own mount path (translated via PLEX_PATH_PREFIX if set); we
-        pass the resolved subarr-side full path to the client which handles
-        translation + section discovery.
+        """#71: best-effort media-server refresh trigger, fanned out over every
+        CONFIGURED media server (Plex today; Jellyfin/Emby join via
+        media_servers in later slices). Each server sees the file at its own
+        mount path (translated internally by that server's client); we pass
+        the resolved subarr-side full path and the fan-out handles the rest.
 
-        Disabled cleanly when (a) no plex client wired, (b) PLEX_PARTIAL_SCAN_ENABLED=0,
-        (c) Plex unconfigured. All failures log.warning and return — never
-        raises into the completion loop."""
-        if self._plex is None:
+        Disabled cleanly when (a) no media server wired/configured, (b)
+        PLEX_PARTIAL_SCAN_ENABLED=0. A single failing server never blocks the
+        others (refresh_file_on_all is best-effort) and never raises into the
+        completion loop."""
+        servers = [s for s in self._media_servers if s and s.is_configured()]
+        if not servers:
             return
         from .config import settings as _settings
 
         if not _settings.plex_partial_scan_enabled:
             return
-        if not self._plex.is_configured():
-            return
         try:
             # #134: library-aware resolve (@slug/ heads).
             subarr_full = str(canonical_to_fs(video_canonical))
         except PathOutsideRootError:
-            log.warning("plex partial-scan skipped: unresolvable canonical %s", video_canonical)
+            log.warning("media-server refresh skipped: unresolvable canonical %s", video_canonical)
             return
-        try:
-            result = await self._plex.partial_scan(subarr_full)
-            log.info(
-                "plex partial-scan fired: section=%s path=%s (ledger entry: %s)",
-                result.get("section"),
-                result.get("plex_path"),
-                video_canonical,
-            )
-        except IntegrationError as e:
-            log.warning(
-                "plex partial-scan failed for %s: %s (will be picked up by Plex's next periodic scan)",
-                video_canonical,
-                e,
-            )
+        from .integrations.media_server import refresh_file_on_all
+
+        results = await refresh_file_on_all(servers, subarr_full)
+        for r in results:
+            log.info("media-server refresh fired: %s (ledger entry: %s)", r, video_canonical)
 
     def _run_aftercare(self, entry) -> None:
         """#156: judge the produced subtitle and record the result. Best-effort

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -320,6 +320,13 @@ class IntegrationBundle:
     def bazarr(self, client):
         self._clients["bazarr"][""] = client
 
+    @property
+    def media_servers(self) -> list:
+        """All constructed media-server clients (currently just Plex). Callers
+        fan out over this and filter on is_configured(). Slice 2 appends
+        Jellyfin when JELLYFIN_* is set."""
+        return [self.plex]
+
     async def aclose(self) -> None:
         closers = [c.aclose() for pool in self._clients.values() for c in pool.values()]
         closers.append(self.tautulli.aclose())

--- a/src/subarr/integrations/media_server.py
+++ b/src/subarr/integrations/media_server.py
@@ -1,0 +1,41 @@
+"""#71 -- the media-server abstraction. Plex, Jellyfin (slice 2), and Emby
+(deferred) implement this. subarr writes subtitle sidecars to disk, then asks
+every configured media server to pick them up; the protocol is that contract."""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class MediaServer(Protocol):
+    """Structural interface for a media server subarr can drive. `type` is a
+    stable discriminator ("plex" | "jellyfin" | "emby")."""
+
+    type: str
+
+    def is_configured(self) -> bool: ...
+    def translate_path(self, subarr_path: str) -> str: ...
+    async def refresh_for_file(self, subarr_file: str) -> dict: ...
+    async def full_refresh(self) -> dict: ...
+    async def status(self) -> dict: ...
+    async def audio_lang_hints(self, titles) -> dict: ...
+    async def aclose(self) -> None: ...
+
+
+async def refresh_file_on_all(servers, subarr_file: str) -> list[dict]:
+    """Fan a per-file refresh out to every CONFIGURED server, best-effort: one
+    server erroring or being unconfigured never blocks the others. Returns the
+    per-server result dicts (skipped servers omitted)."""
+    results: list[dict] = []
+    for srv in servers:
+        try:
+            if not srv.is_configured():
+                continue
+            results.append(await srv.refresh_for_file(subarr_file))
+        except Exception as e:  # noqa: BLE001 -- a failing server must not abort the loop
+            log.warning("media-server refresh failed on %s: %s", getattr(srv, "type", "?"), e)
+    return results

--- a/src/subarr/integrations/plex.py
+++ b/src/subarr/integrations/plex.py
@@ -60,6 +60,7 @@ class PlexClient:
     CircuitBreaker to short-circuit calls when Plex is down/flapping."""
 
     name = "plex"
+    type = "plex"
 
     def __init__(
         self,
@@ -258,6 +259,14 @@ class PlexClient:
             "plex_path": scan_dir,
             "plex_status": r.status_code,
         }
+
+    async def refresh_for_file(self, subarr_file: str) -> dict:
+        """MediaServer protocol name for the per-file targeted refresh."""
+        return await self.partial_scan(subarr_file)
+
+    async def full_refresh(self) -> dict:
+        """MediaServer protocol name for the full library refresh."""
+        return await self.full_scan()
 
     async def status(self) -> dict:
         """Liveness + version probe for /api/integrations/health. Hits Plex

--- a/tests/test_media_server.py
+++ b/tests/test_media_server.py
@@ -1,0 +1,46 @@
+import pytest
+
+from subarr.integrations.media_server import MediaServer
+from subarr.integrations.plex import PlexClient
+
+pytestmark = pytest.mark.asyncio
+
+
+def _client():
+    return PlexClient(
+        base_url="http://plex:32400",
+        token="t",
+        default_section="all",
+        path_prefix="",
+        media_root="/media/library",
+    )
+
+
+def test_plex_client_satisfies_media_server_protocol():
+    c = _client()
+    assert isinstance(c, MediaServer)  # runtime_checkable structural check
+    assert c.type == "plex"
+
+
+async def test_refresh_for_file_delegates_to_partial_scan(monkeypatch):
+    c = _client()
+    calls = {}
+
+    async def fake_partial(p):
+        calls["path"] = p
+        return {"triggered": True, "scope": "partial"}
+
+    monkeypatch.setattr(c, "partial_scan", fake_partial)
+    out = await c.refresh_for_file("/media/library/TV/x.mkv")
+    assert calls["path"] == "/media/library/TV/x.mkv" and out["triggered"] is True
+
+
+async def test_full_refresh_delegates_to_full_scan(monkeypatch):
+    c = _client()
+
+    async def fake_full():
+        return {"triggered": True, "scope": "full"}
+
+    monkeypatch.setattr(c, "full_scan", fake_full)
+    out = await c.full_refresh()
+    assert out["scope"] == "full"

--- a/tests/test_media_server.py
+++ b/tests/test_media_server.py
@@ -3,8 +3,6 @@ import pytest
 from subarr.integrations.media_server import MediaServer
 from subarr.integrations.plex import PlexClient
 
-pytestmark = pytest.mark.asyncio
-
 
 def _client():
     return PlexClient(
@@ -22,6 +20,7 @@ def test_plex_client_satisfies_media_server_protocol():
     assert c.type == "plex"
 
 
+@pytest.mark.asyncio
 async def test_refresh_for_file_delegates_to_partial_scan(monkeypatch):
     c = _client()
     calls = {}
@@ -35,6 +34,7 @@ async def test_refresh_for_file_delegates_to_partial_scan(monkeypatch):
     assert calls["path"] == "/media/library/TV/x.mkv" and out["triggered"] is True
 
 
+@pytest.mark.asyncio
 async def test_full_refresh_delegates_to_full_scan(monkeypatch):
     c = _client()
 

--- a/tests/test_media_server_bundle.py
+++ b/tests/test_media_server_bundle.py
@@ -1,0 +1,14 @@
+"""IntegrationBundle.media_servers -- fan-out list of MediaServer clients (#71)."""
+
+from __future__ import annotations
+
+from subarr.coverage_engine import IntegrationBundle
+from subarr.integrations.media_server import MediaServer
+
+
+def test_bundle_media_servers_lists_plex(subarr_env):
+    b = IntegrationBundle()
+    servers = b.media_servers
+    assert isinstance(servers, list) and len(servers) == 1
+    assert servers[0] is b.plex
+    assert isinstance(servers[0], MediaServer)

--- a/tests/test_plex_partial_scan.py
+++ b/tests/test_plex_partial_scan.py
@@ -296,3 +296,71 @@ async def test_aclose_closes_underlying_client():
     assert not c._client.is_closed, "client should be open before aclose()"
     await c.aclose()
     assert c._client.is_closed, "client must be closed after aclose()"
+
+
+# ── #71 slice 1 task 3: completion-watcher hook fans out over media_servers ──
+
+
+@pytest.mark.asyncio
+async def test_refresh_fans_out_and_isolates_a_failing_server(subarr_env, media_root):
+    """The completion-watcher's post-write refresh hook must fan out over
+    every configured media server (not just Plex) and isolate a failing
+    server so it never blocks the others."""
+    from types import SimpleNamespace
+
+    from subarr.completion_watcher import CompletionWatcher
+    from subarr.paths import canonical_to_fs
+
+    class Srv:
+        def __init__(self, boom: bool):
+            self.type = "x"
+            self.boom = boom
+            self.got: str | None = None
+
+        def is_configured(self) -> bool:
+            return True
+
+        async def refresh_for_file(self, subarr_file: str) -> dict:
+            if self.boom:
+                raise RuntimeError("server down")
+            self.got = subarr_file
+            return {"triggered": True}
+
+    bad, good = Srv(boom=True), Srv(boom=False)
+    bundle = SimpleNamespace(media_servers=[bad, good])
+    w = CompletionWatcher(provenance=None, bundle_provider=lambda: bundle)
+
+    canonical = "TV/Show/ep.mkv"
+    await w._maybe_plex_partial_scan(canonical)
+
+    assert good.got == str(canonical_to_fs(canonical)), "good server should receive the resolved fs path"
+    assert bad.got is None, "the failing server's raise must not have reached the caller"
+
+
+@pytest.mark.asyncio
+async def test_refresh_still_fires_for_directly_injected_single_plex(subarr_env, media_root):
+    """Backward compat: the pre-#71 direct-injection wiring (no bundle_provider,
+    just plex=...) must still fan out over its single-element [plex] list —
+    i.e. the single-Plex case stays behavior-preserving."""
+    from subarr.completion_watcher import CompletionWatcher
+    from subarr.paths import canonical_to_fs
+
+    class Srv:
+        def __init__(self):
+            self.type = "plex"
+            self.got = None
+
+        def is_configured(self):
+            return True
+
+        async def refresh_for_file(self, subarr_file):
+            self.got = subarr_file
+            return {"triggered": True}
+
+    plex = Srv()
+    w = CompletionWatcher(provenance=None, plex=plex)
+
+    canonical = "TV/Show/ep.mkv"
+    await w._maybe_plex_partial_scan(canonical)
+
+    assert plex.got == str(canonical_to_fs(canonical))


### PR DESCRIPTION
Foundation for first-class multi-media-server support (#71/#72). RTFM + live validation + the Slice 1 refactor (Plex behind the abstraction, zero behavior change).

## Design docs
- `docs/jellyfin-api-research-2026-07-15.md` — full Plex→Jellyfin API mapping, gap analysis, validated live against Jellyfin 10.11.11 (auth, VirtualFolders, the sidecar→item-refresh→external-sub core loop, path→itemId lookup).
- `docs/superpowers/specs/2026-07-15-71-media-server-abstraction-design.md` — Model B (Plex + Jellyfin coexist, one-per-type; Emby deferred), config back-compat, best-effort fan-out, multi-instance-arr orthogonality, slicing.
- `docs/superpowers/plans/2026-07-15-71-slice1-media-server-abstraction.md` — this slice.

## Slice 1 code (zero user-visible change)
- `integrations/media_server.py`: `MediaServer` protocol (`runtime_checkable`) + best-effort `refresh_file_on_all` fan-out helper.
- `PlexClient` conforms: `type="plex"` + `refresh_for_file`/`full_refresh` delegating to `partial_scan`/`full_scan`.
- `IntegrationBundle.media_servers` -> `[plex]`.
- `completion_watcher` refresh hook routes through the fan-out over configured servers, preserving every guard (`plex_partial_scan_enabled`, `canonical_to_fs`/`PathOutsideRootError`, unconfigured short-circuit). Single-plex behaves identically.

Admin/health/audio-hints generalization is deferred to Slice 2 (lands with the Jellyfin surfacing; generalizing now with no second server is churn for no behavior change).

## Test plan
- [x] `tests/test_media_server.py` (protocol conformance + delegators), `tests/test_media_server_bundle.py` (media_servers list), `tests/test_plex_partial_scan.py` (+fan-out isolation + single-plex behavior-preservation).
- [x] Regression: plex/completion/retime/coverage/bundle suites green; ruff clean; no plex config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)