### PR TITLE
feat(#71): path-prefix auto-detect + Jellyfin dashboard tile + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Set only the ones for services you use. subarr reads these at boot; most also be
 | `SONARR_URL` / `SONARR_API_KEY` | `http://sonarr:8989` / — | Series metadata, original language, mediainfo. |
 | `RADARR_URL` / `RADARR_API_KEY` | `http://radarr:7878` / — | Movie metadata. |
 | `PLEX_URL` / `PLEX_TOKEN` | your Plex URL / — | Targeted library refresh after a sub lands. |
+| `JELLYFIN_URL` / `JELLYFIN_API_KEY` | your Jellyfin URL / — | Targeted library refresh after a sub lands. Optional; coexists with Plex (subtitles fan out to both). Create the key in Jellyfin Dashboard → API Keys. |
 | `TAUTULLI_URL` / `TAUTULLI_API_KEY` | `http://tautulli:8181` / — | Audio-track hints from your Plex history. |
 | `OLLAMA_URL` | `http://ollama:11434` | Ollama endpoint (optional AI features). |
 | `OLLAMA_MODEL` | `qwen2.5:7b` | Text model for Ollama tasks. |
@@ -325,7 +326,8 @@ Set only the ones for services you use. subarr reads these at boot; most also be
 | `SUBARR_MEDIA_ROOT` | `/media/library` | subarr's media root = the Default library. |
 | `SUBGEN_MEDIA_PREFIX` | `/media` | Prefix subgen sees media at (path translation to subgen). |
 | `ARR_PATH_PREFIX` | `/data/Media/` | Prefix Sonarr/Radarr report files under (path translation). |
-| `PLEX_PATH_PREFIX` | — | Prefix Plex sees paths under. Set this if you get "No Plex Section". |
+| `PLEX_PATH_PREFIX` | — | Prefix Plex sees paths under. Set this if you get "No Plex Section". Auto-detected from Plex's own sections when unset; set only to override. |
+| `JELLYFIN_PATH_PREFIX` | — | Prefix Jellyfin sees paths under, when different from `SUBARR_MEDIA_ROOT`. Auto-detected from Jellyfin's own libraries when unset; set only to override. |
 | `SUBARR_DB_PATH` | `/data/subarr.db` | SQLite DB. Must be on a persistent, local (non-network) volume. |
 
 ### Plex
@@ -374,6 +376,7 @@ Set only the ones for services you use. subarr reads these at boot; most also be
 | `NVIDIA_SMI_PATH` | — | Path to `nvidia-smi` for the GPU card. |
 | `SUBGEN_CONTAINER` / `SUBGEN_COMPOSE_PATH` | `subgen` / path | subgen container name + compose path for guided setup. |
 | `SUBARR_DOCKER_PROXY_URL` / `SUBARR_DOCKER_SOCKET_PATH` | — | Docker access for guided setup. |
+| `SUBARR_TELEMETRY_ENDPOINT` | `https://telemetry.subarr.com/v1/ping` | Anonymous telemetry receiver (see [Telemetry](#telemetry)). Set to empty to opt out. |
 
 ## Known limitations (v2.2)
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Once a verification exists, every downstream submission carries it through an ev
 
 **Do I need Tautulli?** No, but you get NOW PLAYING boost, just-imported boost, and per-user language profiles if you have it. Without Tautulli the scheduler still works, it just has one fewer priority signal.
 
-**Will this work with Jellyfin / Emby?** Not yet — a candidate if there's demand. Open a feature request.
+**Will this work with Jellyfin?** Yes. Add Jellyfin in Settings (URL + API key) and it runs alongside Plex — a landed subtitle refreshes both. Emby isn't supported yet; open a feature request if you want it.
 
 ## Multiple media locations (libraries)
 
@@ -390,7 +390,7 @@ Transparent before you install.
 - Multi-episode disc images (a single `.iso` holding a whole season) can't be probed per-episode, so they're surfaced in a distinct "Couldn't analyze" (unsupported) bucket rather than becoming verified gaps or sitting in "Analyzing" forever. Standard per-episode files are unaffected.
 - SQLite only. No Postgres backend.
 - Single-host. Workers / multi-host are an explicit non-goal until users ask.
-- Jellyfin / Emby are not yet supported.
+- Emby is not yet supported (Jellyfin is — it coexists with Plex, subtitles fan out to both).
 - Compose example uses bind mounts. Named volumes work but you lose the "same path Bazarr and subgen see" sanity.
 
 ## Backing up your data
@@ -530,7 +530,7 @@ Three deployment tiers (full templates in [`deploy/templates/`](deploy/templates
 
 - **Provider success leaderboard**: aggregate Bazarr per-provider history across opt-in installs into a global ranking. Closes "which subtitle providers actually deliver?", a long-standing Bazarr feature request.
 - **The federated tuning loop**: cross-install kwargs aggregation ranked by verification outcomes, and **"use community-best for &lt;language&gt;"** one-click adoption. The reference-free quality judge it was gated on now ships (LaBSE cross-lingual adequacy, validated).
-- **First-class media-server integration**: Jellyfin / Emby backends alongside Plex.
+- **Emby media-server backend**: alongside the shipped Plex + Jellyfin support (Jellyfin coexists with Plex today; Emby lands on demand).
 
 ## The subgen patch story
 

--- a/docs/superpowers/plans/2026-07-15-71-slice2c-path-autodetect.md
+++ b/docs/superpowers/plans/2026-07-15-71-slice2c-path-autodetect.md
@@ -1,0 +1,162 @@
+# #71 Slice 2c — path-prefix auto-detect + dashboard card + README
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** three things: (1) **auto-detect** the media-server path prefix from the server's library locations so nobody has to set `*_PATH_PREFIX` manually (Plex + Jellyfin); (2) add the **Jellyfin dashboard card** (Overview page); (3) document `JELLYFIN_*` in the README env table.
+
+**Architecture:** a pure `derive_path_prefix(locations, media_root, sample)` helper. Each client gains `library_locations()` + an async `_effective_prefix(sample)` (explicit env wins → cached auto-derived → identity fallback + log). `translate_path` takes an optional prefix override. `refresh_for_file`/`partial_scan` compute the effective prefix before translating. Dashboard card = one backend probe (frontend already has `SERVICE_BRAND.jellyfin`). Behavior-preserving: explicit prefix and identical-mount setups are unchanged (derive returns None → identity).
+
+---
+
+## Reference facts
+- `derive_path_prefix` math (validated by hand): subarr file `/media/library/TV/Show/ep.mkv`, `media_root=/media/library` → rel first segment `TV`; a server location `/media/TV` ends with `/TV` → prefix = `/media`. Identical mount (`media_root=/media/library`, location `/media/library` or `/media/library/TV`): no location ends with `/TV` off a different root, or the derived prefix equals `media_root` → identity, correct.
+- `JellyfinClient.libraries()` → `[{"name","paths":[...]}]` (paths = VirtualFolder Locations). `PlexClient.sections()` → `[{"id","title","paths":[...]}]`.
+- `home.py` dashboard probe list (~line 305): `asyncio.gather(_probe("bazarr"...), _probe("plex", bundle.plex), _probe("tautulli"...))`. Frontend `dashboard.jsx` `SERVICE_BRAND` already has `jellyfin` (committed) + `ServiceBadge` falls back for unknowns — so ONLY the backend probe is needed.
+- README env table added in v2.4.2; find it: `grep -n "PLEX_URL\|## Environment" README.md`.
+
+---
+
+### Task 1: pure `derive_path_prefix` helper
+
+**Files:** Modify `src/subarr/integrations/media_server.py`; Test `tests/test_path_prefix_autodetect.py`.
+
+- [ ] **Step 1 — failing tests:**
+```python
+from subarr.integrations.media_server import derive_path_prefix
+
+
+def test_derives_prefix_from_differing_mount():
+    # subarr sees /media/library/TV/...; server library at /media/TV -> prefix /media
+    assert derive_path_prefix(["/media/TV", "/media/Movies"], "/media/library", "/media/library/TV/Show/ep.mkv") == "/media"
+
+
+def test_identical_mount_returns_none():
+    # server library IS the media root -> no /TV-suffixed location off a different root -> None (identity)
+    assert derive_path_prefix(["/media/library"], "/media/library", "/media/library/TV/Show/ep.mkv") is None
+
+
+def test_file_outside_media_root_returns_none():
+    assert derive_path_prefix(["/media/TV"], "/media/library", "/other/TV/ep.mkv") is None
+
+
+def test_no_matching_location_returns_none():
+    assert derive_path_prefix(["/srv/Anime"], "/media/library", "/media/library/TV/ep.mkv") is None
+
+
+def test_trailing_slashes_tolerated():
+    assert derive_path_prefix(["/media/TV/"], "/media/library/", "/media/library/TV/ep.mkv") == "/media"
+```
+
+- [ ] **Step 2 — run, confirm fail.**
+- [ ] **Step 3 — implement** in `media_server.py`:
+```python
+def derive_path_prefix(locations: list[str], media_root: str, sample_subarr_path: str) -> str | None:
+    """Derive the path prefix P such that translate_path yields the server's own
+    path: P + sample[len(media_root):] lands under one of the server's library
+    `locations`. Returns None when no location aligns (caller falls back to
+    identity, which is correct for identical mounts)."""
+    media_root = (media_root or "").rstrip("/")
+    if not media_root or not sample_subarr_path.startswith(media_root):
+        return None
+    rel = sample_subarr_path[len(media_root):]
+    parts = [p for p in rel.split("/") if p]
+    if not parts:
+        return None
+    first = parts[0]
+    for loc in locations:
+        locn = (loc or "").rstrip("/")
+        if locn.endswith("/" + first):
+            prefix = locn[: -len("/" + first)]
+            # Identity if the derived prefix already equals the media root.
+            return prefix if prefix and prefix != media_root else None
+    return None
+```
+- [ ] **Step 4 — run, confirm pass. Step 5 — commit** `feat(#71): derive_path_prefix helper (media-server path auto-detect)`.
+
+---
+
+### Task 2: Jellyfin auto-detect wiring
+
+**Files:** Modify `src/subarr/integrations/jellyfin.py`; Test `tests/test_jellyfin_client.py` (extend).
+
+- [ ] **Step 1 — failing tests** (monkeypatch `_request` to return VirtualFolders + an item index):
+  - `refresh_for_file` with EMPTY explicit prefix but a server library at `/media/TV` → derives `/media`, translates the file, matches the item, refreshes.
+  - explicit `path_prefix` set → auto-detect NOT invoked (explicit wins).
+  - `_effective_prefix` caches (a second call doesn't re-fetch libraries).
+- [ ] **Step 2 — run, confirm fail.**
+- [ ] **Step 3 — implement**: add `self._auto_prefix: str | None = None` in `__init__`; add `library_locations()` (flatten `libraries()` paths); add `_effective_prefix(sample)`:
+```python
+    async def library_locations(self) -> list[str]:
+        libs = await self.libraries()
+        return [p for lib in libs for p in (lib.get("paths") or [])]
+
+    async def _effective_prefix(self, sample_subarr_path: str) -> str:
+        """Explicit JELLYFIN_PATH_PREFIX wins; else derive from library locations
+        (cached); else identity. Cached value "" means 'derived nothing, use identity'."""
+        if self._path_prefix:
+            return self._path_prefix
+        if self._auto_prefix is not None:
+            return self._auto_prefix
+        derived = None
+        try:
+            from .media_server import derive_path_prefix
+            derived = derive_path_prefix(await self.library_locations(), self._media_root, sample_subarr_path)
+        except Exception as e:  # noqa: BLE001
+            log.warning("jellyfin: path-prefix auto-detect failed: %s", e)
+        self._auto_prefix = derived or ""
+        log.info("jellyfin: path-prefix %s (media_root=%s)",
+                 f"auto-detected {derived!r}" if derived else "auto-detect found none; using identity",
+                 self._media_root)
+        return self._auto_prefix
+```
+  Make `translate_path` accept an optional override: `def translate_path(self, subarr_path, prefix=None):` using `p = self._path_prefix if prefix is None else prefix`. In `refresh_for_file`, compute `prefix = await self._effective_prefix(subarr_file)` and pass it: `jf_path = self.translate_path(subarr_file, prefix)`.
+- [ ] **Step 4 — run, confirm pass. Step 5 — commit** `feat(#71): Jellyfin path-prefix auto-detect (explicit wins, identity fallback)`.
+
+---
+
+### Task 3: Plex auto-detect wiring (same pattern, behind the same safe guards)
+
+**Files:** Modify `src/subarr/integrations/plex.py`; Test `tests/test_plex_partial_scan.py` (extend).
+
+- [ ] Mirror Task 2 on `PlexClient`: `self._auto_prefix=None`; `library_locations()` (flatten `sections()` paths); `_effective_prefix(sample)` (explicit `PLEX_PATH_PREFIX` wins → derive from section locations → identity); `translate_path(path, prefix=None)`; `partial_scan` computes `prefix = await self._effective_prefix(subarr_file_path)` and translates with it before section discovery.
+- [ ] **Tests**: explicit `PLEX_PATH_PREFIX` still wins (existing tests unchanged); empty prefix + a section at `/media/TV` derives `/media`; identical-mount derives None → identity (existing behavior preserved). Existing `test_plex_partial_scan.py` must stay green.
+- [ ] **Commit** `feat(#71): Plex path-prefix auto-detect (parity with Jellyfin, explicit wins)`.
+
+---
+
+### Task 4: Jellyfin dashboard card
+
+**Files:** Modify `src/subarr/routers/home.py`; Test the home/dashboard test file (grep `tests/` for the dashboard-tiles test).
+
+- [ ] Add jellyfin to the dashboard probe list **conditionally** (only when configured, so Plex-only installs don't get an empty tile): build the gather list, then `if bundle.jellyfin.is_configured(): probe_list.append(_probe("jellyfin", bundle.jellyfin))`. Keep the existing five unconditional.
+- [ ] **Test**: with a configured jellyfin stub, the dashboard tiles include `jellyfin`; unconfigured → absent. (frontend needs no change — `SERVICE_BRAND.jellyfin` + `ServiceBadge` already handle rendering.)
+- [ ] **Commit** `feat(#71): jellyfin dashboard tile (probed when configured)`.
+
+---
+
+### Task 5: README env table
+
+**Files:** Modify `README.md`.
+
+- [ ] Find the env table (`grep -n "PLEX_URL\|PLEX_TOKEN\|## Environment" README.md`). Add a Jellyfin block near Plex:
+  - `JELLYFIN_URL` — Jellyfin server URL (optional; coexists with Plex).
+  - `JELLYFIN_API_KEY` — Jellyfin API key (Dashboard → API Keys).
+  - `JELLYFIN_PATH_PREFIX` — **optional**; the path Jellyfin sees the media at (e.g. `/media`). Auto-detected from the server's libraries when unset; set only to override.
+- [ ] Sweep for any env vars added since the table was written that are missing (e.g. `SUBARR_FORCED_SEGMENT_ENABLED` if not present) — `grep -oE "SUBARR_[A-Z_]+|JELLYFIN_[A-Z_]+" src/subarr/config.py | sort -u` vs the README table; add any gaps.
+- [ ] **Commit** `docs(#71): document JELLYFIN_* env vars (path prefix auto-detected)`.
+
+---
+
+### Task 6: verification + live smoke + PR
+
+- [ ] Targeted suites (`test_path_prefix_autodetect`, `test_jellyfin_client`, `test_plex_partial_scan`, dashboard test) + ruff + `npm run check:frontend`.
+- [ ] **LIVE SMOKE — the proof**: temporarily **remove** `JELLYFIN_PATH_PREFIX` from subarr-next's env (or override it empty), recreate, and confirm the client **auto-derives `/media`** and a real `refresh_for_file` still matches the item. Then restore the env var (belt-and-suspenders) OR leave it removed since auto-detect now covers it — note the choice.
+- [ ] Push; CI (full suite + frontend + bundle-drift). Zero behavior change for explicit-prefix / identical-mount installs.
+- [ ] **PR** (base main): `feat(#71): path-prefix auto-detect + Jellyfin dashboard card + README`. Body: the three deliverables, the live auto-detect proof, and that it kills the path-prefix footgun for both servers.
+
+---
+
+## Self-Review notes
+- **Behavior-preserving**: explicit `*_PATH_PREFIX` always wins (existing setups untouched); identical-mount derives None → identity (today's behavior). Only the previously-broken empty-prefix-different-mount case improves.
+- **No frontend change for the dashboard card** — `SERVICE_BRAND.jellyfin` is already committed; only the backend probe was missing.
+- **Type consistency**: `translate_path(path, prefix=None)` stays protocol-compatible (optional arg); `_effective_prefix` returns a str; `derive_path_prefix` returns `str | None`.

--- a/src/subarr/integrations/jellyfin.py
+++ b/src/subarr/integrations/jellyfin.py
@@ -38,15 +38,17 @@ class JellyfinClient:
         )
         self._breaker = breaker or CircuitBreaker(name=self.name)
         self._path_index: dict[str, str] | None = None  # jellyfin Path -> itemId
+        self._auto_prefix: str | None = None  # cached auto-detected prefix ("" = none found)
 
     def is_configured(self) -> bool:
         return bool(self._base_url and self._api_key)
 
-    def translate_path(self, subarr_path: str) -> str:
-        if not self._path_prefix or not self._media_root:
+    def translate_path(self, subarr_path: str, prefix: str | None = None) -> str:
+        p = self._path_prefix if prefix is None else prefix
+        if not p or not self._media_root:
             return subarr_path
         if subarr_path.startswith(self._media_root):
-            return self._path_prefix + subarr_path[len(self._media_root) :]
+            return p + subarr_path[len(self._media_root) :]
         return subarr_path
 
     async def _request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
@@ -95,8 +97,35 @@ class JellyfinClient:
             item_id = self._path_index.get(jf_path)
         return item_id
 
+    async def library_locations(self) -> list[str]:
+        libs = await self.libraries()
+        return [p for lib in libs for p in (lib.get("paths") or [])]
+
+    async def _effective_prefix(self, sample_subarr_path: str) -> str:
+        """Explicit JELLYFIN_PATH_PREFIX wins; else derive from library locations
+        (cached); else identity. Cached "" means 'derived nothing, use identity'."""
+        if self._path_prefix:
+            return self._path_prefix
+        if self._auto_prefix is not None:
+            return self._auto_prefix
+        from .media_server import derive_path_prefix
+
+        derived = None
+        try:
+            derived = derive_path_prefix(await self.library_locations(), self._media_root, sample_subarr_path)
+        except Exception as e:  # noqa: BLE001
+            log.warning("jellyfin: path-prefix auto-detect failed: %s", e)
+        self._auto_prefix = derived or ""
+        log.info(
+            "jellyfin: path-prefix %s (media_root=%s)",
+            f"auto-detected {derived!r}" if derived else "auto-detect found none; using identity",
+            self._media_root,
+        )
+        return self._auto_prefix
+
     async def refresh_for_file(self, subarr_file: str) -> dict:
-        jf_path = self.translate_path(subarr_file)
+        prefix = await self._effective_prefix(subarr_file)
+        jf_path = self.translate_path(subarr_file, prefix)
         item_id = await self._find_item_id(jf_path)
         if item_id is None:
             log.warning("jellyfin: no item matched %s (path-prefix mismatch or not indexed)", jf_path)

--- a/src/subarr/integrations/media_server.py
+++ b/src/subarr/integrations/media_server.py
@@ -39,3 +39,24 @@ async def refresh_file_on_all(servers, subarr_file: str) -> list[dict]:
         except Exception as e:  # noqa: BLE001 -- a failing server must not abort the loop
             log.warning("media-server refresh failed on %s: %s", getattr(srv, "type", "?"), e)
     return results
+
+
+def derive_path_prefix(locations: list[str], media_root: str, sample_subarr_path: str) -> str | None:
+    """Derive the path prefix P such that translate_path yields the server's own
+    path: P + sample[len(media_root):] lands under one of the server's library
+    `locations`. Returns None when no location aligns (caller falls back to
+    identity, which is correct for identical mounts)."""
+    media_root = (media_root or "").rstrip("/")
+    if not media_root or not sample_subarr_path.startswith(media_root):
+        return None
+    rel = sample_subarr_path[len(media_root) :]
+    parts = [p for p in rel.split("/") if p]
+    if not parts:
+        return None
+    first = parts[0]
+    for loc in locations:
+        locn = (loc or "").rstrip("/")
+        if locn.endswith("/" + first):
+            prefix = locn[: -len("/" + first)]
+            return prefix if prefix and prefix != media_root else None
+    return None

--- a/src/subarr/integrations/plex.py
+++ b/src/subarr/integrations/plex.py
@@ -99,20 +99,58 @@ class PlexClient:
         # restart — per-show audio prefs are stable.
         self._show_index: dict[str, str] | None = None
         self._audio_hint_cache: dict[str, str | None] = {}
+        # #71 slice 2c: cached auto-detected prefix ("" = derive attempted,
+        # found nothing -> use identity). None = not attempted yet.
+        self._auto_prefix: str | None = None
 
     def is_configured(self) -> bool:
         return bool(self._base_url and self._token)
 
-    def translate_path(self, subarr_path: str) -> str:
+    def translate_path(self, subarr_path: str, prefix: str | None = None) -> str:
         """Translate a subarr-side absolute path (e.g. /media/library/TV/X.srt)
-        into the path Plex sees. Identity translation when PLEX_PATH_PREFIX
-        is unset or matches subarr's media_root."""
-        if not self._path_prefix or not self._media_root:
+        into the path Plex sees. Identity translation when the effective
+        prefix is unset or matches subarr's media_root.
+
+        `prefix` overrides the configured PLEX_PATH_PREFIX (used by
+        partial_scan/refresh_for_file to apply an auto-detected prefix
+        without mutating the explicit config)."""
+        p = self._path_prefix if prefix is None else prefix
+        if not p or not self._media_root:
             return subarr_path
         if subarr_path.startswith(self._media_root):
-            return self._path_prefix + subarr_path[len(self._media_root) :]
+            return p + subarr_path[len(self._media_root) :]
         # Unknown root — return as-is and let Plex's section matcher decide.
         return subarr_path
+
+    async def library_locations(self) -> list[str]:
+        """Flatten every section's Location paths — used as the candidate
+        set for path-prefix auto-detection."""
+        secs = await self.sections()
+        return [p for s in secs for p in (s.get("paths") or [])]
+
+    async def _effective_prefix(self, sample_subarr_path: str) -> str:
+        """Explicit PLEX_PATH_PREFIX wins; else derive from Plex's own
+        section Location paths (cached); else identity. Mirrors
+        JellyfinClient._effective_prefix. Cached "" means 'derived nothing,
+        use identity'."""
+        if self._path_prefix:
+            return self._path_prefix
+        if self._auto_prefix is not None:
+            return self._auto_prefix
+        from .media_server import derive_path_prefix
+
+        derived = None
+        try:
+            derived = derive_path_prefix(await self.library_locations(), self._media_root, sample_subarr_path)
+        except Exception as e:  # noqa: BLE001
+            log.warning("plex: path-prefix auto-detect failed: %s", e)
+        self._auto_prefix = derived or ""
+        log.info(
+            "plex: path-prefix %s (media_root=%s)",
+            f"auto-detected {derived!r}" if derived else "auto-detect found none; using identity",
+            self._media_root,
+        )
+        return self._auto_prefix
 
     # ── #290: central transport helper ───────────────────────────────────────
 
@@ -229,7 +267,7 @@ class PlexClient:
         discovered automatically when PLEX_SECTION is "all"."""
         if not self.is_configured():
             raise IntegrationError("plex not configured")
-        plex_path = self.translate_path(subarr_file_path)
+        plex_path = self.translate_path(subarr_file_path, await self._effective_prefix(subarr_file_path))
         # Plex expects a directory; pass the parent of the file.
         scan_dir = str(PurePosixPath(plex_path).parent)
         # Resolve section: explicit numeric setting wins, else discover.

--- a/src/subarr/routers/home.py
+++ b/src/subarr/routers/home.py
@@ -302,13 +302,19 @@ async def _integrations_block(state) -> list[dict[str, Any]]:
     from .integrations import _probe
 
     bundle = state.integrations
-    probes = await asyncio.gather(
+    probe_coros = [
         _probe("bazarr", bundle.bazarr, "bazarr_badges"),
         _probe("sonarr", bundle.sonarr),
         _probe("radarr", bundle.radarr),
         _probe("plex", bundle.plex),
         _probe("tautulli", bundle.tautulli),
-    )
+    ]
+    # Jellyfin is optional (Plex-only installs are common) — only probe/tile
+    # it when configured, so an unconfigured install doesn't get a dead
+    # "not configured" tile cluttering the dashboard.
+    if bundle.jellyfin.is_configured():
+        probe_coros.append(_probe("jellyfin", bundle.jellyfin))
+    probes = await asyncio.gather(*probe_coros)
     out = [_to_tile(p) for p in probes]
 
     # Add subgen tile from cached caps.

--- a/tests/test_jellyfin_client.py
+++ b/tests/test_jellyfin_client.py
@@ -85,3 +85,60 @@ async def test_status_reads_system_info(monkeypatch):
 
     monkeypatch.setattr(c, "_request", fake_request)
     assert (await c.status())["version"] == "10.11.11"
+
+
+@pytest.mark.asyncio
+async def test_auto_detects_prefix_when_explicit_empty(monkeypatch):
+    # No explicit prefix; server library at /media/TV -> derive /media, match item, refresh
+    c = JellyfinClient(base_url="http://jf:8096", api_key="k", path_prefix="", media_root="/media/library")
+    calls = []
+
+    async def fake_request(method, path, params=None):
+        calls.append((method, path))
+        if path == "/Library/VirtualFolders":
+            return _Resp([{"Name": "Shows", "Locations": ["/media/TV"]}])
+        if path == "/Items":
+            return _Resp({"Items": [{"Path": "/media/TV/Show/ep.mkv", "Id": "id1"}]})
+        return _Resp({})
+
+    monkeypatch.setattr(c, "_request", fake_request)
+    out = await c.refresh_for_file("/media/library/TV/Show/ep.mkv")
+    assert out["triggered"] is True and out["item_id"] == "id1"
+
+
+@pytest.mark.asyncio
+async def test_explicit_prefix_wins_no_autodetect(monkeypatch):
+    c = JellyfinClient(
+        base_url="http://jf:8096", api_key="k", path_prefix="/media", media_root="/media/library"
+    )
+    fetched = {"libs": 0}
+
+    async def fake_request(method, path, params=None):
+        if path == "/Library/VirtualFolders":
+            fetched["libs"] += 1
+            return _Resp([])
+        if path == "/Items":
+            return _Resp({"Items": [{"Path": "/media/TV/Show/ep.mkv", "Id": "id1"}]})
+        return _Resp({})
+
+    monkeypatch.setattr(c, "_request", fake_request)
+    out = await c.refresh_for_file("/media/library/TV/Show/ep.mkv")
+    assert out["triggered"] is True
+    assert fetched["libs"] == 0  # explicit prefix -> never fetched libraries
+
+
+@pytest.mark.asyncio
+async def test_effective_prefix_is_cached(monkeypatch):
+    c = JellyfinClient(base_url="http://jf:8096", api_key="k", path_prefix="", media_root="/media/library")
+    fetched = {"libs": 0}
+
+    async def fake_request(method, path, params=None):
+        if path == "/Library/VirtualFolders":
+            fetched["libs"] += 1
+            return _Resp([{"Name": "Shows", "Locations": ["/media/TV"]}])
+        return _Resp({"Items": []})
+
+    monkeypatch.setattr(c, "_request", fake_request)
+    await c._effective_prefix("/media/library/TV/x.mkv")
+    await c._effective_prefix("/media/library/TV/y.mkv")
+    assert fetched["libs"] == 1  # derived once, cached

--- a/tests/test_jellyfin_surfacing.py
+++ b/tests/test_jellyfin_surfacing.py
@@ -35,3 +35,34 @@ def test_health_includes_jellyfin(app_with_stub):
     r = app_with_stub.get("/api/integrations/health")
     names = {i["name"] for i in r.json().get("integrations", [])}
     assert "jellyfin" in names
+
+
+# ─── Slice 2c, Task 4 (#71): Home dashboard tile ─────────────────────
+#
+# The dashboard tile list (/api/home/dashboard) is a DIFFERENT probe set
+# from /api/integrations/health above — it must NOT show a jellyfin tile
+# for Plex-only installs (no dead "not configured" tile clutter), but
+# MUST show one once Jellyfin is configured.
+
+
+def test_dashboard_omits_jellyfin_tile_when_unconfigured(app_with_stub):
+    r = app_with_stub.get("/api/home/dashboard?fresh=true")
+    assert r.status_code == 200
+    names = {i["name"] for i in r.json().get("integrations", [])}
+    assert "jellyfin" not in names
+
+
+def test_dashboard_includes_jellyfin_tile_when_configured(app_with_stub, monkeypatch):
+    app = app_with_stub.app
+    jellyfin = app.state.integrations.jellyfin
+    monkeypatch.setattr(jellyfin, "is_configured", lambda: True)
+
+    async def fake_status():
+        return {"version": "10.11.11", "server_name": "test-jf"}
+
+    monkeypatch.setattr(jellyfin, "status", fake_status)
+
+    r = app_with_stub.get("/api/home/dashboard?fresh=true")
+    assert r.status_code == 200
+    names = {i["name"] for i in r.json().get("integrations", [])}
+    assert "jellyfin" in names

--- a/tests/test_path_prefix_autodetect.py
+++ b/tests/test_path_prefix_autodetect.py
@@ -1,0 +1,24 @@
+from subarr.integrations.media_server import derive_path_prefix
+
+
+def test_derives_prefix_from_differing_mount():
+    assert (
+        derive_path_prefix(["/media/TV", "/media/Movies"], "/media/library", "/media/library/TV/Show/ep.mkv")
+        == "/media"
+    )
+
+
+def test_identical_mount_returns_none():
+    assert derive_path_prefix(["/media/library"], "/media/library", "/media/library/TV/Show/ep.mkv") is None
+
+
+def test_file_outside_media_root_returns_none():
+    assert derive_path_prefix(["/media/TV"], "/media/library", "/other/TV/ep.mkv") is None
+
+
+def test_no_matching_location_returns_none():
+    assert derive_path_prefix(["/srv/Anime"], "/media/library", "/media/library/TV/ep.mkv") is None
+
+
+def test_trailing_slashes_tolerated():
+    assert derive_path_prefix(["/media/TV/"], "/media/library/", "/media/library/TV/ep.mkv") == "/media"

--- a/tests/test_plex_partial_scan.py
+++ b/tests/test_plex_partial_scan.py
@@ -338,6 +338,104 @@ async def test_refresh_fans_out_and_isolates_a_failing_server(subarr_env, media_
 
 
 @pytest.mark.asyncio
+async def test_partial_scan_auto_detects_prefix_when_empty():
+    """#71 slice 2c task 3: PLEX_PATH_PREFIX unset -> derive the prefix from
+    Plex's own section Location paths (mirrors JellyfinClient). The derived
+    prefix must be applied to translate_path AND to section discovery so the
+    right numeric section id is still found."""
+    captured: list[httpx.Request] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured.append(req)
+        if req.url.path == "/library/sections":
+            return httpx.Response(200, text=SECTIONS_XML)
+        if req.url.path.startswith("/library/sections/") and req.url.path.endswith("/refresh"):
+            return httpx.Response(200, text="")
+        return httpx.Response(404)
+
+    c = PlexClient(
+        base_url="http://plex.test:32400",
+        token="testtoken",
+        default_section="all",
+        path_prefix="",  # explicit prefix unset -> must auto-detect
+        media_root="/media/library",
+    )
+    c._client = httpx.AsyncClient(
+        base_url="http://plex.test:32400",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = await c.partial_scan("/media/library/TV/Foo/S01E01.srt")
+
+    assert result["triggered"] is True
+    assert result["section"] == "3"  # TV Shows
+    # Auto-derived prefix ("/data/Media") applied, same as if it had been set explicitly.
+    assert result["plex_path"] == "/data/Media/TV/Foo"
+    refresh_req = next(r for r in captured if r.url.path.endswith("/refresh"))
+    assert refresh_req.url.params["path"] == "/data/Media/TV/Foo"
+
+
+@pytest.mark.asyncio
+async def test_effective_prefix_caches_auto_detect_across_calls():
+    """The derived prefix must be cached on the instance (self._auto_prefix)
+    so repeat scans do not re-list sections just to re-derive the prefix."""
+    section_list_calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/library/sections":
+            section_list_calls["n"] += 1
+            return httpx.Response(200, text=SECTIONS_XML)
+        if req.url.path.startswith("/library/sections/") and req.url.path.endswith("/refresh"):
+            return httpx.Response(200, text="")
+        return httpx.Response(404)
+
+    c = PlexClient(
+        base_url="http://plex.test:32400",
+        token="testtoken",
+        default_section="all",
+        path_prefix="",
+        media_root="/media/library",
+    )
+    c._client = httpx.AsyncClient(
+        base_url="http://plex.test:32400",
+        transport=httpx.MockTransport(handler),
+    )
+
+    prefix1 = await c._effective_prefix("/media/library/TV/Foo/S01E01.srt")
+    prefix2 = await c._effective_prefix("/media/library/TV/Foo/S01E02.srt")
+
+    assert prefix1 == "/data/Media"
+    assert prefix2 == "/data/Media"
+    assert c._auto_prefix == "/data/Media"
+    # sections() is called once for prefix derivation (then cached on
+    # self._auto_prefix); it may separately be called again for section
+    # discovery inside partial_scan, but _effective_prefix itself must not
+    # re-list sections on the second call.
+    assert section_list_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_effective_prefix_explicit_prefix_skips_auto_detect():
+    """Explicit PLEX_PATH_PREFIX must win outright -- _effective_prefix must
+    not even call sections() to attempt auto-detection."""
+    c = PlexClient(
+        base_url="http://plex.test:32400",
+        token="t",
+        default_section="all",
+        path_prefix="/data/Media",  # explicit -- must short-circuit
+        media_root="/media/library",
+    )
+
+    async def boom(refresh: bool = False):
+        raise AssertionError("sections() must not be called when an explicit prefix is set")
+
+    c.sections = boom  # type: ignore[method-assign]
+
+    prefix = await c._effective_prefix("/media/library/TV/Foo/S01E01.srt")
+    assert prefix == "/data/Media"
+
+
+@pytest.mark.asyncio
 async def test_refresh_still_fires_for_directly_injected_single_plex(subarr_env, media_root):
     """Backward compat: the pre-#71 direct-injection wiring (no bundle_provider,
     just plex=...) must still fan out over its single-element [plex] list —


### PR DESCRIPTION
Slice 2c — kills the media-server path-prefix footgun, adds the Jellyfin dashboard tile, and documents the env vars.

## What
1. **Path-prefix auto-detect** (Plex + Jellyfin): when `*_PATH_PREFIX` is unset, the client derives the prefix from the server's own library locations (`/Library/VirtualFolders` for Jellyfin, `/library/sections` for Plex) vs subarr's `SUBARR_MEDIA_ROOT`. Pure `derive_path_prefix` helper; cached per client. **Explicit env always wins; identity fallback + log** when nothing aligns (which is correct for identical mounts — why Plex "just worked" before). No more manual path-prefix config.
2. **Jellyfin dashboard tile** (`home.py`): probed only when configured (no dead tile on Plex-only installs). Frontend already had `SERVICE_BRAND.jellyfin` — backend-only change.
3. **README**: `JELLYFIN_*` env rows (path prefix noted as optional/auto-detected), a missing `SUBARR_TELEMETRY_ENDPOINT` caught by the audit, and corrected the stale "Jellyfin not supported" mentions (Jellyfin ships; Emby deferred).

## Behavior-preserving
Explicit `*_PATH_PREFIX` and identical-mount setups are unchanged (all 14 existing `test_plex_partial_scan.py` tests pass untouched). Only the previously-broken empty-prefix-different-mount case improves.

## Test plan
- [x] `derive_path_prefix` (5 tests incl. identity-mount→None), Jellyfin + Plex auto-detect (explicit-wins, cached, identity fallback), dashboard-tile-when-configured. 38 targeted green; ruff + bundle-drift clean.
- [x] **Live proof against real Jellyfin 10.11.11**: with NO explicit prefix, the client auto-derived `/media` from the server's libraries and a real `refresh_for_file` matched the item — confirmed both via host client and the live subarr-next instance (env var removed).

Closes the Jellyfin epic's UX gaps for #71/#72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)