### PR TITLE
fix(ci): expire the apt layer daily so security patches actually land

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,12 @@ jobs:
             type=sha,format=short
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
+      # Expire the Dockerfile's apt layer daily, so a published image never
+      # ships packages Debian has already patched just because the GHA layer
+      # cache was warm — see the APT_REFRESH comment in the Dockerfile.
+      - id: aptdate
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -82,6 +88,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            APT_REFRESH=${{ steps.aptdate.outputs.date }}
 
   # Auto-create the GitHub Release on a version tag, AFTER the image publishes
   # (#229). A bare tag with no Release shows an empty title in releases.atom,

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -140,6 +140,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      # Expire the Dockerfile's apt layer daily. Without this the GHA cache
+      # serves a stale layer and we scan (and ship) packages that Debian has
+      # already patched — see the APT_REFRESH comment in the Dockerfile.
+      - id: aptdate
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
       - name: build image (no push)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -147,6 +152,8 @@ jobs:
           load: true
           tags: subarr:scan
           cache-from: type=gha
+          build-args: |
+            APT_REFRESH=${{ steps.aptdate.outputs.date }}
       # The table-format invocation is the actual PR gate. Why not the
       # SARIF one? In format=sarif mode, trivy-action internally scans
       # with "all severities" to populate the GitHub code-scanning UI,

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,17 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 PIP_NO_CACHE_DIR=1
 # also patches ffmpeg/mkvtoolnix's transitive deps to +debNuN — upgrading before
 # the install left those freshly-pulled deps at the unpatched base version.
 # Patch-don't-suppress, same as subarr-subgen.
-RUN apt-get update \
+#
+# APT_REFRESH exists because the GHA layer cache would otherwise serve this
+# layer for days: neither `update` nor `upgrade` re-runs on a cache hit, so a
+# security patch that Debian has already published silently never lands and we
+# ship a known-fixed CVE (caught by the trivy gate on libtiff CVE-2026-12912,
+# fixed in +deb13u3 while the cached layer still had u2). CI passes the current
+# UTC date, so this layer expires once a day and every scan + published image
+# gets current packages. Referenced in the RUN so the value actually busts it.
+ARG APT_REFRESH=0
+RUN echo "apt-refresh=${APT_REFRESH}" \
+    && apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg mkvtoolnix passwd util-linux \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

The trivy gate on #427 was failing on `libtiff6` CVE-2026-12912 (installed `4.7.0-3+deb13u2`, fixed in `+deb13u3`). Root cause is not the CVE, it is the cache: both the trivy scan build (`security.yml`) and the release publish build (`release.yml`) use `cache-from: type=gha`, which made the Dockerfile apt layer a cache hit for days. On a cache hit neither `apt-get update` nor `apt-get upgrade -y` re-runs, so published security patches silently never reached the image.

This is structural, not a one-off. The earlier Mesa fix only worked incidentally because reordering the `RUN` changed its text and busted the cache by accident. Left alone, published images can carry CVEs Debian has already fixed.

## Fix

- `Dockerfile`: `ARG APT_REFRESH=0`, referenced inside the `RUN` so the value actually invalidates the layer.
- `security.yml` + `release.yml`: pass `APT_REFRESH=<current UTC date>` as a build-arg.

The layer now expires once per day. Normal layer caching is otherwise preserved (pip install, source copy, etc all still cache).

## Verification

Local build with the cache-busted arg, same base image:

```
ii  libtiff6:amd64  4.7.0-3+deb13u3  amd64  Tag Image File Format (TIFF) library
```

`zizmor` clean on both workflows (1 ignored, 8 suppressed, no findings).

## Test Plan

- [ ] trivy job goes green on this PR
- [ ] rebase #427 on this and confirm its trivy job goes green too