### PR TITLE
ci: watch the published image, and make :stable promotion arch-safe

### DIFF
--- a/.github/workflows/image-staleness.yml
+++ b/.github/workflows/image-staleness.yml
@@ -1,0 +1,142 @@
+# Weekly staleness detector for the PUBLISHED image.
+#
+# The problem it solves: security.yml's trivy job builds a FRESH image and
+# scans that. A fresh build picks up whatever Debian published this morning,
+# so it is green almost by construction. Meanwhile users pull
+# ghcr.io/coaxk/subarr:latest, which was built whenever we last cut a release
+# and never changes afterwards. Releases are tag-driven and infrequent, so
+# that image can sit for weeks accumulating unpatched packages while every
+# scan stays green.
+#
+# Ported from coaxk/subarr-subgen, where this exact detector caught the
+# published image 7 days behind with 11 outstanding security packages
+# (subarr-subgen#33) on its first scheduled run.
+#
+# This job inspects the ARTIFACT instead of a rebuild: pull the published
+# image, ask apt what is upgradable, and report anything from a -security
+# pocket. It deliberately does NOT rebuild or republish — silently changing
+# what :latest contains under an unchanged tag is the "artifact is not the
+# tag" trap in reverse. A human cuts the next release when it justifies one.
+#
+# POCKET NAMING: subarr is Debian (python:3.12-slim -> trixie), so security
+# updates render as `pkg/trixie-security`; subarr-subgen is Ubuntu, where they
+# render as `pkg/jammy-security`. The `-security` substring matches both.
+# Plain `trixie`/`stable` and `trixie-updates` entries are ordinary updates,
+# NOT security, and are deliberately excluded — verified against the live
+# image's sources.list.d (deb.debian.org/debian-security, Suites:
+# trixie-security).
+#
+# Sticky issue: one issue per episode, close it after cutting the release and
+# the next occurrence opens fresh.
+
+name: image-staleness
+
+on:
+  schedule:
+    # Fridays 07:00 UTC. Staggered away from security.yml (Mon 07:00) and away
+    # from subarr-subgen's own staleness run (Thu 07:00), so a bad week does
+    # not deliver both reports at once.
+    - cron: "0 7 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: published image OS package staleness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # open/update the sticky report
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      IMAGE: ghcr.io/coaxk/subarr:latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: inspect the published image
+        id: inspect
+        run: |
+          set -euo pipefail
+          docker pull -q "$IMAGE"
+
+          BUILT="$(docker inspect "$IMAGE" --format '{{.Created}}')"
+          BUILT_EPOCH="$(date -u -d "$BUILT" +%s)"
+          AGE_DAYS=$(( ( $(date -u +%s) - BUILT_EPOCH ) / 86400 ))
+          echo "built=$BUILT" >> "$GITHUB_OUTPUT"
+          echo "age_days=$AGE_DAYS" >> "$GITHUB_OUTPUT"
+
+          # `apt list --upgradable` needs fresh lists; the image strips them.
+          # --entrypoint sh so this does not boot subarr.
+          docker run --rm --entrypoint sh "$IMAGE" -c \
+            'apt-get update -qq >/dev/null 2>&1 && apt list --upgradable 2>/dev/null' \
+            | grep -v '^Listing' | sort > all.txt || true
+
+          grep -- '-security' all.txt > sec.txt || true
+          echo "total=$(wc -l < all.txt)" >> "$GITHUB_OUTPUT"
+          echo "security=$(wc -l < sec.txt)" >> "$GITHUB_OUTPUT"
+
+          # Printed unconditionally: a silent run is ambiguous (genuinely clean
+          # vs the probe broke), so this line is what proves the check ran.
+          echo "image is $AGE_DAYS days old; $(wc -l < all.txt) upgradable, $(wc -l < sec.txt) from -security"
+
+      - name: report if behind
+        if: steps.inspect.outputs.security != '0'
+        # Env indirection rather than inline ${{ }} in the script: an
+        # expression expanded directly into `run:` becomes shell code
+        # (template injection). Same practice as release.yml. (zizmor)
+        env:
+          BUILT: ${{ steps.inspect.outputs.built }}
+          AGE_DAYS: ${{ steps.inspect.outputs.age_days }}
+          TOTAL: ${{ steps.inspect.outputs.total }}
+          SECURITY: ${{ steps.inspect.outputs.security }}
+        run: |
+          set -euo pipefail
+          {
+            echo "The published image users pull is behind on OS security updates."
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Image | \`${IMAGE}\` |"
+            echo "| Built | ${BUILT} |"
+            echo "| Age | ${AGE_DAYS} days |"
+            echo "| Upgradable packages | ${TOTAL} |"
+            echo "| From a -security pocket | **${SECURITY}** |"
+            echo
+            echo "This is not a trivy finding. security.yml builds a fresh image and scans"
+            echo "that, so it stays green while the artifact on GHCR ages. These are packages"
+            echo "with published fixes that the running image does not have."
+            echo
+            echo "<details><summary>Security-pocket packages</summary>"
+            echo
+            echo '```'
+            cat sec.txt
+            echo '```'
+            echo
+            echo "</details>"
+            echo
+            echo "**Action:** cut a patch release when this looks worth it. The Dockerfile"
+            echo "already runs \`apt-get upgrade -y\` behind APT_REFRESH, so a rebuild picks"
+            echo "these up with no code change. An OS-security refresh is a rebuild, not a"
+            echo "feature release: bump the version so the artifact is identifiable, and the"
+            echo "soak does not restart (the code is unchanged; only packages moved)."
+            echo
+            echo "Deliberately not auto-rebuilt: published versions are immutable, and quietly"
+            echo "changing what \`:latest\` contains under the same tag defeats the point."
+            echo
+            echo "Close this issue once the release is cut; the next occurrence opens a fresh one."
+            echo
+            echo "Run: ${RUN_URL}"
+          } > body.md
+
+          bash scripts/sticky-issue.sh \
+            "${GITHUB_REPOSITORY}" \
+            "image-staleness" \
+            "Published image is behind on OS security updates" \
+            "body.md" \
+            "image-staleness,low-priority" \
+            "still behind as of $(date -u +%Y-%m-%d): ${SECURITY} security-pocket package(s), image ${AGE_DAYS} days old"

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -1,0 +1,159 @@
+# Promote a published version to :stable.
+#
+# Until 2026-07-29 this was a manual `docker tag` + `docker push`, and :stable
+# did not exist at all despite README/docs telling production users to track
+# it. Two things made hand-promotion risky enough to encode:
+#
+#   1. MULTI-ARCH. subarr publishes linux/amd64 + linux/arm64. `docker pull`
+#      + `docker tag` + `docker push` pushes only the puller's architecture,
+#      so :stable would silently lose arm64 — it would exist, pull fine on
+#      x86, and simply fail to resolve on a Pi. `buildx imagetools create`
+#      copies the manifest LIST, preserving every platform. Never replace it
+#      with tag+push. (subarr-subgen is amd64-only so it got away with
+#      tag+push; that is why the two repos looked like they could share a
+#      command and could not.)
+#
+#   2. Promoting a stale artifact. :stable is what risk-averse users track,
+#      so shipping them an image with known-unpatched OS packages is worse
+#      than leaving :stable where it is. The gate below refuses in that case.
+#
+# Soak policy: RELEASES/docs prescribe a soak before promotion. That governs
+# CODE. A pure OS-security rebuild of already-soaked code does not restart the
+# clock — re-soaking would strand :stable on unpatched packages for another
+# week, inverting what the soak protects against. Use soak_override for that
+# case and say why in the run.
+
+name: promote-stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published version to promote (e.g. 2.5.0) — must already exist on GHCR"
+        required: true
+      allow_stale:
+        description: "Promote even if the image has outstanding -security packages (say why in the run)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: promote to :stable
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # retag on GHCR
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      VERSION: ${{ inputs.version }}
+      ALLOW_STALE: ${{ inputs.allow_stale }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: verify the source tag exists and is multi-arch
+        id: src
+        run: |
+          set -euo pipefail
+          REF="${IMAGE}:${VERSION}"
+          if ! docker manifest inspect "$REF" > /dev/null 2>&1; then
+            echo "::error::${REF} does not exist on GHCR. Publish it before promoting."
+            exit 1
+          fi
+          docker manifest inspect "$REF" > manifest.json
+
+          ARCHES="$(python3 -c "
+          import json
+          m = json.load(open('manifest.json'))
+          got = [x['platform']['os'] + '/' + x['platform']['architecture']
+                 for x in m.get('manifests', [])
+                 if x.get('platform', {}).get('architecture') not in (None, 'unknown')]
+          print(','.join(sorted(got)))
+          ")"
+          echo "source arches: ${ARCHES}"
+          echo "arches=${ARCHES}" >> "$GITHUB_OUTPUT"
+
+          # A release build publishes both. If one is missing the manifest is
+          # already damaged and promoting would propagate that to :stable.
+          case "$ARCHES" in
+            *linux/amd64*) ;;
+            *) echo "::error::source manifest has no linux/amd64: ${ARCHES}"; exit 1 ;;
+          esac
+          case "$ARCHES" in
+            *linux/arm64*) ;;
+            *) echo "::error::source manifest has no linux/arm64: ${ARCHES} — refusing, this would ship a Pi-broken :stable"; exit 1 ;;
+          esac
+
+      - name: refuse to promote an image behind on security updates
+        id: staleness
+        run: |
+          set -euo pipefail
+          REF="${IMAGE}:${VERSION}"
+          docker pull -q "$REF"
+          docker run --rm --entrypoint sh "$REF" -c \
+            'apt-get update -qq >/dev/null 2>&1 && apt list --upgradable 2>/dev/null' \
+            | grep -v '^Listing' | sort > all.txt || true
+          grep -- '-security' all.txt > sec.txt || true
+          COUNT="$(wc -l < sec.txt)"
+          echo "outstanding -security packages: ${COUNT}"
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "::warning::${REF} has ${COUNT} outstanding -security package(s)"
+            cat sec.txt
+            if [ "$ALLOW_STALE" != "true" ]; then
+              echo "::error::refusing to promote. :stable is what risk-averse users track."
+              echo "::error::Cut a rebuild (no code change needed — the Dockerfile upgrades"
+              echo "::error::behind APT_REFRESH) and promote that, or re-run with allow_stale."
+              exit 1
+            fi
+            echo "::warning::allow_stale was set — promoting anyway"
+          fi
+
+      - name: promote (manifest-list copy, preserves every arch)
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create -t "${IMAGE}:stable" "${IMAGE}:${VERSION}"
+
+      - name: verify :stable matches the source, arch for arch
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, subprocess, os, sys
+
+          image = os.environ["IMAGE"]
+          version = os.environ["VERSION"]
+
+          def digests(ref):
+              raw = subprocess.run(
+                  ["docker", "manifest", "inspect", ref],
+                  capture_output=True, text=True, check=True,
+              ).stdout
+              m = json.loads(raw)
+              return {
+                  x["platform"]["os"] + "/" + x["platform"]["architecture"]: x["digest"]
+                  for x in m.get("manifests", [])
+                  if x.get("platform", {}).get("architecture") not in (None, "unknown")
+              }
+
+          src = digests(f"{image}:{version}")
+          dst = digests(f"{image}:stable")
+          for plat in sorted(set(src) | set(dst)):
+              a, b = src.get(plat), dst.get(plat)
+              print(f"  {plat}: {(a or 'MISSING')[:19]} -> {(b or 'MISSING')[:19]}")
+          if src != dst:
+              print("MISMATCH: :stable does not match the source manifest", file=sys.stderr)
+              sys.exit(1)
+          print(f":stable now serves {version} on {len(src)} platform(s)")
+          PY

--- a/scripts/sticky-issue.sh
+++ b/scripts/sticky-issue.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Open-or-update a single sticky issue, keyed by a unique label.
+#
+# Why: a weekly detector without stickiness opens a NEW issue every run while
+# the same unresolved episode persists, burying the inbox in duplicates.
+# Ported from coaxk/subarr-subgen (where it had already caused that mess).
+# Sticky semantics:
+#
+#   - An OPEN issue carrying $STICKY_LABEL already exists  -> add a comment
+#     (one issue accumulates "still happening" updates).
+#   - None open (never created, or we fixed + CLOSED the last one) -> create
+#     a fresh one from $BODY_FILE.
+#
+# So one issue per unresolved episode; closing it after we act resets the
+# cycle, and a genuinely new occurrence opens a new issue.
+#
+# Uses gh (native, no third-party action). Requires GH_TOKEN in the env and
+# the repo's issues:write permission. Labels passed in must already exist
+# (gh does not auto-create them).
+#
+# Usage:
+#   sticky-issue.sh <repo> <sticky_label> <title> <body_file> <labels> <note>
+set -euo pipefail
+
+REPO="$1"          # owner/name
+STICKY_LABEL="$2"  # the unique key label used to find the open issue
+TITLE="$3"         # title used only when creating
+BODY_FILE="$4"     # body used only when creating
+LABELS="$5"        # comma-separated labels applied on create (must exist)
+NOTE="$6"          # comment body appended when the issue already exists
+
+existing="$(gh issue list --repo "$REPO" --state open --label "$STICKY_LABEL" \
+  --json number --jq '.[0].number // empty')"
+
+if [ -n "$existing" ]; then
+  echo "sticky issue #$existing exists (label=$STICKY_LABEL) — commenting instead of opening a duplicate"
+  gh issue comment "$existing" --repo "$REPO" --body "$NOTE"
+else
+  echo "no open issue for label=$STICKY_LABEL — creating"
+  gh issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE" --label "$LABELS"
+fi


### PR DESCRIPTION
Two gaps found by accident while promoting 2.5.0 to `:stable` today. Both are now closed by design rather than by luck.

## 1. subarr had no staleness detector

`security.yml` builds a **fresh** image and scans that, so it is green by construction while the artifact on GHCR ages. subarr-subgen had the identical blind spot, and its detector caught the published image **7 days behind with 11 outstanding security packages** on its first scheduled run ([subarr-subgen#33](https://github.com/coaxk/subarr-subgen/issues/33)).

subarr's 2.5.0 happened to come back clean when I checked it today - but that was luck, not coverage. Same structure, same eventual drift, just slower.

Ported here on **Fridays 07:00 UTC**, staggered off subgen's Thursday run so a bad week does not deliver both reports at once. Also ports `scripts/sticky-issue.sh`, which subarr did not have.

**Pocket naming was checked, not assumed.** subarr is Debian (`python:3.12-slim` -> trixie), subgen is Ubuntu. I verified against the live image's `sources.list.d` that Debian security updates come from `Suites: trixie-security`, so they render as `pkg/trixie-security` and the `-security` substring matches both distros. Plain `trixie`/`stable` and `trixie-updates` entries are ordinary updates and stay excluded - I nearly mis-diagnosed this as a false-negative before checking.

## 2. `:stable` promotion was hand-run and genuinely dangerous here

**subarr is multi-arch.** `docker pull` + `docker tag` + `docker push` publishes only the puller's architecture, so `:stable` would silently lose arm64 - it would exist, pull fine on x86, and simply not resolve on a Pi, which the README explicitly advertises. The failure mode is invisible from an x86 machine.

`promote-stable.yml` uses `docker buildx imagetools create`, which copies the manifest **list**. It also:

- refuses if the source tag does not exist on GHCR
- refuses if either arch is missing from the source manifest
- **refuses if the image has outstanding `-security` packages** (`allow_stale` overrides, reason recorded in the run) - `:stable` is what risk-averse users track, so shipping them known-unpatched packages is worse than not promoting
- verifies `:stable` matches the source **arch for arch** afterwards

## Verification

The verify logic run against the real 2.5.0 -> `:stable` promotion I did today:

```
  linux/amd64: sha256:264e648e173c -> sha256:264e648e173c
  linux/arm64: sha256:c7042b5059fb -> sha256:c7042b5059fb
MATCH (2 platforms)
negative control (arm64 dropped): correctly MISMATCH
```

The negative control matters: without it, a verify step that only compared "does :stable exist" would pass on a broken single-arch promotion.

zizmor clean on both workflows.

## Test Plan

- [ ] CI green
- [ ] after merge, `workflow_dispatch` promote-stable with version `2.5.0` and confirm it is a no-op that passes all gates
- [ ] `workflow_dispatch` image-staleness and confirm the unconditional log line reports a plausible age + package count