### PR TITLE
feat(#445): retimer borrows slack from the next cue

### DIFF
--- a/src/subarr/subtitle_retime.py
+++ b/src/subarr/subtitle_retime.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .subtitle_readability import Cue, parse_srt
+from .subtitle_readability import CRITICAL_CPS, Cue, parse_srt
 
 
 @dataclass(frozen=True)
@@ -24,6 +24,15 @@ class RetimeParams:
     min_cue_ms: int = 1000  # pad micro-cues to this (clears the 833ms too_short floor)
     min_gap_ms: int = 100  # inter-cue gap always preserved
     max_cue_ms: int = 7000  # never display longer than this (MAX_DURATION_S)
+    # [#445] Borrow at most this many ms from the NEXT cue's start to rescue an
+    # over-CPS cue with no gap to grow into. 0 disables borrowing entirely.
+    #
+    # 500ms is the knee of the measured curve on the #171 Phase 2 corpus: it
+    # takes our shipped output from 2.81% to 0.85% of cues over 25 CPS, about
+    # 70% of the total available gain, while bounding the worst-case delay at
+    # half a second. Uncapped reaches 0.55% but delays a cue by up to 1.9s,
+    # which is its own defect and one the CPS metric cannot see.
+    max_borrow_ms: int = 500
 
 
 def retime_cues(cues: list[Cue], params: RetimeParams = RetimeParams()) -> list[Cue]:
@@ -44,6 +53,64 @@ def retime_cues(cues: list[Cue], params: RetimeParams = RetimeParams()) -> list[
             desired = max(desired, c.start_ms + round(c.char_count / params.target_cps * 1000))
         new_end = max(c.end_ms, min(desired, bound))  # clamp to gap/max; never shorten
         out.append(Cue(index=c.index, start_ms=c.start_ms, end_ms=new_end, lines=list(c.lines)))
+    return _borrow_from_next(out, params)
+
+
+def _borrow_from_next(cues: list[Cue], params: RetimeParams) -> list[Cue]:
+    """[#445] Lend an over-CPS cue time by starting the NEXT cue later.
+
+    End-extension cannot help a cue whose neighbour begins immediately, and on
+    the #171 Phase 2 corpus that was **every** surviving violation: 120 of 120
+    were blocked by no gap, none by max_cue_ms. The median shortfall was 220ms
+    while the median real gap to the next cue was 80ms.
+
+    Only ever delays the next cue, never advances one -- text must never be
+    displayed before its speech. Lends only what the neighbour can spare while
+    staying under CRITICAL_CPS itself, so it relieves a violation rather than
+    relocating it, and is bounded by ``max_borrow_ms``.
+    """
+    if params.max_borrow_ms <= 0 or len(cues) < 2:
+        return cues
+
+    out = list(cues)
+    for i in range(len(out) - 1):
+        a, b = out[i], out[i + 1]
+        if a.duration_s <= 0 or a.cps <= CRITICAL_CPS:
+            continue
+        # What A needs to reach the CRITICAL bar -- not target_cps. Borrowing is
+        # ALL OR NOTHING against that bar, for two reasons.
+        #
+        # Idempotency: the module guarantees it. Borrowing toward target_cps
+        # leaves A still above CRITICAL when the cap binds, so a second pass
+        # borrows another max_borrow_ms, and a third, and so on. Stopping
+        # exactly at CRITICAL means the next pass sees `a.cps <= CRITICAL_CPS`
+        # and does nothing.
+        #
+        # Honesty about the trade: the cost here is paid by the VIEWER, in the
+        # next cue arriving late. Paying it for a cue that stays unreadable
+        # anyway buys nothing, so a borrow that cannot finish the job is not
+        # made at all.
+        want = (
+            min(
+                a.start_ms + round(a.char_count / CRITICAL_CPS * 1000),
+                a.start_ms + params.max_cue_ms,
+            )
+            - a.end_ms
+        )
+        if want <= 0:
+            continue
+        # What B can give up and still clear the bar. Its own minimum is set by
+        # CRITICAL_CPS, not target_cps -- we relieve A without creating a new
+        # violation, rather than chasing comfort for A at B's expense.
+        b_floor_ms = round(b.char_count / CRITICAL_CPS * 1000) if b.char_count else 0
+        slack = (b.end_ms - b.start_ms) - b_floor_ms
+        give = max(0, min(want, slack, params.max_borrow_ms))
+        if give < want:
+            continue  # cannot finish the job -- do not charge the viewer for it
+        if give <= 0:
+            continue
+        out[i] = Cue(index=a.index, start_ms=a.start_ms, end_ms=a.end_ms + give, lines=list(a.lines))
+        out[i + 1] = Cue(index=b.index, start_ms=b.start_ms + give, end_ms=b.end_ms, lines=list(b.lines))
     return out
 
 

--- a/tests/test_subtitle_retime.py
+++ b/tests/test_subtitle_retime.py
@@ -41,7 +41,10 @@ def test_no_gap_leaves_cue_unchanged_as_residual():
 def test_min_gap_always_preserved():
     cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 3000, 5000, "next")]
     out = retime_cues(cues, P)
-    assert out[0].end_ms <= 3000 - P.min_gap_ms  # never within min_gap of next start
+    # Compare against the next cue's ACTUAL start, not the input literal: #445
+    # borrowing may legitimately have moved it later, and hard-coding 3000 here
+    # would fail on a gap that is still perfectly preserved.
+    assert out[0].end_ms <= out[1].start_ms - P.min_gap_ms
 
 
 def test_never_exceeds_max_cue_ms():
@@ -174,3 +177,86 @@ def test_retime_srt_leaves_comfortable_input_essentially_unchanged():
     after = parse_srt(retime_srt(_CALM_SRT))
     # already comfortable + adequate duration → no end moved.
     assert [c.end_ms for c in before] == [c.end_ms for c in after]
+
+
+# ── #445: borrow slack from the next cue ───────────────────────────────────
+#
+# The end-extension above cannot help a cue whose neighbour starts immediately.
+# Measured on the #171 Phase 2 corpus, 120 of 120 surviving over-CPS cues on the
+# new-segmenter arm were blocked by exactly that: no gap to grow into.
+#
+# Borrowing pushes the NEXT cue's start LATER to lend time, only as far as that
+# cue can spare while staying under the 25 CPS bar itself. It never moves a
+# start earlier, so text is never displayed before its speech.
+
+
+def test_borrow_lends_time_from_a_slack_neighbour():
+    # A: 60 chars in 2.0s = 30 cps, no gap. Reaching the 25 cps bar needs
+    # 2400ms, i.e. 400ms of borrow -- inside the 500ms cap. B has 4 chars in
+    # 6.0s, so ample slack.
+    cues = [_cue(1, 0, 2000, "x" * 60), _cue(2, 2000, 8000, "next")]
+    out = retime_cues(cues, RetimeParams(max_borrow_ms=500))
+    assert out[0].end_ms == 2400, "A extended exactly to the 25 cps bar"
+    assert out[1].start_ms == 2400, "B's start moves later by the same amount"
+    assert out[1].end_ms == 8000, "B's end never moves"
+    assert out[0].cps <= 25.0 + 0.01
+
+
+def test_borrow_never_moves_a_start_earlier():
+    # The whole point: no cue may ever be displayed before its speech.
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 8000, "next")]
+    out = retime_cues(cues, RetimeParams(max_borrow_ms=500))
+    for before, after in zip(cues, out):
+        assert after.start_ms >= before.start_ms
+
+
+def test_borrow_never_pushes_the_neighbour_over_the_cps_bar():
+    # Assert the INVARIANT, not a hand-computed number. B is itself extended by
+    # the target_cps pass before any borrowing happens, which changes how much
+    # slack it has -- a literal here encodes a mental model rather than the
+    # contract, and the first draft of this test got that number wrong.
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 7000, "y" * 100)]
+    out = retime_cues(cues, RetimeParams(max_borrow_ms=10_000))
+    assert out[1].cps <= 25.0 + 0.01, "lending must never push B over the bar"
+    assert out[0].end_ms > 2000, "A gained time"
+    assert out[1].start_ms >= 2000, "B never starts earlier"
+
+
+def test_borrow_beyond_the_cap_is_refused_entirely():
+    # A needs 1200ms to reach the bar (80 chars). With a 300ms cap the job
+    # cannot be finished, so NOTHING is borrowed -- the viewer is not charged a
+    # late cue for a subtitle that stays unreadable anyway. This is also what
+    # keeps the pass idempotent under a binding cap.
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 20000, "next")]
+    out = retime_cues(cues, RetimeParams(max_borrow_ms=300))
+    assert out[0].end_ms == 2000, "no partial borrow"
+    assert out[1].start_ms == 2000, "B untouched"
+
+
+def test_borrow_disabled_at_zero_leaves_timings_untouched():
+    # Off switch, and the back-compat guarantee for anything pinned to the
+    # pre-#445 behaviour.
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 8000, "next")]
+    assert retime_cues(cues, RetimeParams(max_borrow_ms=0)) == retime_cues(
+        cues, RetimeParams(max_borrow_ms=0)
+    )
+    out = retime_cues(cues, RetimeParams(max_borrow_ms=0))
+    assert out[0].end_ms == 2000 and out[1].start_ms == 2000
+
+
+def test_borrow_creates_no_overlaps():
+    cues = [
+        _cue(1, 0, 2000, "x" * 80),
+        _cue(2, 2000, 8000, "y" * 20),
+        _cue(3, 8000, 9000, "z"),
+    ]
+    out = retime_cues(cues, RetimeParams(max_borrow_ms=500))
+    for a, b in zip(out, out[1:]):
+        assert a.end_ms <= b.start_ms
+
+
+def test_borrow_is_idempotent():
+    cues = [_cue(1, 0, 2000, "x" * 80), _cue(2, 2000, 8000, "next")]
+    p = RetimeParams(max_borrow_ms=500)
+    once = retime_cues(cues, p)
+    assert retime_cues(once, p) == once


### PR DESCRIPTION
Closes #445.

## Why

End-extension cannot help a cue whose neighbour starts immediately. On the #171 Phase 2 corpus that was **every** surviving violation: 120 of 120 blocked by no gap, none by `max_cue_ms`. Median shortfall 220ms against a median real gap of 80ms.

## What

Push the **next** cue's start later to lend time to an over-CPS cue. Never moves a start earlier, so text is never displayed before its speech - the explicit constraint on this work.

Bounded by `max_borrow_ms` (new, default 500) and by what the neighbour can spare while staying under 25 CPS itself, so it relieves a violation rather than relocating one.

## Measured, 35-clip committed corpus

| arm | before | after | overlaps | cues delayed | max delay |
|---|---|---|---|---|---|
| ours (`2026.07.3-r1`) | 2.81% | **0.85%** | 0 | 32 | 460ms |
| new segmenter | 5.58% | **2.84%** | 0 | 60 | 500ms |
| upstream today | 13.43% | **6.29%** | 0 | 230 | 500ms |

**Roughly a 3x reduction on our own output**, zero new overlaps anywhere.

## The 500ms default

Knee of the measured curve. Takes ~70% of the available gain while bounding the worst case at half a second. Uncapped reaches 0.55% but delays a cue by up to **1.9s**, which is its own defect - and one the CPS metric cannot see, the same blind spot that makes `min_gap = 0` look like a win when it is not.

⚠️ **This changes shipped behaviour by default.** `max_borrow_ms=0` disables it entirely and reproduces the pre-#445 timings exactly, covered by a test. If you would rather ship this opt-in, that is a one-line default change and the main thing worth deciding in review.

## All-or-nothing, and where that came from

Borrowing only happens if it gets the cue **under** the 25 CPS bar. If it cannot finish the job, nothing is borrowed.

That came from a failing test, not foresight. `test_borrow_is_idempotent` caught that a capped partial borrow is taken **again on every pass** - 500ms, then another 500ms - breaking an invariant this module explicitly states. Stopping exactly at the bar makes the next pass a no-op.

It is also the honest trade: the cost is paid by the **viewer**, in a late cue. Paying it for a subtitle that stays unreadable anyway buys nothing.

## Test-quality notes

Two of my own new expectations were wrong, and I fixed the **tests**, not the code. Both hand-computed a number from a model that ignored the neighbour being end-extended first (a 20 CPS neighbour is itself extended toward `target_cps` before any borrowing). One now asserts the **invariant** - B never exceeds 25 CPS - which is what it should have asserted originally.

Also corrects the pre-existing `test_min_gap_always_preserved`, which compared against the input literal for the next cue's start rather than its actual start. It would fail on a gap that is still perfectly preserved.

## Note for #171

At a **300ms** cap the arm2-arm3 delta is +1.85pp, inside the #171 gate - which partially contradicts my earlier comment there that the retimer cannot close it. I am not proposing 300ms on that basis: the cap has to be chosen on sync-quality grounds, and picking a value *because* it clears a gate is the metric-gaming this study has avoided throughout. Correction noted on #171 separately.

## Verification

- [x] 7 new tests; idempotency, no-early-start, cap, off-switch, no-new-overlaps, neighbour-stays-under-bar
- [x] Full suite 1713 passed, 14 skipped (was 1706 - exactly the 7 new)
- [x] ruff clean
- [x] Measured on committed study output, not fixtures

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
