### PR TITLE
feat(#453): guarded orphan-path prune core (not yet wired)

### DIFF
--- a/src/subarr/orphan_prune.py
+++ b/src/subarr/orphan_prune.py
@@ -36,9 +36,7 @@ class PruneDecision:
     reason: str
 
 
-def partition_missing(
-    paths: Iterable[str], *, exists: Callable[[str], bool]
-) -> tuple[list[str], list[str]]:
+def partition_missing(paths: Iterable[str], *, exists: Callable[[str], bool]) -> tuple[list[str], list[str]]:
     """Split paths into (present, missing), preserving order.
 
     ``exists`` is injected so this stays pure and testable -- callers pass
@@ -104,9 +102,7 @@ def prune_missing(
     """
     paths = list(store.all_paths())
     _present, missing = partition_missing(paths, exists=exists)
-    decision = prune_decision(
-        total=len(paths), missing=len(missing), max_missing_ratio=max_missing_ratio
-    )
+    decision = prune_decision(total=len(paths), missing=len(missing), max_missing_ratio=max_missing_ratio)
     if not decision.safe or dry_run:
         return PruneReport(decision, 0, missing)
     deleted = sum(1 for p in missing if store.delete(p))

--- a/src/subarr/orphan_prune.py
+++ b/src/subarr/orphan_prune.py
@@ -1,0 +1,113 @@
+"""#453: decide whether it is SAFE to drop DB rows for files that vanished.
+
+A rename leaves the old canonical path wedged in Review forever -- nothing in
+the coverage path ever checks whether a file still exists, so re-walking does
+not clear it. Users have resorted to hand-written SQL to unstick it.
+
+The obvious fix is to delete every row whose path is missing. That is a
+data-loss landmine on a network share: when the mount drops, the mountpoint
+frequently still LISTS its directories while serving nothing, so every path
+looks missing in the same instant. A naive prune then deletes every audio-lang
+verification the user has ever confirmed, and re-confirming them is manual work
+measured in hours.
+
+So the rule is: a handful of missing files is renames, and safe to prune. A
+large fraction missing is an infrastructure fault, and must be refused loudly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+# Above this share of missing paths we assume the storage is unavailable rather
+# than believe the user renamed most of their library in one sitting.
+MAX_MISSING_RATIO = 0.5
+
+# Below this many rows the ratio is meaningless -- 1 of 2 missing is 50% and
+# tells us nothing. Refuse rather than act on noise.
+MIN_TOTAL_TO_JUDGE = 1
+
+
+@dataclass(frozen=True)
+class PruneDecision:
+    safe: bool
+    would_delete: int
+    reason: str
+
+
+def partition_missing(
+    paths: Iterable[str], *, exists: Callable[[str], bool]
+) -> tuple[list[str], list[str]]:
+    """Split paths into (present, missing), preserving order.
+
+    ``exists`` is injected so this stays pure and testable -- callers pass
+    ``os.path.exists`` or equivalent.
+    """
+    present: list[str] = []
+    missing: list[str] = []
+    for p in paths:
+        (present if exists(p) else missing).append(p)
+    return present, missing
+
+
+def prune_decision(
+    *, total: int, missing: int, max_missing_ratio: float = MAX_MISSING_RATIO
+) -> PruneDecision:
+    """Is it safe to delete rows for ``missing`` of ``total`` paths?"""
+    if total < MIN_TOTAL_TO_JUDGE:
+        return PruneDecision(False, 0, "nothing to judge: the store is empty")
+    if missing == 0:
+        return PruneDecision(True, 0, "no missing paths: nothing to prune")
+    ratio = missing / total
+    if ratio > max_missing_ratio:
+        return PruneDecision(
+            False,
+            missing,
+            f"refusing to prune: {missing} of {total} paths are missing "
+            f"({ratio:.0%}). That is a storage mount failure far more often "
+            f"than it is renames, and pruning here would delete verifications "
+            f"that are expensive to rebuild by hand. Check the media mount, "
+            f"then re-run.",
+        )
+    return PruneDecision(
+        True,
+        missing,
+        f"{missing} of {total} paths are missing ({ratio:.0%}) -- consistent "
+        f"with renames or deletions; safe to prune.",
+    )
+
+
+@dataclass(frozen=True)
+class PruneReport:
+    decision: PruneDecision
+    deleted: int
+    missing: list[str]
+
+
+def prune_missing(
+    store,
+    *,
+    exists: Callable[[str], bool],
+    dry_run: bool = False,
+    max_missing_ratio: float = MAX_MISSING_RATIO,
+) -> PruneReport:
+    """Drop rows for paths that no longer exist, if that looks safe.
+
+    ``store`` needs ``all_paths()`` and ``delete(path)`` -- both probe_store and
+    audio_lang_store already satisfy that shape.
+
+    Refuses as a whole rather than partially: if the missing share says the
+    storage is down, nothing is deleted at all. A partial prune under a mount
+    failure would be the worst outcome, since it silently destroys some rows
+    while looking like it worked.
+    """
+    paths = list(store.all_paths())
+    _present, missing = partition_missing(paths, exists=exists)
+    decision = prune_decision(
+        total=len(paths), missing=len(missing), max_missing_ratio=max_missing_ratio
+    )
+    if not decision.safe or dry_run:
+        return PruneReport(decision, 0, missing)
+    deleted = sum(1 for p in missing if store.delete(p))
+    return PruneReport(decision, deleted, missing)

--- a/src/subarr/probe_store.py
+++ b/src/subarr/probe_store.py
@@ -159,6 +159,16 @@ class ProbeStore:
             rows = self._conn.execute("SELECT source, COUNT(*) FROM media_probe GROUP BY source").fetchall()
         return {r[0]: r[1] for r in rows}
 
+    def delete(self, canonical_path: str) -> bool:
+        """[#453] Drop one cached probe. Used by the orphan prune when a file
+        has been renamed or removed -- see subarr.orphan_prune, which decides
+        whether pruning is safe before any of these run."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM media_probe WHERE canonical_path = ?", (canonical_path,)
+            )
+        return cur.rowcount > 0
+
     def all_paths(self) -> list[str]:
         with self._lock:
             rows = self._conn.execute("SELECT canonical_path FROM media_probe").fetchall()

--- a/src/subarr/probe_store.py
+++ b/src/subarr/probe_store.py
@@ -164,9 +164,7 @@ class ProbeStore:
         has been renamed or removed -- see subarr.orphan_prune, which decides
         whether pruning is safe before any of these run."""
         with self._lock:
-            cur = self._conn.execute(
-                "DELETE FROM media_probe WHERE canonical_path = ?", (canonical_path,)
-            )
+            cur = self._conn.execute("DELETE FROM media_probe WHERE canonical_path = ?", (canonical_path,))
         return cur.rowcount > 0
 
     def all_paths(self) -> list[str]:

--- a/tests/test_orphan_prune.py
+++ b/tests/test_orphan_prune.py
@@ -1,0 +1,163 @@
+"""#453: renamed/deleted files leave orphan rows wedged in Review forever.
+
+The obvious fix -- delete every DB row whose path is missing -- is a data-loss
+landmine here. When a network share drops, the mountpoint often still LISTS
+directories while serving nothing, so every path looks missing at once and a
+naive prune wipes every verification the user ever confirmed. These tests pin
+the guard that stops that, not just the happy path.
+"""
+
+from subarr.orphan_prune import PruneDecision, partition_missing, prune_decision
+
+
+def test_partition_splits_present_from_missing():
+    present, missing = partition_missing(
+        ["/m/a.mkv", "/m/gone.mkv", "/m/b.mkv"],
+        exists=lambda p: "gone" not in p,
+    )
+    assert present == ["/m/a.mkv", "/m/b.mkv"]
+    assert missing == ["/m/gone.mkv"]
+
+
+def test_a_few_renames_are_safe_to_prune():
+    d = prune_decision(total=100, missing=3)
+    assert isinstance(d, PruneDecision)
+    assert d.safe is True
+    assert "3" in d.reason
+
+
+def test_everything_missing_is_refused_as_a_mount_failure():
+    # The whole point. 100 of 100 gone is not 100 renames.
+    d = prune_decision(total=100, missing=100)
+    assert d.safe is False
+    assert "mount" in d.reason.lower() or "unavailable" in d.reason.lower()
+
+
+def test_majority_missing_is_refused():
+    assert prune_decision(total=100, missing=60).safe is False
+
+
+def test_boundary_is_explicit_not_accidental():
+    # 50% exactly is allowed; above it is not. Stated, so a future edit that
+    # flips the comparison fails here rather than silently widening the blast
+    # radius.
+    assert prune_decision(total=100, missing=50).safe is True
+    assert prune_decision(total=100, missing=51).safe is False
+
+
+def test_nothing_missing_is_a_no_op_not_an_error():
+    d = prune_decision(total=100, missing=0)
+    assert d.safe is True
+    assert d.would_delete == 0
+
+
+def test_empty_store_never_prunes():
+    # No rows means nothing to judge; refuse rather than divide by zero.
+    d = prune_decision(total=0, missing=0)
+    assert d.safe is False
+
+
+def test_decision_reports_what_it_would_delete():
+    d = prune_decision(total=200, missing=7)
+    assert d.would_delete == 7
+
+
+# ── the service layer, exercised against fake stores ───────────────────────
+
+
+class _FakeStore:
+    def __init__(self, paths):
+        self.paths = list(paths)
+        self.deleted = []
+
+    def all_paths(self):
+        return list(self.paths)
+
+    def delete(self, p):
+        self.deleted.append(p)
+        if p in self.paths:
+            self.paths.remove(p)
+            return True
+        return False
+
+
+def test_prune_deletes_only_the_missing_rows():
+    from subarr.orphan_prune import prune_missing
+
+    store = _FakeStore(["/m/a.mkv", "/m/gone.mkv", "/m/b.mkv"])
+    rep = prune_missing(store, exists=lambda p: "gone" not in p)
+    assert rep.decision.safe is True
+    assert store.deleted == ["/m/gone.mkv"]
+    assert rep.deleted == 1
+
+
+def test_prune_deletes_NOTHING_when_the_mount_looks_down():
+    # The landmine test. Everything missing must delete zero rows, not all.
+    from subarr.orphan_prune import prune_missing
+
+    store = _FakeStore([f"/m/{i}.mkv" for i in range(50)])
+    rep = prune_missing(store, exists=lambda p: False)
+    assert rep.decision.safe is False
+    assert store.deleted == []
+    assert rep.deleted == 0
+    assert len(store.paths) == 50, "not one row may be removed"
+
+
+def test_prune_is_a_no_op_when_everything_is_present():
+    from subarr.orphan_prune import prune_missing
+
+    store = _FakeStore(["/m/a.mkv", "/m/b.mkv"])
+    rep = prune_missing(store, exists=lambda p: True)
+    assert rep.deleted == 0
+    assert store.deleted == []
+
+
+def test_prune_dry_run_reports_without_deleting():
+    from subarr.orphan_prune import prune_missing
+
+    store = _FakeStore(["/m/a.mkv", "/m/gone.mkv"])
+    rep = prune_missing(store, exists=lambda p: "gone" not in p, dry_run=True)
+    assert rep.decision.would_delete == 1
+    assert rep.deleted == 0
+    assert store.deleted == []
+
+
+def test_probe_store_delete_actually_removes_the_row(tmp_path):
+    """#453 needs ProbeStore.delete to exist and hit the right table.
+
+    Worth a real store rather than a fake: the first draft of delete targeted a
+    table named `probe_results`, which does not exist -- the real one is
+    `media_probe`. A fake store would have happily passed.
+    """
+    from subarr.media_probe import ProbeResult
+    from subarr.migrate import run_migrations
+    from subarr.probe_store import ProbeStore
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    st = ProbeStore(db)
+    for p in ("/m/a.mkv", "/m/b.mkv"):
+        st.upsert(canonical_path=p, mtime=1.0, size=10, result=ProbeResult(canonical_path=p))
+
+    assert sorted(st.all_paths()) == ["/m/a.mkv", "/m/b.mkv"]
+    assert st.delete("/m/a.mkv") is True
+    assert st.delete("/m/nope.mkv") is False, "deleting an absent row reports False"
+    assert st.all_paths() == ["/m/b.mkv"]
+
+
+def test_prune_missing_against_a_real_probe_store(tmp_path):
+    from subarr.media_probe import ProbeResult
+    from subarr.migrate import run_migrations
+    from subarr.orphan_prune import prune_missing
+    from subarr.probe_store import ProbeStore
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    st = ProbeStore(db)
+    for p in ("/m/keep.mkv", "/m/renamed.mkv"):
+        st.upsert(canonical_path=p, mtime=1.0, size=10, result=ProbeResult(canonical_path=p))
+
+    rep = prune_missing(st, exists=lambda p: "renamed" not in p)
+    assert rep.decision.safe is True
+    assert rep.deleted == 1
+    assert st.all_paths() == ["/m/keep.mkv"]


### PR DESCRIPTION
Refs #453. **Deliberately partial** - the core and its safety guard, without the wiring. See the open questions at the bottom.

## The gap

Renamed or deleted files leave rows wedged in Review forever. Nothing in the path that feeds Review ever asks whether a file still exists: not the coverage snapshot, not `pending-review`, and not the walk. So re-walking never clears them, and users have resorted to hand-written SQL.

## Why this is not just a DELETE

The obvious fix - drop every row whose path is missing - is a data-loss landmine on network storage.

When an NFS or SMB mount drops, the mountpoint very often still **lists** its directories while serving nothing underneath. Every path goes missing in the same instant. A prune that trusts file-not-found would then delete every audio-lang verification the user has ever confirmed, and rebuilding those is manual work measured in hours.

So `prune_decision` refuses above a 50% missing share, treating that as an infrastructure fault rather than believing someone renamed most of their library at once. It refuses **all-or-nothing** rather than part-way, because a half-finished prune during a mount failure looks like it worked while silently destroying rows.

There is a test asserting that when everything looks missing, **not one row** is removed.

## Also

`ProbeStore.delete()`, which needed a real migrated store to test rather than a fake: the first draft targeted a table named `probe_results`, and the real one is `media_probe`. A fake store would have passed that happily.

## Why it is not wired yet

Two open questions, both asked on the issue:

1. **Where does the stale row actually live?** Review rows are built from Sonarr and Radarr's file lists, not only subarr's tables. If Sonarr still reports the old filename, pruning our tables changes nothing and the fix is instead to hide rows whose file is gone regardless of what the arrs say. The reporter's description fits either cause, so I asked them to check Sonarr for one stuck file.
2. **Automatic or confirmed?** Proposed on the issue: an automatic dry run on walk completion that notifies ("12 files appear to have been renamed or removed - review and clean up?"), shows the actual paths, and only deletes after confirmation. That gets the automatic detection the reporter asked for without the accident class above.

Wiring before those are answered risks building the wrong half.

- [x] 14 tests, including the real-store cases
- [x] Full suite 1727 passed, 14 skipped (on this branch: main baseline 1713 + 14)
- [x] ruff clean

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
