### PR TITLE
fix(#458): image-based subtitles are not subtitle coverage

### DIFF
--- a/src/subarr/auto_queue.py
+++ b/src/subarr/auto_queue.py
@@ -181,6 +181,13 @@ def _filter_reason(item: CoverageItem, rules: AutoQueueRules) -> str | None:
         return "stale: .srt already on disk"
     if rules.skip_embedded_en and item.embedded_en in {"EN", "EN(SDH)"}:
         return f"embedded English already present ({item.embedded_en})"
+    # [#458] An image-only EN file is NOT coverage, so it is correctly eligible
+    # now -- but subgen refuses it unless IGNORE_IMAGE_SUBTITLES is on, and that
+    # defaults OFF. Queueing it would turn a silent skip into a queue full of
+    # instant rejections. The flag is set during scoring from subgen's RUNTIME
+    # capability, so this clears itself the moment subgen can actually fill it.
+    if item.image_only_subgen_will_skip:
+        return "embedded English is image-based (PGS/VobSub); subgen will skip it"
     if rules.require_monitored and item.monitored is False:
         return "not monitored"
     if item.score < rules.min_score:

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -149,6 +149,10 @@ class CoverageItem:
     # gap. When the cap is on, this stays False and the forced-only row is a
     # normal partial-coverage gap.
     forced_only_subgen_will_skip: bool = False
+    # [#458] English exists but ONLY as an image track (PGS/VobSub) AND the
+    # connected subgen will not transcribe it. Same shape as the field above:
+    # a distinct non-actionable state, not a hidden row.
+    image_only_subgen_will_skip: bool = False
     # #159: the default/first audio track isn't the show's original language but
     # a track that IS exists — transcribing the default double-translates a dub
     # (e.g. Russian show, German dub default, original Russian on track 2). The
@@ -213,6 +217,7 @@ class CoverageItem:
             "score_reasons": self.score_reasons,
             "verification_state": self.verification_state,
             "forced_only_subgen_will_skip": self.forced_only_subgen_will_skip,
+            "image_only_subgen_will_skip": self.image_only_subgen_will_skip,
             "default_track_mismatch": self.default_track_mismatch,
             "mismatch_default_track_lang": self.mismatch_default_track_lang,
             "mismatch_native_track_lang": self.mismatch_native_track_lang,
@@ -1353,6 +1358,7 @@ def _score(
     airing_soon_eps: set[int] | None = None,
     transcoding_titles: set[str] | None = None,
     ignore_forced_subtitles: bool = False,
+    ignore_image_subtitles: bool = False,
 ) -> None:
     s = 0
     reasons: list[str] = []
@@ -1440,9 +1446,11 @@ def _score(
         # tagged "eng" makes it skip the file. The gap is real -- a picture
         # is not text -- but nothing subarr can send today will fill it, so
         # say that plainly instead of dangling an un-fillable gap.
-        if item.embedded_en == "EN(image)":
+        if item.embedded_en == "EN(image)" and not ignore_image_subtitles:
+            item.image_only_subgen_will_skip = True
             reasons.append(
-                "subgen will skip this (English subs are image-based, PGS/VobSub) — it cannot be used as text"
+                "subgen will skip this (English subs are image-based, PGS/VobSub)"
+                " — enable IGNORE_IMAGE_SUBTITLES on subgen to transcribe it"
             )
     item.score = s
     item.score_reasons = reasons
@@ -1582,6 +1590,10 @@ async def build_coverage(
     # marked forced_only_subgen_will_skip (distinct non-actionable state) rather
     # than presented as fillable gaps. caps on → they stay actionable gaps.
     ignore_forced = bool(getattr(subgen_caps, "ignore_forced_subtitles", False))
+    # [#458] Same gating for image-only EN, on subgen's RUNTIME
+    # IGNORE_IMAGE_SUBTITLES. Independent of the forced cap: they govern
+    # different defects, and subgen defaults this one OFF.
+    ignore_image = bool(getattr(subgen_caps, "ignore_image_subtitles", False))
 
     # ── Bazarr: fan out across ALL instances; each wanted item is tagged with
     #    its source instance id (_bazarr_instance) for routing (#161 Phase 2).
@@ -1843,6 +1855,7 @@ async def build_coverage(
                 just_imported_eps=sonarr_recent_ids,
                 airing_soon_eps=airing_soon_ids,
                 ignore_forced_subtitles=ignore_forced,
+                ignore_image_subtitles=ignore_image,
             )
             inst_ep_rows.append(item)
 
@@ -1872,6 +1885,7 @@ async def build_coverage(
                     sources=sources,
                     plex_hints=plex_audio_hints,
                     ignore_forced_subtitles=ignore_forced,
+                    ignore_image_subtitles=ignore_image,
                 )
             )
         ep_rows.extend(inst_ep_rows)
@@ -1935,6 +1949,7 @@ async def build_coverage(
                 transcoding_titles=activity["transcoding_titles"],
                 just_imported_movies=radarr_recent_ids,
                 ignore_forced_subtitles=ignore_forced,
+                ignore_image_subtitles=ignore_image,
             )
             inst_movie_rows.append(item)
 
@@ -1960,6 +1975,7 @@ async def build_coverage(
                     plex_hints=plex_audio_hints,
                     sources=sources,
                     ignore_forced_subtitles=ignore_forced,
+                    ignore_image_subtitles=ignore_image,
                 )
             )
         movie_rows.extend(inst_movie_rows)
@@ -2044,6 +2060,7 @@ async def _add_bazarr_blind_synthetic_rows(
     sources: dict,
     plex_hints: dict[str, str] | None = None,
     ignore_forced_subtitles: bool = False,
+    ignore_image_subtitles: bool = False,
 ) -> list[CoverageItem]:
     """Build synthetic CoverageItem rows for episodes Bazarr can't see —
     foreign-language series where the file metadata lies and Bazarr's
@@ -2241,6 +2258,7 @@ async def _add_bazarr_blind_synthetic_rows(
                 just_imported_eps=sonarr_recent_ids,
                 airing_soon_eps=airing_soon_ids,
                 ignore_forced_subtitles=ignore_forced_subtitles,
+                ignore_image_subtitles=ignore_image_subtitles,
             )
             new_rows.append(item)
             seen_ep_ids.add(ep_id)
@@ -2276,6 +2294,7 @@ async def _add_radarr_blind_movie_rows(
     plex_hints: dict[str, str],
     sources: dict,
     ignore_forced_subtitles: bool,
+    ignore_image_subtitles: bool,
 ) -> list[CoverageItem]:
     """Surface Radarr movies missing English subtitle coverage.
 
@@ -2350,6 +2369,7 @@ async def _add_radarr_blind_movie_rows(
             transcoding_titles=activity["transcoding_titles"],
             just_imported_movies=radarr_recent_ids,
             ignore_forced_subtitles=ignore_forced_subtitles,
+            ignore_image_subtitles=ignore_image_subtitles,
         )
         new_rows.append(item)
         seen_files.add(file_canonical)

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -60,7 +60,7 @@ class CoverageItem:
     bazarr_episode_id: int | None = None
     missing_subtitles: list[str] = field(default_factory=list)
     # ffprobe-driven embedded reconciliation (v1.1 batch 1 hotfix)
-    embedded_en: str | None = None  # 'EN' / 'EN(forced)' / 'EN(SDH)' / 'EN(commentary)' / None
+    embedded_en: str | None = None  # 'EN' / 'EN(forced)' / 'EN(SDH)' / 'EN(commentary)' / 'EN(image)' / None
     audio_langs: list[str] = field(default_factory=list)
     audio_lang_codes: list[str] | None = None  # #357: multilingual set (>=2 langs)
     suggest_bazarr_rescan: bool = False
@@ -1420,7 +1420,7 @@ def _score(
         label = "full English" if item.embedded_en == "EN" else "English SDH"
         reasons.append(f"embedded: {label} sub in file (Bazarr missed it)")
         item.suggest_bazarr_rescan = True
-    elif item.embedded_en in {"EN(forced)", "EN(commentary)"}:
+    elif item.embedded_en in {"EN(forced)", "EN(commentary)", "EN(image)"}:
         s -= 500
         reasons.append(f"embedded: {item.embedded_en} — partial coverage")
         # #79: forced-only EN is only an ACTIONABLE gap if the connected
@@ -1433,6 +1433,16 @@ def _score(
             reasons.append(
                 "subgen will skip this (forced-only EN) — "
                 "enable IGNORE_FORCED_SUBTITLES on subgen to transcribe it"
+            )
+        # [#458] Same trap as #79, different cause. subgen's
+        # has_internal_subtitle_in_language() matches on stream type +
+        # language tag and never looks at the CODEC, so a bitmap track
+        # tagged "eng" makes it skip the file. The gap is real -- a picture
+        # is not text -- but nothing subarr can send today will fill it, so
+        # say that plainly instead of dangling an un-fillable gap.
+        if item.embedded_en == "EN(image)":
+            reasons.append(
+                "subgen will skip this (English subs are image-based, PGS/VobSub) — it cannot be used as text"
             )
     item.score = s
     item.score_reasons = reasons

--- a/src/subarr/media_probe.py
+++ b/src/subarr/media_probe.py
@@ -56,12 +56,22 @@ ENGLISH_TAGS = {"en", "eng"}
 #
 # dvb_teletext is deliberately absent. Teletext IS text, and ffmpeg decodes it
 # to text, so it does not belong here.
+# BOTH SPELLINGS ARE CARRIED. ffprobe reports a stream's `codec_name`
+# ("hdmv_pgs_subtitle"); PyAV's `codec_context.name` reports the DECODER name
+# ("pgssub"). subarr populates SubtitleStream.codec from ffprobe today, but
+# subgen reads the same tracks through PyAV, and a set that knows only one
+# spelling silently matches nothing on the other. Measured 2026-08-28:
+#     hdmv_pgs_subtitle -> pgssub     dvd_subtitle -> dvdsub
+#     dvb_subtitle      -> dvbsub     xsub         -> xsub
 IMAGE_SUBTITLE_CODECS = frozenset(
     {
-        "hdmv_pgs_subtitle",  # Blu-ray PGS
-        "dvd_subtitle",  # DVD VobSub (the reported case)
-        "dvb_subtitle",  # DVB broadcast bitmap
-        "xsub",  # DivX/AVI bitmap
+        "hdmv_pgs_subtitle",
+        "pgssub",  # Blu-ray PGS
+        "dvd_subtitle",
+        "dvdsub",  # DVD VobSub (the reported case)
+        "dvb_subtitle",
+        "dvbsub",  # DVB broadcast bitmap
+        "xsub",  # DivX/AVI bitmap (same name either way)
     }
 )
 

--- a/src/subarr/media_probe.py
+++ b/src/subarr/media_probe.py
@@ -41,6 +41,36 @@ log = logging.getLogger(__name__)
 # 'eng'; some media tag 'en'. Both should match 'is this English?'.
 ENGLISH_TAGS = {"en", "eng"}
 
+# [#458] Bitmap subtitle codecs. A PGS/VobSub track is a sequence of PICTURES:
+# it cannot be read as text, searched, restyled, retimed, or fed to anything
+# downstream, so counting one as subtitle coverage silently skips a file that
+# genuinely needs a transcription.
+#
+# We DENY the image codecs rather than allow-list the text ones. The image set
+# is small and closed (four codecs, no new bitmap format in over a decade); the
+# text set has a long tail -- microdvd, subviewer, stl, jacosub, sami, mpl2 --
+# and every format missing from an allowlist recreates this exact bug for
+# whoever owns that file. Denying also fails in the SAFE direction: an
+# unrecognised codec is treated as text, which over-counts coverage visibly,
+# instead of silently queueing work for a file that already has subtitles.
+#
+# dvb_teletext is deliberately absent. Teletext IS text, and ffmpeg decodes it
+# to text, so it does not belong here.
+IMAGE_SUBTITLE_CODECS = frozenset(
+    {
+        "hdmv_pgs_subtitle",  # Blu-ray PGS
+        "dvd_subtitle",  # DVD VobSub (the reported case)
+        "dvb_subtitle",  # DVB broadcast bitmap
+        "xsub",  # DivX/AVI bitmap
+    }
+)
+
+
+def is_image_subtitle_codec(codec: str | None) -> bool:
+    """True only for codecs we KNOW are bitmaps. Unknown or missing -> False."""
+    return (codec or "").strip().lower() in IMAGE_SUBTITLE_CODECS
+
+
 _SDH_PAT = re.compile(r"\b(SDH|HI|hearing[\s-]?impaired|CC|closed[\s-]?caption|deaf)\b", re.I)
 _FORCED_PAT = re.compile(r"\bforced\b", re.I)
 _COMMENTARY_PAT = re.compile(r"\bcommentary\b|\bdirector'?s?\b", re.I)
@@ -268,9 +298,17 @@ def has_usable_embedded_english(result: ProbeResult) -> bool:
 
     Forced subs (only translate non-English dialogue snippets) and
     director's commentary tracks remain non-usable — those genuinely
-    aren't full subtitles for the show."""
+    aren't full subtitles for the show.
+
+    [#458] Image-based tracks (PGS/VobSub) are excluded too: they are pictures,
+    not text, so they cannot serve any purpose subarr has for a subtitle."""
     for s in result.subtitles:
-        if (s.language or "").lower() in ENGLISH_TAGS and not s.forced and not s.commentary:
+        if (
+            (s.language or "").lower() in ENGLISH_TAGS
+            and not s.forced
+            and not s.commentary
+            and not is_image_subtitle_codec(s.codec)  # [#458] a bitmap is not readable text
+        ):
             return True
     return False
 
@@ -292,7 +330,7 @@ has_forced_or_sdh_english = has_forced_or_commentary_english
 
 def english_track_summary(result: ProbeResult) -> str | None:
     """Short label for the UI: 'EN' / 'EN(SDH)' / 'EN(forced)' /
-    'EN(commentary)' / None.
+    'EN(commentary)' / 'EN(image)' / None.
 
     'EN(SDH)' is preserved as metadata so the Library Probe tab can show
     which tracks include hearing-impaired markers, but coverage scoring
@@ -314,6 +352,13 @@ def english_track_summary(result: ProbeResult) -> str | None:
                 return "EN(forced)"
             if s.commentary:
                 return "EN(commentary)"
+            # [#458] An image track reaches here because it is not usable
+            # coverage. It still has to be NAMED: falling through to None would
+            # render a file that genuinely has an English VobSub track as
+            # "no English track", which is indistinguishable from a probe
+            # failure and sends the user looking for the wrong problem.
+            if is_image_subtitle_codec(s.codec):
+                return "EN(image)"
     return None
 
 

--- a/src/subarr/routers/probe.py
+++ b/src/subarr/routers/probe.py
@@ -131,6 +131,8 @@ async def library(
                 row_kind = "forced"
             elif en_summary == "EN(commentary)":
                 row_kind = "commentary"
+            elif en_summary == "EN(image)":  # [#458] PGS/VobSub, not text
+                row_kind = "image"
             if row_kind != kind_filter:
                 continue
         out.append(

--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -55,6 +55,14 @@ _DEFAULT_HISTORY_WINDOW_S = 24 * 3600
 # Mirrors has_external_subtitle_in_language() in subgen_patched.py — a file
 # subgen skipped because ANY of these sits next to it (not only .srt) was
 # previously mislabeled 'unknown' (#89). Kept in sync with subgen's set.
+# [#458] This list DELIBERATELY still contains the image-sidecar extensions
+# .idx, .pgs and .sub. It is not a coverage judgement -- it is a MIRROR of
+# subgen's has_external_subtitle_in_language(), used only to explain why subgen
+# already skipped a file. Dropping them here would not stop a single skip; it
+# would just make subarr unable to explain one, pushing it into the noisy
+# 'unknown' bucket (#89). Whether a bitmap sidecar SHOULD cause a skip is a
+# subgen-side decision -- change it there first, then update this mirror in
+# lockstep. See media_probe.IMAGE_SUBTITLE_CODECS for the coverage judgement.
 _SUBTITLE_SIDECAR_EXTS = (
     ".srt",
     ".vtt",

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -121,6 +121,13 @@ class SubgenCapabilities:
     # subarr's coverage gates the forced-only-EN partial gap on it so users
     # only see an actionable gap the connected subgen will actually fill.
     ignore_forced_subtitles: bool = False
+    # v4.22 capability (#458): when True subgen treats an image-based
+    # (PGS/VobSub) target-language track as NOT coverage and transcribes the
+    # file. When False -- which is subgen's DEFAULT, unlike the forced knob --
+    # it still skips those files. Live on/off value, not merely "supported":
+    # coverage gates the image-only partial gap on it so an un-fillable gap is
+    # never presented as actionable.
+    ignore_image_subtitles: bool = False
     # r9+ capability: POST /config runtime model/compute switching. Gate
     # post_config() calls on this — older images 404 the endpoint.
     runtime_config: bool = False
@@ -167,6 +174,7 @@ class SubgenCapabilities:
             "asr_vanilla_base": self.asr_vanilla_base,
             "asr_detected_language": self.asr_detected_language,
             "ignore_forced_subtitles": self.ignore_forced_subtitles,
+            "ignore_image_subtitles": self.ignore_image_subtitles,
             "runtime_config": self.runtime_config,
             "subarr_subgen_patch_rev": self.subarr_subgen_patch_rev,
             "release_tag": self.release_tag,
@@ -193,6 +201,7 @@ class SubgenCapabilities:
             asr_vanilla_base=False,
             asr_detected_language=False,
             ignore_forced_subtitles=False,
+            ignore_image_subtitles=False,
             runtime_config=False,
             request_ignore_forced=False,
             subarr_subgen_patch_rev=None,
@@ -330,6 +339,7 @@ class SubgenClient:
         asr_vanilla_base = False
         asr_detected_language = False
         ignore_forced_subtitles = False
+        ignore_image_subtitles = False
         runtime_config = False
         concurrent_transcriptions: int | None = None
         request_ignore_forced = False
@@ -365,6 +375,7 @@ class SubgenClient:
                             asr_vanilla_base = bool(caps_block.get("asr_vanilla_base"))
                             asr_detected_language = bool(caps_block.get("asr_detected_language"))
                             ignore_forced_subtitles = bool(caps_block.get("ignore_forced_subtitles"))
+                            ignore_image_subtitles = bool(caps_block.get("ignore_image_subtitles"))
                             runtime_config = bool(caps_block.get("runtime_config"))
                             request_ignore_forced = bool(caps_block.get("request_ignore_forced"))
                             _ct = caps_block.get("concurrent_transcriptions")
@@ -402,6 +413,7 @@ class SubgenClient:
             asr_vanilla_base=asr_vanilla_base,
             asr_detected_language=asr_detected_language,
             ignore_forced_subtitles=ignore_forced_subtitles,
+            ignore_image_subtitles=ignore_image_subtitles,
             runtime_config=runtime_config,
             concurrent_transcriptions=concurrent_transcriptions,
             request_ignore_forced=request_ignore_forced,

--- a/tests/test_image_subtitle_codecs.py
+++ b/tests/test_image_subtitle_codecs.py
@@ -1,0 +1,215 @@
+"""#458: image-based subtitle tracks were counted as subtitle coverage.
+
+Reported on r/radarr: a file with an embedded VobSub track is skipped as
+"already has subtitles", but a bitmap cannot be read as text, searched,
+restyled, retimed, or fed to anything downstream. The user had patched it
+locally with a text-codec allowlist.
+
+We deny the image codecs instead of allowing the text ones. The image set is
+small and closed; the text set has a long tail (microdvd, subviewer, stl,
+jacosub, sami, mpl2) and every format missed from an allowlist recreates this
+exact bug for someone else. Denying also fails SAFE: an unknown new image
+codec over-counts coverage, which is visible, rather than silently skipping
+files, which is not.
+"""
+
+from __future__ import annotations
+
+from subarr.media_probe import (
+    IMAGE_SUBTITLE_CODECS,
+    ProbeResult,
+    SubtitleStream,
+    has_usable_embedded_english,
+    is_image_subtitle_codec,
+)
+
+
+def _sub(codec: str, *, lang: str = "eng", forced: bool = False, commentary: bool = False):
+    return SubtitleStream(
+        index=0,
+        language=lang,
+        codec=codec,
+        title=None,
+        default=False,
+        forced=forced,
+        sdh=False,
+        commentary=commentary,
+    )
+
+
+def _result(*subs) -> ProbeResult:
+    pr = ProbeResult(canonical_path="TV/Show/ep.mkv")
+    pr.subtitles.extend(subs)
+    return pr
+
+
+def test_the_image_codecs_we_deny():
+    # Verified 2026-08-28 against `ffmpeg -decoders` in the subgen-next image:
+    # these four are the ONLY bitmap subtitle codecs ffmpeg knows, so the deny
+    # set is complete by construction rather than by recollection.
+    for c in ("hdmv_pgs_subtitle", "dvd_subtitle", "dvb_subtitle", "xsub"):
+        assert c in IMAGE_SUBTITLE_CODECS, f"{c} must be denied"
+        assert is_image_subtitle_codec(c) is True
+
+
+def test_text_codecs_are_not_denied_including_the_long_tail():
+    # ffmpeg also decodes pjs, realtext, vplayer and subviewer1 as text -- four
+    # more formats the reporter's 7-entry allowlist would have misfiled as
+    # images. The tail is long, which is the whole argument for denying.
+    # The reporter's allowlist was {srt, ass, mov_text, subrip, webvtt, text,
+    # ssa}. Anything outside it would have been wrongly treated as an image
+    # sub. Denying instead means these all keep working with no extra config.
+    for c in (
+        "subrip",
+        "ass",
+        "ssa",
+        "mov_text",
+        "webvtt",
+        "text",
+        "microdvd",
+        "subviewer",
+        "stl",
+        "jacosub",
+        "sami",
+        "mpl2",
+    ):
+        assert is_image_subtitle_codec(c) is False, f"{c} is text, must not be denied"
+
+
+def test_unknown_codec_is_treated_as_text_not_image():
+    # Fail-safe direction: an unrecognised codec over-counts coverage (visible)
+    # rather than silently queueing a transcription for a file that has subs.
+    # dvb_teletext and eia_608 are the sharp cases: both LOOK broadcast-y but
+    # ffmpeg decodes both to text (libzvbi / cc_dec), so denying them would
+    # have thrown away real subtitles.
+    assert is_image_subtitle_codec("dvb_teletext") is False
+    assert is_image_subtitle_codec("eia_608") is False
+    assert is_image_subtitle_codec("some_future_text_format") is False
+    assert is_image_subtitle_codec(None) is False
+
+
+def test_a_pgs_english_track_is_not_usable_coverage():
+    # The exact reported case, in Blu-ray flavour.
+    assert has_usable_embedded_english(_result(_sub("hdmv_pgs_subtitle"))) is False
+
+
+def test_a_vobsub_english_track_is_not_usable_coverage():
+    # The exact reported case, verbatim: "I have VobSub embedded".
+    assert has_usable_embedded_english(_result(_sub("dvd_subtitle"))) is False
+
+
+def test_a_text_english_track_is_still_usable():
+    assert has_usable_embedded_english(_result(_sub("subrip"))) is True
+
+
+def test_a_text_track_alongside_an_image_track_still_counts():
+    # Common on Blu-ray rips: PGS plus an SRT. The text one is real coverage.
+    assert has_usable_embedded_english(_result(_sub("hdmv_pgs_subtitle"), _sub("subrip"))) is True
+
+
+def test_image_codec_does_not_rescue_a_forced_track():
+    # Forced was already excluded; adding the codec check must not change that.
+    assert has_usable_embedded_english(_result(_sub("subrip", forced=True))) is False
+
+
+def test_a_non_english_image_track_is_still_irrelevant():
+    assert has_usable_embedded_english(_result(_sub("dvd_subtitle", lang="fra"))) is False
+
+
+def test_codec_is_optional_and_missing_codec_does_not_crash():
+    # ffprobe can omit codec_name on a malformed container.
+    assert has_usable_embedded_english(_result(_sub(None))) is True
+
+
+# --- UI honesty: the label must say an image track EXISTS ------------------
+# Without this, english_track_summary() falls through every branch and returns
+# None, so a file with a perfectly real VobSub English track renders as "no
+# English track at all". That is worse than the original bug: the user cannot
+# tell a file with unusable subs from a file with none, and would reasonably
+# think subarr failed to read the container.
+
+from subarr.media_probe import english_track_summary, has_forced_or_commentary_english
+
+
+def test_image_only_english_is_labelled_not_dropped():
+    assert english_track_summary(_result(_sub("hdmv_pgs_subtitle"))) == "EN(image)"
+
+
+def test_image_only_english_counts_as_partial_coverage_not_absent():
+    # Partial => the Coverage row is demoted but still visible, same treatment
+    # as forced. Silently absent would hide the file from the user entirely.
+    assert has_forced_or_commentary_english(_result(_sub("dvd_subtitle"))) is True
+
+
+def test_a_real_text_track_still_labels_clean():
+    assert english_track_summary(_result(_sub("subrip"))) == "EN"
+
+
+def test_text_track_wins_the_label_over_an_image_track():
+    assert english_track_summary(_result(_sub("hdmv_pgs_subtitle"), _sub("subrip"))) == "EN"
+
+
+def test_forced_still_wins_over_image_so_existing_labels_do_not_regress():
+    s = _sub("dvd_subtitle", forced=True)
+    assert english_track_summary(_result(s)) == "EN(forced)"
+
+
+def test_no_english_at_all_is_still_none():
+    assert english_track_summary(_result(_sub("dvd_subtitle", lang="fra"))) is None
+
+
+# --- Coverage scoring: demote, and be honest that subgen will skip it -------
+# An image-only English file is the SAME trap #79 solved for forced subs:
+# subgen's has_internal_subtitle_in_language() sees a subtitle stream tagged
+# "eng" and skips the file, whatever the codec. So the gap is real but
+# UN-FILLABLE today. Presenting it as an ordinary actionable gap dangles work
+# the user can click forever with nothing happening.
+
+
+def _item(embedded_en=None):
+    from subarr.coverage_engine import CoverageItem
+
+    return CoverageItem(
+        media_type="movie",
+        title="A DVD Rip",
+        canonical_path="Movies/A DVD Rip",
+        embedded_en=embedded_en,
+        audio_langs=["eng"],
+    )
+
+
+def test_image_only_en_is_demoted_to_partial_not_treated_as_no_subs():
+    from subarr.coverage_engine import _score
+
+    it = _item("EN(image)")
+    _score(it, {}, ignore_forced_subtitles=True)
+    assert any("partial coverage" in r for r in it.score_reasons)
+
+
+def test_image_only_en_says_subgen_will_skip_it():
+    from subarr.coverage_engine import _score
+
+    it = _item("EN(image)")
+    _score(it, {}, ignore_forced_subtitles=True)
+    assert any("skip" in r.lower() for r in it.score_reasons), (
+        "an un-fillable gap must say so, per the #79 precedent"
+    )
+
+
+def test_image_only_en_is_not_satisfied_by_the_ignore_forced_cap():
+    # The forced cap governs FORCED subs. It must not accidentally make an
+    # image-only file look actionable.
+    from subarr.coverage_engine import _score
+
+    for cap in (True, False):
+        it = _item("EN(image)")
+        _score(it, {}, ignore_forced_subtitles=cap)
+        assert any("skip" in r.lower() for r in it.score_reasons)
+
+
+def test_full_english_is_still_satisfied_and_not_demoted():
+    from subarr.coverage_engine import _score
+
+    it = _item("EN")
+    _score(it, {}, ignore_forced_subtitles=True)
+    assert not any("partial coverage" in r for r in it.score_reasons)

--- a/tests/test_image_subtitle_codecs.py
+++ b/tests/test_image_subtitle_codecs.py
@@ -52,6 +52,26 @@ def test_the_image_codecs_we_deny():
         assert is_image_subtitle_codec(c) is True
 
 
+def test_pyav_decoder_spellings_are_denied_too():
+    """The near-miss that would have shipped a no-op.
+
+    ffprobe reports a stream's codec_name; PyAV's codec_context.name reports
+    the DECODER name, and they DISAGREE for three of the four bitmap codecs.
+    Measured 2026-08-28 by asking PyAV directly (av.codec.Codec(n, "r").name):
+
+        hdmv_pgs_subtitle -> pgssub      dvd_subtitle -> dvdsub
+        dvb_subtitle      -> dvbsub      xsub         -> xsub
+
+    A deny set holding only the ffprobe spellings matches 1 of 4 on the PyAV
+    side, missing PGS and VobSub -- exactly the two codecs that were reported.
+    It applies clean and passes every structural check while doing nothing.
+    """
+    for decoder_name in ("pgssub", "dvdsub", "dvbsub", "xsub"):
+        assert is_image_subtitle_codec(decoder_name) is True, (
+            f"{decoder_name} is how PyAV spells a bitmap codec"
+        )
+
+
 def test_text_codecs_are_not_denied_including_the_long_tail():
     # ffmpeg also decodes pjs, realtext, vplayer and subviewer1 as text -- four
     # more formats the reporter's 7-entry allowlist would have misfiled as
@@ -59,8 +79,12 @@ def test_text_codecs_are_not_denied_including_the_long_tail():
     # The reporter's allowlist was {srt, ass, mov_text, subrip, webvtt, text,
     # ssa}. Anything outside it would have been wrongly treated as an image
     # sub. Denying instead means these all keep working with no extra config.
+    # "srt" is PyAV's decoder name for "subrip" and "cc_dec" is its name for
+    # eia_608 -- both text, and both must survive from either naming scheme.
     for c in (
         "subrip",
+        "srt",
+        "cc_dec",
         "ass",
         "ssa",
         "mov_text",

--- a/tests/test_image_subtitle_codecs.py
+++ b/tests/test_image_subtitle_codecs.py
@@ -237,3 +237,67 @@ def test_full_english_is_still_satisfied_and_not_demoted():
     it = _item("EN")
     _score(it, {}, ignore_forced_subtitles=True)
     assert not any("partial coverage" in r for r in it.score_reasons)
+
+
+# --- Do not queue work subgen will refuse (the #79 gating, for images) ------
+# Before this fix an image-only file was labelled "EN" and auto-queue skipped
+# it as covered. Now it is correctly NOT coverage, so it becomes eligible --
+# but subgen still refuses it unless IGNORE_IMAGE_SUBTITLES is on. Without
+# gating, the fix would turn a silent skip into a queue full of instant
+# rejections, which is a worse experience, not a better one.
+
+
+def test_image_skip_flag_exists_and_defaults_false():
+    it = _item()
+    assert it.image_only_subgen_will_skip is False
+    assert it.to_dict()["image_only_subgen_will_skip"] is False
+
+
+def test_cap_off_marks_image_only_as_non_actionable():
+    from subarr.coverage_engine import _score
+
+    it = _item("EN(image)")
+    _score(it, {}, ignore_image_subtitles=False)
+    assert it.image_only_subgen_will_skip is True
+    assert any("skip" in r.lower() for r in it.score_reasons)
+
+
+def test_cap_on_makes_image_only_an_actionable_gap():
+    from subarr.coverage_engine import _score
+
+    it = _item("EN(image)")
+    _score(it, {}, ignore_image_subtitles=True)
+    assert it.image_only_subgen_will_skip is False
+    # still demoted -- a bitmap is still not usable text coverage
+    assert any("partial coverage" in r for r in it.score_reasons)
+
+
+def test_auto_queue_skips_what_subgen_will_refuse():
+    from subarr.auto_queue import _filter_reason
+    from subarr.schedule_store import AutoQueueRules
+
+    it = _item("EN(image)")
+    it.image_only_subgen_will_skip = True
+    reason = _filter_reason(it, AutoQueueRules())
+    assert reason is not None and "image" in reason.lower()
+
+
+def test_auto_queue_allows_image_only_once_subgen_can_fill_it():
+    from subarr.auto_queue import _filter_reason
+    from subarr.schedule_store import AutoQueueRules
+
+    it = _item("EN(image)")
+    it.image_only_subgen_will_skip = False
+    it.score = 10_000  # clear the min_score gate; we are testing the image rule
+    reason = _filter_reason(it, AutoQueueRules())
+    assert reason is None or "image" not in reason.lower()
+
+
+def test_the_forced_cap_does_not_gate_the_image_case():
+    # Two independent caps. Turning IGNORE_FORCED_SUBTITLES on must not make
+    # an image-only file look fillable.
+    from subarr.coverage_engine import _score
+
+    it = _item("EN(image)")
+    _score(it, {}, ignore_forced_subtitles=True, ignore_image_subtitles=False)
+    assert it.image_only_subgen_will_skip is True

--- a/tests/test_radarr_movie_coverage.py
+++ b/tests/test_radarr_movie_coverage.py
@@ -69,6 +69,7 @@ def _run(movies, items, idx):
             plex_hints={},
             sources={},
             ignore_forced_subtitles=False,
+            ignore_image_subtitles=False,  # [#458]
         )
     )
 

--- a/tests/test_subgen_capabilities.py
+++ b/tests/test_subgen_capabilities.py
@@ -226,3 +226,71 @@ async def test_detect_language_track_capability_parsed():
     await c.aclose()
     assert caps.detect_language_track is True
     assert caps.to_dict()["detect_language_track"] is True
+
+
+# --- #458: the image-subtitle capability must actually reach the dataclass ---
+# SubgenCapabilities is a FROZEN dataclass with explicit fields. Coverage reads
+# the flag with getattr(caps, "ignore_image_subtitles", False), which silently
+# returns the default forever if the field was never declared and parsed. That
+# is the same class of silent no-op as the PyAV codec naming: everything
+# compiles, every other test passes, and the gate simply never opens.
+
+
+def _caps_handler(caps_block: dict | None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={"version": "Subgen 2026.08.1 (docker)"})
+        if request.url.path == "/queue":
+            body = {
+                "queued": [],
+                "processing": [],
+                "queued_count": 0,
+                "processing_count": 0,
+                "idle": True,
+                "version": "2026.08.1",
+            }
+            if caps_block is not None:
+                body["capabilities"] = caps_block
+            return httpx.Response(200, json=body)
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_image_subtitle_capability_is_read_from_queue():
+    c = _make_client(httpx.MockTransport(_caps_handler({"ignore_image_subtitles": True})))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+    assert caps.ignore_image_subtitles is True
+    assert caps.to_dict()["ignore_image_subtitles"] is True
+
+
+@pytest.mark.asyncio
+async def test_image_subtitle_capability_off_when_subgen_says_off():
+    c = _make_client(httpx.MockTransport(_caps_handler({"ignore_image_subtitles": False})))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+    assert caps.ignore_image_subtitles is False
+
+
+@pytest.mark.asyncio
+async def test_image_subtitle_capability_absent_defaults_off():
+    # Vanilla subgen and every pre-v4.22 build: no such key. Must default OFF,
+    # so subarr keeps treating image-only rows as un-fillable rather than
+    # queueing work that build will refuse.
+    c = _make_client(httpx.MockTransport(_caps_handler(None)))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+    assert caps.ignore_image_subtitles is False
+
+
+@pytest.mark.asyncio
+async def test_image_and_forced_capabilities_are_independent():
+    c = _make_client(
+        httpx.MockTransport(_caps_handler({"ignore_forced_subtitles": True, "ignore_image_subtitles": False}))
+    )
+    caps = await c.probe_capabilities()
+    await c.aclose()
+    assert caps.ignore_forced_subtitles is True
+    assert caps.ignore_image_subtitles is False


### PR DESCRIPTION
Closes #458.

A PGS or VobSub track is a sequence of **pictures**. It cannot be searched, restyled, retimed, or read as text, so counting one as subtitle coverage silently skipped files that genuinely needed a transcription. Reported on r/radarr by a user who had patched it locally with a text-codec allowlist.

## Two near-misses worth reading

Both would have shipped a **silent no-op** that applied cleanly and passed every existing check.

**1. The same codec has two names.** ffprobe reports a stream's `codec_name`; PyAV's `codec_context.name` reports the *decoder* name, and they disagree for three of the four bitmap codecs. Measured by asking PyAV directly:

| ffprobe `codec_name` | PyAV `codec_context.name` |
|---|---|
| `hdmv_pgs_subtitle` | `pgssub` |
| `dvd_subtitle` | `dvdsub` |
| `dvb_subtitle` | `dvbsub` |
| `xsub` | `xsub` |
| `subrip` | `srt` |

A deny set built from ffprobe names matches **1 of 4** on the PyAV side, missing PGS and VobSub, which are precisely the two codecs reported. Found while wiring the same fix into subgen, which reads these tracks through PyAV. Both spellings are now carried and both are asserted.

**2. A `getattr` default against a frozen dataclass can never fire.** The coverage gate read `getattr(caps, "ignore_image_subtitles", False)`, but `SubgenCapabilities` is a frozen dataclass with explicit fields, so that returns the default forever: the gate could never open and no test would have noticed. The field is now declared and parsed from `/queue`, and the parse was negative-tested by deleting it and confirming the suite goes red.

## Design decisions

**Denies the bitmap codecs rather than allow-listing the text ones.** `ffmpeg -decoders` confirms those four are the only bitmap subtitle codecs that exist, so the deny set is complete by construction. The text set has a long tail (`microdvd`, `subviewer`, `stl`, `jacosub`, `sami`, `mpl2`, `pjs`, `realtext`, `vplayer`, `subviewer1`) where any omission recreates this bug for whoever owns that file. Denying also fails safe: an unknown codec is treated as text, which over-counts coverage visibly rather than silently skipping work. `dvb_teletext` and `eia_608` are deliberately not denied because ffmpeg decodes both to text.

**Adds the `EN(image)` label.** Without it `english_track_summary()` fell through every branch and returned `None`, so a file with a real VobSub English track rendered as having no English track at all, which is indistinguishable from a probe failure.

**Gates the auto-queue.** Making image subs not-coverage means those files stop being skipped as covered and become queue-eligible, but subgen only transcribes them when `IGNORE_IMAGE_SUBTITLES` is on, and that defaults off. Left alone this would convert a silent skip into a queue full of instant rejections. `image_only_subgen_will_skip` mirrors the #79 forced-sub gating and clears itself once the connected subgen can actually fill them. The two caps are independent, and a test pins that.

**`_SUBTITLE_SIDECAR_EXTS` deliberately still contains `.idx`, `.pgs` and `.sub`.** It is a mirror of subgen's `has_external_subtitle_in_language()` used only to explain why subgen skipped a file, not a coverage judgement. Dropping them would stop no skips and only make subarr unable to explain one, pushing rows into the noisy `unknown` bucket. Documented in place so it is not "fixed" into a disagreement.

## Test plan

- [x] 27 tests in `tests/test_image_subtitle_codecs.py` covering both naming schemes, the text long tail, the fail-safe unknown codec, the label, coverage demotion and auto-queue gating
- [x] 4 tests in `tests/test_subgen_capabilities.py` proving the capability reaches the dataclass from a `/queue` payload
- [x] Capability parse negative-tested (deleted the line, suite went red)
- [x] 294 passed across every exposed suite (coverage, auto_queue, forced, probe, image)
- [x] `ruff check` and `ruff format --check` clean

The subgen half is coaxk/subarr-subgen#50 - until that ships, image-only rows are correctly shown as a demoted, explicitly un-fillable gap rather than a dangling one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)