### PR TITLE
feat(#458): send bypass_skip so image-only rows can actually be filled

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -504,6 +504,7 @@ async def lifespan(app_: FastAPI):
             scan,
             audio_language_override=job.audio_language_override,
             ignore_forced=job.ignore_forced,
+            bypass_skip=job.bypass_skip,
         )
         # Full provenance (series_id carried on the job) so completion_watcher
         # fires Bazarr's scan-disk task the moment subgen finishes (#66/#116 s6).

--- a/src/subarr/migrations/030_pending_queue_bypass_skip.sql
+++ b/src/subarr/migrations/030_pending_queue_bypass_skip.sql
@@ -1,0 +1,18 @@
+-- 030_pending_queue_bypass_skip.sql
+--
+-- #458 follow-on: a pending job can carry a per-request `bypass_skip` flag so
+-- the feeder forwards it to subgen's POST /batch (?bypass_skip=true, subgen
+-- v4.23+). That bypasses EVERY one of subgen's skip heuristics for that one
+-- request.
+--
+-- Needed because #458 exposed a file class no existing knob can reach: English
+-- audio whose only English subtitle is a BITMAP. Once image subs correctly stop
+-- counting as coverage the row becomes a real gap, but subgen still refuses it
+-- via SKIP_IF_AUDIO_LANGUAGES=eng (English audio has nothing to translate).
+-- `ignore_forced` does not help either: the subtitle is not forced, it is a
+-- picture. The only alternatives were unskipping every English file in the
+-- library, or leaving the gap permanently unfillable.
+--
+-- 0/1 INTEGER, default 0 = normal skip behaviour. Pre-existing rows get 0,
+-- which is correct: they were queued as ordinary gaps, not skip-overrides.
+ALTER TABLE pending_queue ADD COLUMN bypass_skip INTEGER NOT NULL DEFAULT 0;

--- a/src/subarr/pending_queue.py
+++ b/src/subarr/pending_queue.py
@@ -67,6 +67,10 @@ class PendingJob:
     # so a forced-only file is transcribed instead of skipped ("transcribe a
     # full sub anyway"). Default False = normal skip behaviour.
     ignore_forced: bool = False
+    # [#458 follow-on] forward ?bypass_skip=true to subgen's /batch for THIS
+    # job, overruling every skip heuristic. For the image-only-subtitle class,
+    # which SKIP_IF_AUDIO_LANGUAGES otherwise refuses forever.
+    bypass_skip: bool = False
     # #368: owning movie's Radarr id, carried so completion_watcher can upload the
     # finished .srt straight to the owning Bazarr (the movie analogue of
     # series_id + sonarr_episode_id). None for episodes / path-only jobs.
@@ -88,6 +92,7 @@ class PendingJob:
             "series_id": self.series_id,
             "sonarr_episode_id": self.sonarr_episode_id,
             "ignore_forced": self.ignore_forced,
+            "bypass_skip": self.bypass_skip,
             "radarr_movie_id": self.radarr_movie_id,
         }
 
@@ -95,7 +100,7 @@ class PendingJob:
 _COLS = (
     "id, canonical_path, position, priority, status, "
     "audio_language_override, task, source, created_at, submitted_at, error, "
-    "series_id, sonarr_episode_id, ignore_forced, radarr_movie_id"
+    "series_id, sonarr_episode_id, ignore_forced, radarr_movie_id, bypass_skip"
 )
 
 # Statements built ONCE as constants. The only interpolation is the static
@@ -110,7 +115,12 @@ _SELECT = f"SELECT {_COLS} FROM pending_queue"  # nosec B608
 _Q_ACTIVE_BY_PATH = f"{_SELECT} WHERE canonical_path = ? AND status IN (?, ?) LIMIT 1"
 _Q_MAXPOS = "SELECT MAX(position) FROM pending_queue WHERE status = ? AND priority = ?"
 _Q_INSERT = (  # nosec B608
-    f"INSERT INTO pending_queue ({_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    # Placeholders are DERIVED from _COLS rather than written out. They were a
+    # hardcoded run of 15 "?", which silently went out of step with _COLS the
+    # moment a column was added (#458 follow-on added the 16th). Deriving them
+    # makes that class of drift impossible. Still no user input in the SQL:
+    # _COLS is a module constant and every value is bound as a parameter.
+    f"INSERT INTO pending_queue ({_COLS}) VALUES ({', '.join('?' * (_COLS.count(',') + 1))})"
 )
 _Q_GET = f"{_SELECT} WHERE id = ?"
 _Q_LIST_ALL = f"{_SELECT} ORDER BY priority DESC, position ASC, created_at ASC"
@@ -138,6 +148,7 @@ def _row(r: tuple) -> PendingJob:
         series_id=r[11],
         sonarr_episode_id=r[12],
         ignore_forced=bool(r[13]),
+        bypass_skip=bool(r[15]),
         radarr_movie_id=r[14],
     )
 
@@ -170,6 +181,7 @@ class PendingQueueStore:
         series_id: int | None = None,
         sonarr_episode_id: int | None = None,
         ignore_forced: bool = False,
+        bypass_skip: bool = False,
         radarr_movie_id: int | None = None,
     ) -> PendingJob:
         """Add a job, or return the existing ACTIVE one for this path (dedup —
@@ -210,6 +222,7 @@ class PendingQueueStore:
                 series_id=series_id,
                 sonarr_episode_id=sonarr_episode_id,
                 ignore_forced=ignore_forced,
+                bypass_skip=bypass_skip,
                 radarr_movie_id=radarr_movie_id,
             )
             self._conn.execute(
@@ -230,6 +243,7 @@ class PendingQueueStore:
                     job.sonarr_episode_id,
                     int(job.ignore_forced),
                     job.radarr_movie_id,
+                    int(job.bypass_skip),
                 ),
             )
             return job

--- a/src/subarr/routers/coverage_actions.py
+++ b/src/subarr/routers/coverage_actions.py
@@ -64,6 +64,13 @@ class CoverageQueueRequest(BaseModel):
     # this when the connected subgen advertises capabilities.request_ignore_forced;
     # an older subgen silently drops the param (the file re-skips, no harm).
     ignore_forced: bool = False
+    # [#458 follow-on] 'transcribe this anyway' for a row whose only English
+    # subtitle is a BITMAP. Those files usually have English audio too, so
+    # subgen's SKIP_IF_AUDIO_LANGUAGES refuses them and ignore_forced does not
+    # help -- the sub is not forced, it is a picture. Forwards
+    # ?bypass_skip=true. Only sent when the connected subgen advertises
+    # capabilities.bypass_skip; older builds drop it and the file re-skips.
+    bypass_skip: bool = False
 
 
 @router.post("/coverage/queue", status_code=202)
@@ -167,6 +174,7 @@ async def coverage_queue(req: CoverageQueueRequest, request: Request) -> dict:
         sonarr_episode_id=req.sonarr_episode_id,
         radarr_movie_id=req.radarr_movie_id,
         ignore_forced=req.ignore_forced,
+        bypass_skip=req.bypass_skip,
     )
 
     return {

--- a/src/subarr/scan_runner.py
+++ b/src/subarr/scan_runner.py
@@ -113,6 +113,10 @@ class ScanRunner:
         # /batch (transcribe a forced-only file anyway). In-memory, same lifetime
         # as _overrides — lost on restart, but so is the in-flight scan.
         self._ignore_forced: set[str] = set()
+        # [#458 follow-on] scans allowed to overrule subgen's skip heuristics
+        # entirely -- the image-only-subtitle class, which SKIP_IF_AUDIO_LANGUAGES
+        # otherwise refuses forever.
+        self._bypass_skip: set[str] = set()
         self._lock = asyncio.Lock()
         # Callable returning the cached SubgenCapabilities snapshot.
         # We don't probe per-scan — caps are stable per app boot.
@@ -165,11 +169,14 @@ class ScanRunner:
         scan: Scan,
         audio_language_override: str | None = None,
         ignore_forced: bool = False,
+        bypass_skip: bool = False,
     ) -> None:
         if audio_language_override:
             self._overrides[scan.id] = audio_language_override
         if ignore_forced:
             self._ignore_forced.add(scan.id)
+        if bypass_skip:
+            self._bypass_skip.add(scan.id)
         task = asyncio.create_task(self._run(scan.id), name=f"scan-{scan.id}")
         self._tasks[scan.id] = task
         task.add_done_callback(
@@ -177,6 +184,7 @@ class ScanRunner:
                 self._tasks.pop(sid, None),
                 self._overrides.pop(sid, None),
                 self._ignore_forced.discard(sid),
+                self._bypass_skip.discard(sid),
             )
         )
 
@@ -243,6 +251,7 @@ class ScanRunner:
                     reverse=scan.reverse,
                     audio_language_override=override,
                     ignore_forced=scan_id in self._ignore_forced,
+                    bypass_skip=scan_id in self._bypass_skip,
                 )
                 result.subgen_status_code = status_code
                 result.subgen_body = body

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -128,6 +128,13 @@ class SubgenCapabilities:
     # coverage gates the image-only partial gap on it so an un-fillable gap is
     # never presented as actionable.
     ignore_image_subtitles: bool = False
+    # v4.23 capability (#458 follow-on): POST /batch accepts bypass_skip=true,
+    # which skips EVERY skip heuristic for that one request. Needed for the
+    # file class that has English audio AND only image-based English subs:
+    # SKIP_IF_AUDIO_LANGUAGES refuses it and no other knob reaches it without
+    # unskipping the whole library. Gate the UI action on this -- an older
+    # subgen drops the unknown param and re-skips, which reads as a dead button.
+    bypass_skip: bool = False
     # r9+ capability: POST /config runtime model/compute switching. Gate
     # post_config() calls on this — older images 404 the endpoint.
     runtime_config: bool = False
@@ -175,6 +182,7 @@ class SubgenCapabilities:
             "asr_detected_language": self.asr_detected_language,
             "ignore_forced_subtitles": self.ignore_forced_subtitles,
             "ignore_image_subtitles": self.ignore_image_subtitles,
+            "bypass_skip": self.bypass_skip,
             "runtime_config": self.runtime_config,
             "subarr_subgen_patch_rev": self.subarr_subgen_patch_rev,
             "release_tag": self.release_tag,
@@ -202,6 +210,7 @@ class SubgenCapabilities:
             asr_detected_language=False,
             ignore_forced_subtitles=False,
             ignore_image_subtitles=False,
+            bypass_skip=False,
             runtime_config=False,
             request_ignore_forced=False,
             subarr_subgen_patch_rev=None,
@@ -340,6 +349,7 @@ class SubgenClient:
         asr_detected_language = False
         ignore_forced_subtitles = False
         ignore_image_subtitles = False
+        bypass_skip = False
         runtime_config = False
         concurrent_transcriptions: int | None = None
         request_ignore_forced = False
@@ -376,6 +386,7 @@ class SubgenClient:
                             asr_detected_language = bool(caps_block.get("asr_detected_language"))
                             ignore_forced_subtitles = bool(caps_block.get("ignore_forced_subtitles"))
                             ignore_image_subtitles = bool(caps_block.get("ignore_image_subtitles"))
+                            bypass_skip = bool(caps_block.get("bypass_skip"))
                             runtime_config = bool(caps_block.get("runtime_config"))
                             request_ignore_forced = bool(caps_block.get("request_ignore_forced"))
                             _ct = caps_block.get("concurrent_transcriptions")
@@ -414,6 +425,7 @@ class SubgenClient:
             asr_detected_language=asr_detected_language,
             ignore_forced_subtitles=ignore_forced_subtitles,
             ignore_image_subtitles=ignore_image_subtitles,
+            bypass_skip=bypass_skip,
             runtime_config=runtime_config,
             concurrent_transcriptions=concurrent_transcriptions,
             request_ignore_forced=request_ignore_forced,
@@ -515,6 +527,7 @@ class SubgenClient:
         kwargs: dict[str, Any] | None = None,
         task: str | None = None,
         ignore_forced: bool = False,
+        bypass_skip: bool = False,
     ) -> tuple[int, dict[str, Any]]:
         """POST /batch with subgen's V4.1 structured response.
 
@@ -571,6 +584,12 @@ class SubgenClient:
             # False so ≤v4.14 subgen keeps its global behaviour (and silently
             # drops the unknown param). Gate on capabilities.request_ignore_forced.
             params["ignore_forced"] = "true"
+        if bypass_skip:
+            # v4.23 (#458 follow-on): bypass EVERY skip heuristic for this batch.
+            # Omitted when False so the request stays byte-identical to what
+            # callers send today; a pre-v4.23 subgen drops the unknown param and
+            # re-skips the file. Gate on capabilities.bypass_skip.
+            params["bypass_skip"] = "true"
         try:
             r = await self._client.post("/batch", params=params)
         except httpx.HTTPError as e:

--- a/tests/test_bypass_skip_plumbing.py
+++ b/tests/test_bypass_skip_plumbing.py
@@ -1,0 +1,166 @@
+"""#458 follow-on: subarr must be able to say "transcribe this one anyway".
+
+After the #458 fix, a file whose only English subtitle is a bitmap correctly
+stops counting as covered. But subgen still refuses to transcribe it when
+SKIP_IF_AUDIO_LANGUAGES contains its audio language, which is the common case:
+these are English-audio files whose English subs are pictures. Measured on a
+real library, 128 files sit in exactly that blind spot.
+
+subgen v4.23 adds ?bypass_skip=true for this. These tests pin the plumbing,
+because the failure mode is silent: drop the flag anywhere along
+  request -> scan_runner.start -> _run -> SubgenClient.batch -> query param
+and subarr still returns 202, subgen still returns 200, and the file is still
+skipped. The user sees a button that does nothing, with no error to explain it.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from subarr.subgen_client import SubgenClient
+
+
+def _client(handler) -> SubgenClient:
+    c = SubgenClient(base_url="http://fake-subgen:9000")
+    c._client = httpx.AsyncClient(base_url="http://fake-subgen:9000", transport=httpx.MockTransport(handler))
+    return c
+
+
+# ── the capability must be declared and parsed ──────────────────────────────
+def _caps_handler(caps: dict | None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/status":
+            return httpx.Response(200, json={"version": "Subgen 2026.08.1 (docker)"})
+        if request.url.path == "/queue":
+            body = {
+                "queued": [],
+                "processing": [],
+                "queued_count": 0,
+                "processing_count": 0,
+                "idle": True,
+                "version": "2026.08.1",
+            }
+            if caps is not None:
+                body["capabilities"] = caps
+            return httpx.Response(200, json=body)
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_bypass_skip_capability_is_read():
+    c = _client(_caps_handler({"bypass_skip": True}))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+    assert caps.bypass_skip is True
+    assert caps.to_dict()["bypass_skip"] is True
+
+
+@pytest.mark.asyncio
+async def test_bypass_skip_capability_absent_defaults_off():
+    # Every subgen before v4.23, including vanilla. Must default OFF so subarr
+    # does not offer an action that silently does nothing.
+    c = _client(_caps_handler(None))
+    caps = await c.probe_capabilities()
+    await c.aclose()
+    assert caps.bypass_skip is False
+
+
+# ── the query param must actually reach the wire ────────────────────────────
+@pytest.mark.asyncio
+async def test_batch_sends_bypass_skip_when_asked():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 1, "dispatched": 1})
+
+    c = _client(handler)
+    await c.batch("/media/TV/x", bypass_skip=True)
+    await c.aclose()
+    assert seen["params"].get("bypass_skip") == "true"
+
+
+@pytest.mark.asyncio
+async def test_batch_omits_bypass_skip_by_default():
+    """Omitted, not sent as false.
+
+    A pre-v4.23 subgen drops an unknown param silently, so sending it is
+    harmless there -- but omitting keeps the request identical to what every
+    existing caller sends today, which is what makes this change provably
+    behaviour-preserving.
+    """
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"walked": 1, "dispatched": 1})
+
+    c = _client(handler)
+    await c.batch("/media/TV/x")
+    await c.aclose()
+    assert "bypass_skip" not in seen["params"]
+
+
+# ── the flag must survive the scan_runner hop ───────────────────────────────
+def test_scan_runner_accepts_and_tracks_bypass_skip():
+    import inspect
+
+    from subarr.scan_runner import ScanRunner
+
+    assert "bypass_skip" in inspect.signature(ScanRunner.start).parameters
+    assert inspect.signature(ScanRunner.start).parameters["bypass_skip"].default is False
+
+
+def test_coverage_queue_request_exposes_bypass_skip():
+    from subarr.routers.coverage_actions import CoverageQueueRequest
+
+    req = CoverageQueueRequest()
+    assert req.bypass_skip is False
+    assert CoverageQueueRequest(bypass_skip=True).bypass_skip is True
+
+
+# ── the whole chain, end to end ─────────────────────────────────────────────
+def test_pending_job_carries_bypass_skip_through_persistence(tmp_path):
+    """It has to survive the DB round trip, not just the request.
+
+    The job is written to SQLite and drained later by the feeder, so a flag that
+    is accepted by the API but never persisted would be lost between enqueue and
+    submit -- the button appears to work and the file is still skipped.
+    """
+    from subarr.migrate import run_migrations
+    from subarr.pending_queue import PendingQueueStore
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    q = PendingQueueStore(db)
+    job = q.enqueue("TV/Show/ep.mkv", source="gaps", bypass_skip=True)
+    again = q.get(job.id)
+    assert again is not None
+    assert again.bypass_skip is True, "flag lost across the DB round trip"
+    assert again.to_dict()["bypass_skip"] is True
+
+
+def test_pending_job_defaults_to_not_bypassing(tmp_path):
+    from subarr.migrate import run_migrations
+    from subarr.pending_queue import PendingQueueStore
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    q = PendingQueueStore(db)
+    job = q.enqueue("TV/Show/ep.mkv", source="gaps")
+    assert q.get(job.id).bypass_skip is False
+
+
+def test_insert_placeholders_match_the_column_list():
+    """Pins the drift this change exposed.
+
+    The INSERT had a hardcoded run of 15 '?' against _COLS. Adding a 16th column
+    would have thrown at runtime on the first enqueue, not at import, so nothing
+    in CI would necessarily have caught it before a user did.
+    """
+    from subarr.pending_queue import _COLS, _Q_INSERT
+
+    assert _Q_INSERT.count("?") == _COLS.count(",") + 1


### PR DESCRIPTION
Completes the #458 loop, paired with coaxk/subarr-subgen#51 (patch 0039, rev v4.23).

## The gap this closes

#464 stopped image subtitles counting as coverage, which made those files honest gaps. **Nothing could fill them.** They are overwhelmingly English-audio files, so subgen refuses them via `SKIP_IF_AUDIO_LANGUAGES=eng`, and `ignore_forced` does not apply because the subtitle is not forced, it is a picture.

Measured on a real library: **128 files** sat in exactly that state - visible, correctly classified, and permanently unfillable. Verified on a real file before and after:

```
normal                -> skipped ("Contains a skipped audio language")
bypass_skip=True      -> proceeds
explicit bypass=False -> unchanged
```

## What this threads

`CoverageQueueRequest` -> `pending_queue` (persisted) -> feeder -> `ScanRunner.start` -> `SubgenClient.batch` -> query param, plus `capabilities.bypass_skip` so the action is only offered against a subgen that honours it. An older build silently drops the unknown param and re-skips the file, which reads to the user as a button that does nothing.

**Persistence is the subtle part, and is tested.** The job is written to SQLite and drained later by the feeder, so a flag accepted by the API but never stored would be lost between enqueue and submit - the same invisible failure one layer down. Migration `030` adds the column defaulting to 0, correct for pre-existing rows since they were queued as ordinary gaps.

## Drift fixed rather than worked around

The INSERT carried a **hardcoded run of 15 `?`** against `_COLS`. Adding a 16th column would have thrown on the first `enqueue()` at runtime, not at import, so nothing in CI would necessarily have caught it before a user did. Placeholders are now derived from `_COLS`, and a test pins that they match. No change to the SQL-injection posture: `_COLS` is a module constant and every value is still bound.

## Test plan

- [x] 9 new tests: capability declared/parsed, absent-defaults-off, param reaches the wire, omitted when unset, scan_runner signature, request model, DB round trip, default, placeholder/column parity
- [x] 139 passed across every affected suite (pending, bypass, scan_runner, subgen caps, coverage actions, migrations)
- [x] Migration verified to apply cleanly and default all existing rows to 0
- [x] `ruff check` and `ruff format --check` clean

The flag is **omitted rather than sent as false** when unset, so requests from existing callers stay byte-identical.

## Note

There is no UI control yet - this is the plumbing and the capability gate. The button that sends `bypass_skip: true` for an `EN(image)` row is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)