### PR TITLE
fix(#468): resolve a skipped pending row immediately instead of after 60s

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -112,7 +112,7 @@ from .arena_service import ArenaService
 from .arena_store import ArenaStore
 from .aftercare_store import AfterCareStore
 from .existing_audit_service import ExistingAuditService
-from .scan_runner import ScanRunner
+from .scan_runner import PATH_STATUS_SKIPPED, ScanRunner
 from .scan_store import ScanStore
 from .crash_store import CrashStore
 from .data_persistence import check_data_persistence
@@ -395,6 +395,40 @@ async def lifespan(app_: FastAPI):
         ("forced-segment", None),
     ):
         app_.state.task_health.register(_tname, expected_interval_s=_tiv)
+
+    def _record_scan_outcome(app_ref, canonical_path: str, status: str, detail: str) -> None:
+        """[#468] Act on subgen's verdict for one path as soon as it arrives.
+
+        Only SKIPPED is actionable here. OK and EMPTY are already handled by the
+        existing completion and orphan paths, and ERROR must stay visible rather
+        than being quietly dropped.
+
+        Both halves matter. Removing the row alone leaves the depth slot
+        reserved for the full INFLIGHT_GRACE_S, which is the part that actually
+        idles the GPU.
+
+        Note this deliberately acts on subgen's ANSWER, never on a locally
+        predicted one. A bypass_skip job (#458) is submitted on purpose against
+        subgen's own judgement; when subgen accepts it the status is OK, so it
+        is untouched here. A local "looks already satisfied, drop it" check
+        would have deleted exactly those jobs.
+        """
+        if status != PATH_STATUS_SKIPPED:
+            return
+        try:
+            store = getattr(app_ref.state, "pending_queue", None)
+            if store is not None and store.resolve_skipped(canonical_path):
+                log.info(
+                    "pending: resolved %s immediately (subgen skipped: %s)",
+                    canonical_path,
+                    detail or "no reason given",
+                )
+            feeder = getattr(app_ref.state, "queue_feeder", None)
+            if feeder is not None:
+                feeder.release_inflight(canonical_path)
+        except Exception:  # noqa: BLE001 — must never cost a transcription
+            log.debug("outcome recorder failed for %s", canonical_path, exc_info=True)
+
     app_.state.runner = ScanRunner(
         store=app_.state.scans,
         caps_provider=lambda: getattr(app_.state, "subgen_caps", None),
@@ -403,6 +437,13 @@ async def lifespan(app_: FastAPI):
         subgen_provider=lambda: app_.state.subgen,
         # Best-effort anonymous error-class recording for telemetry.
         error_recorder=lambda cls: app_.state.errors.record(cls),
+        # [#468] subgen answers "skipped" in the /batch response, milliseconds
+        # after submission. Without this the pending row waits out the 60s
+        # orphan sweep and holds a depth slot for 30s of it, so a backlog of
+        # already-satisfied files drains one slot at a time with the GPU idle.
+        outcome_recorder=lambda canonical_path, status, detail: _record_scan_outcome(
+            app_, canonical_path, status, detail
+        ),
     )
     # #131 tuning-lab arena. Sweeps persist (SQLite) so history survives a
     # restart and feeds the federated tournament (#124). Reconcile any run that

--- a/src/subarr/pending_feeder.py
+++ b/src/subarr/pending_feeder.py
@@ -158,6 +158,17 @@ class PendingQueueFeeder:
                 pass
         log.info("queue feeder stopped")
 
+    def release_inflight(self, canonical_path: str) -> None:
+        """[#468] Drop a path's depth reservation immediately.
+
+        This is the half that actually recovers the GPU. Removing the pending
+        row is not enough: a submitted job holds a slot until it surfaces in
+        subgen's queue or INFLIGHT_GRACE_S (30s) expires, and a SKIPPED file
+        never surfaces, so without this the feeder still cannot refill the slot
+        for the full grace window.
+        """
+        self._inflight.pop(canonical_to_subgen_batch(canonical_path), None)
+
     # ── one tick (public for tests) ─────────────────────────────────
 
     async def tick(self) -> int:

--- a/src/subarr/pending_queue.py
+++ b/src/subarr/pending_queue.py
@@ -317,6 +317,27 @@ class PendingQueueStore:
             )
             return cur.rowcount > 0
 
+    def resolve_skipped(self, canonical_path: str) -> int:
+        """[#468] REMOVE SUBMITTED rows for a path subgen told us it skipped.
+
+        Same disposal as resolve_orphaned_submitted -- the scan has recorded the
+        outcome, so the pending row has done its job -- but driven by subgen's
+        explicit answer instead of by the 60s absence timeout. subgen reports
+        `skipped` in the POST /batch response within milliseconds; waiting out
+        ORPHAN_GRACE_S to infer the same thing is what left @AztecGuyGDL with
+        110 stale rows draining slowly.
+
+        Deliberately only SUBMITTED. A PENDING row for the same path has not
+        been sent to subgen yet, so this verdict says nothing about it, and
+        dropping it would silently discard work the user is still waiting on.
+        """
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM pending_queue WHERE status = ? AND canonical_path = ?",
+                (STATUS_SUBMITTED, canonical_path),
+            )
+            return cur.rowcount or 0
+
     def resolve_orphaned_submitted(self, live_subgen_paths: set[str], *, older_than_s: float) -> int:
         """#336: REMOVE SUBMITTED jobs that subgen no longer reports and that were
         submitted longer ago than `older_than_s` (past the surface-in-/queue grace).

--- a/src/subarr/scan_runner.py
+++ b/src/subarr/scan_runner.py
@@ -93,6 +93,7 @@ class ScanRunner:
         caps_provider=None,
         subgen_provider=None,
         error_recorder=None,
+        outcome_recorder=None,
     ):
         # subgen is resolved through a provider so onboarding live-reload
         # can swap the client on app.state without restarting the runner.
@@ -127,6 +128,12 @@ class ScanRunner:
         # default; app.py wires it to ErrorStore.record. Must never raise
         # into the scan path (ErrorStore.record already swallows).
         self._error_recorder = error_recorder or (lambda cls: None)
+        # [#468] Per-path outcome hook, called as soon as /batch is classified.
+        # subgen answers "skipped" in milliseconds; without this the pending row
+        # waits out the 60s orphan sweep and holds a depth slot for 30s of it.
+        # No-op by default and must never raise into the scan path, same
+        # contract as _error_recorder above.
+        self._outcome_recorder = outcome_recorder or (lambda canonical_path, status, detail: None)
 
     @property
     def _subgen(self):
@@ -258,6 +265,13 @@ class ScanRunner:
                 result.status, _batch_err = classify_batch_outcome(status_code, body)
                 if _batch_err:
                     result.error = _batch_err
+                # [#468] Hand the verdict straight to whoever is tracking this
+                # path. Swallowing is deliberate: a reporting hook must never
+                # cost a transcription.
+                try:
+                    self._outcome_recorder(path, result.status, _batch_err)
+                except Exception:  # noqa: BLE001
+                    log.debug("outcome_recorder raised for %s", path, exc_info=True)
             except SubgenUnavailable as e:
                 result.status = PATH_STATUS_ERROR
                 result.error = str(e)

--- a/tests/test_skip_outcome_propagation.py
+++ b/tests/test_skip_outcome_propagation.py
@@ -1,0 +1,201 @@
+"""#468: propagate subgen's skip outcome instead of waiting out the orphan sweep.
+
+Reported by @AztecGuyGDL on #453 with 110 affected rows in one scan.
+
+subarr already receives the answer and throws it away. POST /batch replies
+`{"walked": 1, "queued": 0, "skipped": 1}` immediately and classify_batch_outcome
+maps it to SKIPPED within milliseconds, but the feeder's submit_job callable
+returns None, so the outcome never reaches the pending row. The row then sits
+SUBMITTED until resolve_orphaned_submitted clears it after ORPHAN_GRACE_S (60s).
+
+The GPU cost is NOT the orphan sweep, which clears every eligible row in one
+call. It is the depth slot: a submitted job reserves one until it surfaces in
+subgen's queue or INFLIGHT_GRACE_S (30s) expires, and a skipped file never
+surfaces. So both the row AND the slot have to be released.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from subarr.migrate import run_migrations
+from subarr.pending_queue import STATUS_SUBMITTED, PendingQueueStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PendingQueueStore:
+    db = tmp_path / "subarr.db"
+    run_migrations(db)
+    return PendingQueueStore(db)
+
+
+# ── the store must be able to resolve one path on demand ────────────────────
+def test_resolve_skipped_removes_the_submitted_row(store):
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    store.mark_submitted(job.id)
+    assert store.get(job.id).status == STATUS_SUBMITTED
+
+    n = store.resolve_skipped("TV/Show/ep.mkv")
+    assert n == 1
+    assert store.get(job.id) is None, "a skipped row has done its job and is dropped"
+
+
+def test_resolve_skipped_leaves_pending_rows_alone(store):
+    """Only SUBMITTED rows are resolved.
+
+    A PENDING row for the same path has not been sent to subgen yet, so the
+    skip verdict says nothing about it. Dropping it would silently discard work
+    the user is still waiting on.
+    """
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    assert store.resolve_skipped("TV/Show/ep.mkv") == 0
+    assert store.get(job.id) is not None
+
+
+def test_resolve_skipped_does_not_touch_other_paths(store):
+    a = store.enqueue("TV/Show/a.mkv", source="gaps")
+    b = store.enqueue("TV/Show/b.mkv", source="gaps")
+    store.mark_submitted(a.id)
+    store.mark_submitted(b.id)
+
+    store.resolve_skipped("TV/Show/a.mkv")
+    assert store.get(a.id) is None
+    assert store.get(b.id) is not None
+
+
+def test_resolve_skipped_on_an_unknown_path_is_a_no_op(store):
+    assert store.resolve_skipped("TV/Nothing/here.mkv") == 0
+
+
+# ── the runner must report the outcome ──────────────────────────────────────
+def test_scan_runner_accepts_an_outcome_recorder():
+    import inspect
+
+    from subarr.scan_runner import ScanRunner
+
+    assert "outcome_recorder" in inspect.signature(ScanRunner.__init__).parameters
+
+
+def test_outcome_recorder_defaults_to_a_no_op():
+    """It must never be required, and must never raise into the scan path.
+
+    Same contract as error_recorder beside it: a telemetry-ish hook that cannot
+    be allowed to break a transcription.
+    """
+    from subarr.scan_runner import ScanRunner
+
+    r = ScanRunner(subgen=None, store=None)
+    r._outcome_recorder("TV/x.mkv", "skipped", "sub exists")  # must not raise
+
+
+# ── the feeder must release the slot, not just drop the row ────────────────
+def test_feeder_exposes_inflight_release():
+    import inspect
+
+    from subarr.pending_feeder import PendingQueueFeeder
+
+    assert hasattr(PendingQueueFeeder, "release_inflight")
+    assert "canonical_path" in inspect.signature(PendingQueueFeeder.release_inflight).parameters
+
+
+def test_releasing_inflight_frees_the_depth_slot():
+    """The whole point of #468.
+
+    Without this the row is gone but the slot is still reserved for the full
+    30s grace, so the feeder still cannot refill it and the GPU still idles.
+    """
+    from subarr.paths import canonical_to_subgen_batch
+    from subarr.pending_feeder import PendingQueueFeeder
+
+    f = PendingQueueFeeder.__new__(PendingQueueFeeder)
+    sg = canonical_to_subgen_batch("TV/Show/ep.mkv")
+    f._inflight = {sg: 12345.0}
+
+    f.release_inflight("TV/Show/ep.mkv")
+    assert sg not in f._inflight
+
+
+def test_releasing_an_unknown_path_is_harmless():
+    from subarr.pending_feeder import PendingQueueFeeder
+
+    f = PendingQueueFeeder.__new__(PendingQueueFeeder)
+    f._inflight = {}
+    f.release_inflight("TV/Nothing/here.mkv")  # must not raise
+    assert f._inflight == {}
+
+
+# ── the link that matters: does the runner actually CALL it? ────────────────
+# Every piece above can be correct while the recorder is never invoked, which
+# would leave the whole fix inert and every unit test still green.
+
+
+@pytest.mark.asyncio
+async def test_runner_reports_a_skip_to_the_recorder(tmp_path):
+    import asyncio
+
+    from subarr.scan_runner import PATH_STATUS_SKIPPED, ScanRunner
+    from subarr.scan_store import ScanStore
+
+    seen = []
+
+    class _Subgen:
+        async def batch(self, directory, **kw):
+            # exactly what subgen returns for an already-covered file
+            return 200, {"walked": 1, "queued": 0, "skipped": 1, "already_in_queue": 0}
+
+    db = tmp_path / "scans.db"
+    run_migrations(db)
+    store = ScanStore(db)
+    runner = ScanRunner(
+        subgen=_Subgen(),
+        store=store,
+        outcome_recorder=lambda path, status, detail: seen.append((path, status, detail)),
+    )
+    scan = store.create(["TV/Show/ep.mkv"], reverse=False)
+    runner.start(scan)
+    for _ in range(200):  # let the scan task run
+        await asyncio.sleep(0.01)
+        if seen:
+            break
+
+    assert seen, "runner never reported the outcome — the fix would be inert"
+    path, status, detail = seen[0]
+    assert path == "TV/Show/ep.mkv"
+    assert status == PATH_STATUS_SKIPPED
+    assert "skipped" in (detail or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_a_queued_file_is_not_reported_as_skipped(tmp_path):
+    """The negative case. If OK also reported SKIPPED we would delete pending
+    rows for files subgen actually accepted, which is far worse than the bug."""
+    import asyncio
+
+    from subarr.scan_runner import PATH_STATUS_SKIPPED, ScanRunner
+    from subarr.scan_store import ScanStore
+
+    seen = []
+
+    class _Subgen:
+        async def batch(self, directory, **kw):
+            return 200, {"walked": 1, "queued": 1, "skipped": 0, "already_in_queue": 0}
+
+    db = tmp_path / "scans.db"
+    run_migrations(db)
+    store = ScanStore(db)
+    runner = ScanRunner(
+        subgen=_Subgen(),
+        store=store,
+        outcome_recorder=lambda path, status, detail: seen.append((path, status, detail)),
+    )
+    scan = store.create(["TV/Show/ep.mkv"], reverse=False)
+    runner.start(scan)
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if seen:
+            break
+
+    assert seen, "recorder should still fire, just not with SKIPPED"
+    assert seen[0][1] != PATH_STATUS_SKIPPED


### PR DESCRIPTION
Closes #468. Reported by @AztecGuyGDL on #453 with **110 affected rows in one scan**.

## The information was already there and being discarded

`POST /batch` replies `{"walked": 1, "queued": 0, "skipped": 1}` in milliseconds, and `classify_batch_outcome` maps that to `PATH_STATUS_SKIPPED` right there. But the feeder's `submit_job` callable is typed `async (job) -> None`, so the verdict never reaches the pending row.

The row then waits out `ORPHAN_GRACE_S` (60s) for the orphan sweep to infer the same fact from its absence in subgen's queue.

## Two halves, and the second is the one that recovers the GPU

Removing the row is not enough. A submitted job reserves a **depth slot** until it surfaces in subgen's queue or `INFLIGHT_GRACE_S` (30s) expires, and a skipped file never surfaces. Drop only the row and the slot stays pinned for the full grace window with the GPU still idle, which is the actual complaint.

So `ScanRunner` gains an `outcome_recorder` hook, `PendingQueueFeeder` gains `release_inflight`, and the recorder calls both.

The hook follows the shape of `error_recorder` beside it: no-op by default, exceptions swallowed, because a reporting hook must never cost a transcription.

## Why not revalidate coverage before submit

That was the reporter's suggestion and it would work for their case, but it re-derives a decision subgen has already made, using different logic. subarr's coverage view and `should_skip_file` do not agree in general and are not meant to: subgen also skips on audio language, filename patterns, and rules subarr does not model. A local pre-check would drift and would only ever cover the one skip reason it was written for.

**It would also delete exactly the `bypass_skip` jobs shipped earlier today** (#466/#467), since those are submitted deliberately against subgen's judgement. Acting on subgen's response is correct in both cases; a prediction is not. When subgen accepts a bypass job the status is `OK`, so it is untouched here.

## Scope discipline

- Only `SKIPPED` is actionable. `OK` and `EMPTY` already have handling, and `ERROR` must stay visible rather than being quietly dropped.
- `resolve_skipped` touches `SUBMITTED` rows only. A `PENDING` row for the same path has not been sent to subgen, so the verdict says nothing about it, and dropping it would discard work the user is still waiting on.

## Test plan

- [x] 11 tests: store resolves one path, leaves PENDING alone, ignores other paths, no-ops on unknown; runner accepts the hook; hook defaults to a safe no-op; feeder exposes and performs the release; two integration tests driving a real scan through a fake subgen
- [x] 101 passed across pending / feeder / scan_runner suites
- [x] Both ruff gates clean

**Verified by sabotage.** Removing the single `self._outcome_recorder(...)` call turns both integration tests red, then green on restore. That is the failure mode worth guarding: every unit test can pass while the recorder is never invoked and the whole fix sits inert.

Follow-up #469 handles rows already stuck in this state, which this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)