### PR TITLE
feat(#469): one-shot reconcile for pending rows already satisfied

### DIFF
--- a/src/subarr/pending_reconcile.py
+++ b/src/subarr/pending_reconcile.py
@@ -1,0 +1,111 @@
+"""#469: clear pending rows whose English coverage is already satisfied.
+
+Companion to #468. That stops NEW rows getting wedged; this clears the ones
+already there. The reporter on #453 had 110 of them, each holding a feeder
+depth slot for 30s as it drained.
+
+Deliberately conservative in one direction. The cost of keeping a row that did
+not need keeping is one wasted submission that #468 now resolves in
+milliseconds. The cost of dropping a row wrongly is silently deleting work the
+user asked for, with nothing to show they ever asked. So every judgement call
+here leans toward KEEPING.
+
+That is also why there is no ratio guard like ``orphan_prune``'s. There the
+danger is a dropped mount making everything look missing at once; here a
+dropped mount makes sidecars look ABSENT, which reads as "not satisfied", which
+keeps rows. The failure mode already falls the safe way.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from .pending_queue import STATUS_SUBMITTED
+
+# Only text subtitles count. A bitmap track (#458) cannot be searched,
+# restyled, retimed or read, so an `.idx`/`.sub`/`.pgs` sibling is not coverage
+# and must never satisfy a pending row -- those files are precisely the ones
+# bypass_skip exists to transcribe.
+_TEXT_SUBTITLE_EXT = ".srt"
+
+# A forced sidecar covers foreign dialogue inside an otherwise-English film, not
+# the whole show. Treating it as coverage would resolve a pending row for a real
+# gap: the #79 defect class, one layer up.
+_FORCED_TOKENS = frozenset({"forced"})
+
+_ENGLISH_TOKENS = frozenset({"en", "eng"})
+
+
+def is_full_english_sidecar(filename: str, stem: str) -> bool:
+    """True only for a FULL English text sidecar belonging to ``stem``.
+
+    Full means not forced. Text means .srt: deliberately narrower than every
+    text format that exists, because a miss here keeps a row (cheap) while a
+    false match deletes one (not).
+    """
+    name = filename.rsplit("/", 1)[-1]
+    if not name.lower().endswith(_TEXT_SUBTITLE_EXT):
+        return False
+    base = name[: -len(_TEXT_SUBTITLE_EXT)]
+    if not base.startswith(stem):
+        return False
+    tail = base[len(stem) :]
+    if not tail.startswith("."):
+        return False
+    parts = [p.lower() for p in tail.split(".") if p]
+    if any(p in _FORCED_TOKENS for p in parts):
+        return False
+    return any(p in _ENGLISH_TOKENS for p in parts)
+
+
+@dataclass
+class ReconcileReport:
+    satisfied: list[str] = field(default_factory=list)
+    resolved: int = 0
+    skipped_bypass: int = 0
+    examined: int = 0
+
+
+def _stem_of(canonical_path: str) -> str:
+    name = canonical_path.rsplit("/", 1)[-1]
+    return name.rsplit(".", 1)[0] if "." in name else name
+
+
+def reconcile_pending(
+    store,
+    *,
+    list_siblings: Callable[[str], list[str]],
+    dry_run: bool = False,
+) -> ReconcileReport:
+    """Resolve SUBMITTED rows that already have a full English text sidecar.
+
+    ``list_siblings`` is injected so this stays pure and testable; callers pass
+    a real directory listing. Any error from it is treated as "cannot tell",
+    which keeps the row.
+
+    SUBMITTED only. A PENDING row has not reached subgen, so nothing has been
+    learned about it, and dropping it would discard work still queued.
+
+    A ``bypass_skip`` row is never resolved. It was submitted on purpose against
+    subgen's judgement, for a file whose only English subtitle is an image
+    track -- such a file can even carry an `.en.idx` sibling. Resolving it would
+    delete exactly the work the user explicitly asked for.
+    """
+    rep = ReconcileReport()
+    for job in store.list(status=STATUS_SUBMITTED):
+        rep.examined += 1
+        if getattr(job, "bypass_skip", False):
+            rep.skipped_bypass += 1
+            continue
+        try:
+            siblings = list_siblings(job.canonical_path)
+        except Exception:  # noqa: BLE001 -- cannot tell => keep the row
+            continue
+        stem = _stem_of(job.canonical_path)
+        if any(is_full_english_sidecar(n, stem) for n in siblings or []):
+            rep.satisfied.append(job.canonical_path)
+    if not dry_run:
+        for path in rep.satisfied:
+            rep.resolved += store.resolve_skipped(path)
+    return rep

--- a/src/subarr/routers/admin.py
+++ b/src/subarr/routers/admin.py
@@ -299,6 +299,54 @@ async def db_orphans_prune(request: Request) -> dict:
     return await asyncio.to_thread(_sweep, request, dry_run=False)
 
 
+def _list_siblings(canonical_path: str) -> list[str]:
+    """Filenames sitting next to a canonical path, or [] if we cannot look.
+
+    Raising is left to the caller's discretion -- reconcile_pending treats any
+    error as "cannot tell" and KEEPS the row, which is the safe direction: when
+    the media mount is down every listing is empty, and an empty listing reads
+    as "no sidecar", so nothing is resolved.
+    """
+    from ..paths import canonical_to_fs
+
+    fs = canonical_to_fs(canonical_path)
+    return [p.name for p in fs.parent.iterdir() if p.is_file()]
+
+
+def _reconcile(request: Request, *, dry_run: bool) -> dict:
+    from ..pending_reconcile import reconcile_pending
+
+    store = getattr(request.app.state, "pending_queue", None)
+    if store is None:
+        return {"examined": 0, "satisfied": [], "resolved": 0, "skipped_bypass": 0}
+    rep = reconcile_pending(store, list_siblings=_list_siblings, dry_run=dry_run)
+    return {
+        "examined": rep.examined,
+        "satisfied": rep.satisfied,
+        "resolved": rep.resolved,
+        "skipped_bypass": rep.skipped_bypass,
+    }
+
+
+@router.get("/admin/db/pending-satisfied")
+async def db_pending_satisfied(request: Request) -> dict:
+    """[#469] DRY RUN: SUBMITTED rows that already have a full English sidecar.
+
+    Deletes nothing. Same reasoning as the orphan dry run: the apply step
+    removes queued work, so the user sees the list first.
+
+    Runs in a thread -- it lists a directory per row, and on a network share
+    that is slow enough to stall the event loop.
+    """
+    return await asyncio.to_thread(_reconcile, request, dry_run=True)
+
+
+@router.post("/admin/db/pending-satisfied/reconcile")
+async def db_pending_satisfied_apply(request: Request) -> dict:
+    """[#469] APPLY. Never touches a bypass_skip row or a PENDING one."""
+    return await asyncio.to_thread(_reconcile, request, dry_run=False)
+
+
 @router.post("/admin/db/backup")
 async def db_backup(request: Request) -> dict:
     """VACUUM INTO a timestamped clean copy of the database.

--- a/tests/test_pending_reconcile.py
+++ b/tests/test_pending_reconcile.py
@@ -1,0 +1,223 @@
+"""#469: one-shot cleanup for pending rows whose coverage is already satisfied.
+
+Companion to #468. That stops NEW rows getting stuck; this clears the ones
+already there. @AztecGuyGDL had 110 of them.
+
+The dangerous direction here is deleting queued work the user still wants, so
+every judgement call leans toward KEEPING a row.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from subarr.migrate import run_migrations
+from subarr.pending_queue import PendingQueueStore
+from subarr.pending_reconcile import (
+    is_full_english_sidecar,
+    reconcile_pending,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PendingQueueStore:
+    db = tmp_path / "subarr.db"
+    run_migrations(db)
+    return PendingQueueStore(db)
+
+
+# ── what counts as a satisfying sidecar ────────────────────────────────────
+def test_a_plain_english_srt_satisfies():
+    assert is_full_english_sidecar("ep.en.srt", "ep") is True
+    assert is_full_english_sidecar("ep.eng.srt", "ep") is True
+
+
+def test_an_engine_suffixed_srt_still_satisfies():
+    # subsyncarr writes several variants per file
+    assert is_full_english_sidecar("ep.en.alass.srt", "ep") is True
+
+
+def test_a_FORCED_sidecar_does_NOT_satisfy():
+    """The trap in the reporter's own example.
+
+    Their file had `ep.eng.srt` AND `ep.forced.en.srt`. A forced sidecar covers
+    foreign dialogue in an otherwise-English film, not the whole show, so
+    treating it as coverage would delete a pending row for a genuine gap. This
+    is the #79 defect class, one layer over.
+    """
+    assert is_full_english_sidecar("ep.forced.en.srt", "ep") is False
+    assert is_full_english_sidecar("ep.en.forced.srt", "ep") is False
+
+
+def test_image_sidecars_never_satisfy():
+    """#458: a bitmap is not text. .idx/.sub/.pgs must never count."""
+    for name in ("ep.en.idx", "ep.en.sub", "ep.en.pgs"):
+        assert is_full_english_sidecar(name, "ep") is False
+
+
+def test_a_non_english_srt_does_not_satisfy():
+    assert is_full_english_sidecar("ep.fr.srt", "ep") is False
+    assert is_full_english_sidecar("ep.srt", "ep") is False
+
+
+def test_a_sidecar_for_a_different_file_does_not_satisfy():
+    assert is_full_english_sidecar("other.en.srt", "ep") is False
+
+
+# ── the reconcile pass ─────────────────────────────────────────────────────
+def _siblings(mapping):
+    """Injected directory lister: canonical_path -> sibling filenames."""
+    return lambda canonical: mapping.get(canonical, [])
+
+
+def test_dry_run_reports_but_deletes_nothing(store):
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    store.mark_submitted(job.id)
+
+    rep = reconcile_pending(
+        store,
+        list_siblings=_siblings({"TV/Show/ep.mkv": ["ep.mkv", "ep.en.srt"]}),
+        dry_run=True,
+    )
+    assert rep.satisfied == ["TV/Show/ep.mkv"]
+    assert rep.resolved == 0
+    assert store.get(job.id) is not None
+
+
+def test_apply_removes_the_satisfied_row(store):
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    store.mark_submitted(job.id)
+
+    rep = reconcile_pending(
+        store,
+        list_siblings=_siblings({"TV/Show/ep.mkv": ["ep.mkv", "ep.en.srt"]}),
+    )
+    assert rep.resolved == 1
+    assert store.get(job.id) is None
+
+
+def test_a_row_with_only_a_forced_sidecar_is_KEPT(store):
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    store.mark_submitted(job.id)
+
+    rep = reconcile_pending(
+        store,
+        list_siblings=_siblings({"TV/Show/ep.mkv": ["ep.mkv", "ep.forced.en.srt"]}),
+    )
+    assert rep.resolved == 0
+    assert store.get(job.id) is not None, "forced-only is a real gap, not coverage"
+
+
+def test_a_bypass_skip_row_is_NEVER_resolved(store):
+    """The constraint that would silently undo #466/#467.
+
+    A bypass_skip job is submitted deliberately against subgen's judgement, for
+    a file whose only English subtitle is an image track. Such a file can even
+    have an .en.idx sibling. Dropping it would delete exactly the work the user
+    explicitly asked for.
+    """
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps", bypass_skip=True)
+    store.mark_submitted(job.id)
+
+    rep = reconcile_pending(
+        store,
+        list_siblings=_siblings({"TV/Show/ep.mkv": ["ep.mkv", "ep.en.srt"]}),
+    )
+    assert rep.resolved == 0
+    assert store.get(job.id) is not None
+    assert "TV/Show/ep.mkv" not in rep.satisfied
+
+
+def test_pending_rows_are_left_alone(store):
+    """Only SUBMITTED. A PENDING row has not been sent to subgen, so it is
+    still queued work the user is waiting on."""
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    rep = reconcile_pending(
+        store,
+        list_siblings=_siblings({"TV/Show/ep.mkv": ["ep.mkv", "ep.en.srt"]}),
+    )
+    assert rep.resolved == 0
+    assert store.get(job.id) is not None
+
+
+def test_an_unreadable_directory_keeps_the_row(store):
+    """Fails SAFE.
+
+    If the media mount is down every listing comes back empty, which reads as
+    "no sidecar" and therefore "not satisfied", so rows are KEPT. That is the
+    correct direction: the opposite would delete the whole queue during an
+    outage.
+    """
+    job = store.enqueue("TV/Show/ep.mkv", source="gaps")
+    store.mark_submitted(job.id)
+
+    def _boom(canonical):
+        raise OSError("mount is down")
+
+    rep = reconcile_pending(store, list_siblings=_boom)
+    assert rep.resolved == 0
+    assert store.get(job.id) is not None
+
+
+def test_empty_queue_is_a_clean_no_op(store):
+    rep = reconcile_pending(store, list_siblings=_siblings({}))
+    assert rep.resolved == 0
+    assert rep.satisfied == []
+
+
+# ── the endpoints ──────────────────────────────────────────────────────────
+DRY = "/api/admin/db/pending-satisfied"
+APPLY = "/api/admin/db/pending-satisfied/reconcile"
+
+
+def test_dry_run_endpoint_lists_but_does_not_resolve(app_with_stub, media_root):
+    c = app_with_stub
+    q = c.app.state.pending_queue
+    f = media_root / "TV" / "Show" / "ep.mkv"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(b"x")
+    (f.parent / "ep.en.srt").write_text("1\n", encoding="utf-8")
+
+    job = q.enqueue("TV/Show/ep.mkv", source="gaps")
+    q.mark_submitted(job.id)
+
+    body = c.get(DRY).json()
+    assert "TV/Show/ep.mkv" in body["satisfied"]
+    assert body["resolved"] == 0
+    assert q.get(job.id) is not None
+
+
+def test_apply_endpoint_resolves_it(app_with_stub, media_root):
+    c = app_with_stub
+    q = c.app.state.pending_queue
+    f = media_root / "TV" / "Show" / "ep.mkv"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(b"x")
+    (f.parent / "ep.en.srt").write_text("1\n", encoding="utf-8")
+
+    job = q.enqueue("TV/Show/ep.mkv", source="gaps")
+    q.mark_submitted(job.id)
+
+    body = c.post(APPLY).json()
+    assert body["resolved"] == 1
+    assert q.get(job.id) is None
+
+
+def test_apply_endpoint_spares_a_bypass_skip_row(app_with_stub, media_root):
+    """End-to-end guard on the constraint that would undo #466/#467."""
+    c = app_with_stub
+    q = c.app.state.pending_queue
+    f = media_root / "TV" / "Show" / "ep.mkv"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(b"x")
+    (f.parent / "ep.en.srt").write_text("1\n", encoding="utf-8")
+
+    job = q.enqueue("TV/Show/ep.mkv", source="gaps", bypass_skip=True)
+    q.mark_submitted(job.id)
+
+    body = c.post(APPLY).json()
+    assert body["resolved"] == 0
+    assert body["skipped_bypass"] == 1
+    assert q.get(job.id) is not None


### PR DESCRIPTION
Closes #469. Companion to #468 (merged): that stops **new** rows getting wedged, this clears the ones already there. The reporter on #453 had **110**, each holding a feeder depth slot for 30s as it drained.

## Conservative in one direction, on purpose

Keeping a row that did not need keeping costs one wasted submission, which #468 now resolves in milliseconds. Dropping a row wrongly silently deletes work the user asked for, with nothing left to show they ever asked.

Every judgement call leans toward **keeping**.

## No ratio guard, unlike `orphan_prune`

That asymmetry is deliberate. In `orphan_prune` the danger is a dropped mount making everything look missing at once, so it refuses in bulk. Here a dropped mount makes sidecars look **absent**, which reads as "not satisfied", which **keeps** rows. The failure mode already falls the safe way, and a test pins it by making the directory listing raise.

## Three things that would each have been a silent data-loss bug

**A forced sidecar does not satisfy.** The reporter's own example carried both `ep.eng.srt` and `ep.forced.en.srt`. The existing `_is_en_sidecar_for` helper matches *any* `en`/`eng` token, so it accepts the forced one. A forced sub covers foreign dialogue inside an otherwise-English film, not the show, so resolving on it would drop a row for a genuine gap. That is the #79 defect class one layer up.

**An image sidecar does not satisfy.** Only `.srt` counts, so `.idx`/`.sub`/`.pgs` can never resolve a row. Those files are exactly what `bypass_skip` exists to transcribe.

**A `bypass_skip` row is never resolved at all.** It was submitted deliberately against subgen's judgement, and such a file can legitimately carry an `.en.idx` sibling, so resolving it would delete precisely the work the user explicitly asked for.

`SUBMITTED` only. A `PENDING` row has not reached subgen, so nothing has been learned about it.

## Interface

Dry run plus explicit apply, matching the orphan prune, because the apply removes queued work and the user should see the list first:

- `GET /api/admin/db/pending-satisfied`
- `POST /api/admin/db/pending-satisfied/reconcile`

Both run in a thread: they list a directory per row, and on a network share that is slow enough to stall the event loop.

## Test plan

- [x] 16 tests: sidecar matching (plain, engine-suffixed, forced, image, wrong language, wrong file), dry run, apply, forced-only kept, bypass_skip spared, PENDING untouched, unreadable directory keeps rows, empty queue, plus three endpoint tests
- [x] 146 passed across pending / reconcile / admin / orphan suites
- [x] Both ruff gates clean

**Verified by sabotage.** Removing the `bypass_skip` guard turns both the unit test and the endpoint test red, then green on restore. That is the regression most worth catching, since it would quietly undo #466/#467 while every other test stayed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)