### PR TITLE
fix(#157): register every task that reports health

### DIFF
--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -393,6 +393,22 @@ async def lifespan(app_: FastAPI):
         # #364: opt-in deep-scan walker. expected_interval_s=None (event-driven,
         # never "stale") — sits on the unified Health roster like audio-audit.
         ("forced-segment", None),
+        # [#157] These five recorded health but were never seeded, so they only
+        # appeared on the Health page AFTER their first success. A loop that
+        # dies during startup, or never starts, therefore had no row at all —
+        # a more silent failure than the #79 case this issue exists to prevent,
+        # because #79 at least logged every cycle.
+        #
+        # telemetry is the one that matters: a real 24h loop. Its cadence is
+        # given so the staleness branch works.
+        ("telemetry", 86400),
+        # The rest are one-shot startup checks. expected_interval_s=None so the
+        # staleness branch never fires (same treatment as audio-audit): they
+        # show "never run yet" if they never ran, with no false stale alarm.
+        ("data-persistence", None),
+        ("data-network-fs", None),
+        ("db-integrity", None),
+        ("single-process", None),
     ):
         app_.state.task_health.register(_tname, expected_interval_s=_tiv)
 

--- a/tests/test_task_health_registration.py
+++ b/tests/test_task_health_registration.py
@@ -1,0 +1,109 @@
+"""#157 Phase 1 gap: a task that reports health but is never registered.
+
+register() seeds a row so a task appears as "never run yet" BEFORE its first
+cycle. Without it a task only becomes visible once it has already succeeded
+once -- so a loop that dies during startup, or never starts at all, has no row
+and is invisible on the Health page.
+
+That is a MORE silent failure than the #79 case this issue exists to prevent.
+#79 at least logged a warning every cycle; a task that never reaches its first
+success produces nothing, and the Health page cannot show an absence it does
+not know about.
+
+This test derives the invariant from the source rather than listing names, so
+a task added later that reports without registering fails here instead of
+going quietly missing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src" / "subarr"
+
+
+def _module_string_constants(tree: ast.AST) -> dict[str, str]:
+    """Module-level NAME = "literal" bindings, so a task referenced by constant
+    (FORCED_SEGMENT_TASK, TASK_NAME, ...) resolves to its real name."""
+    out: dict[str, str] = {}
+    for node in tree.body:  # type: ignore[attr-defined]
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        out[tgt.id] = node.value.value
+    return out
+
+
+def _reporting_task_names() -> set[str]:
+    """Every task name passed to record_success/record_failure across src."""
+    names: set[str] = set()
+    for py in SRC.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        consts = _module_string_constants(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in ("record_success", "record_failure"):
+                continue
+            if not node.args:
+                continue
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                names.add(first.value)
+            elif isinstance(first, ast.Name) and first.id in consts:
+                names.add(consts[first.id])
+    return names
+
+
+def _registered_task_names() -> set[str]:
+    """Every name passed to task_health.register() in app.py."""
+    app = SRC / "app.py"
+    tree = ast.parse(app.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    # the registration loop is `for _tname, _tiv in ( ("x", 600), ... ):`
+    for node in ast.walk(tree):
+        if isinstance(node, ast.For) and isinstance(node.iter, ast.Tuple):
+            for elt in node.iter.elts:
+                if isinstance(elt, ast.Tuple) and elt.elts:
+                    first = elt.elts[0]
+                    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                        names.add(first.value)
+        # and any direct register("name") call
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr == "register" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    names.add(first.value)
+    return names
+
+
+def test_the_scanner_actually_finds_things():
+    """Guard the guard.
+
+    If either scanner silently returned an empty set the real assertion below
+    would pass vacuously and this whole file would be decorative.
+    """
+    reporting = _reporting_task_names()
+    registered = _registered_task_names()
+    assert len(reporting) >= 8, f"scanner found too few reporters: {sorted(reporting)}"
+    assert len(registered) >= 8, f"scanner found too few registrations: {sorted(registered)}"
+
+
+def test_every_reporting_task_is_registered():
+    """The invariant. A task that records health must also be seeded.
+
+    Otherwise it is invisible until its first success, which is exactly when
+    you most need to see it.
+    """
+    reporting = _reporting_task_names()
+    registered = _registered_task_names()
+    missing = sorted(reporting - registered)
+    assert not missing, (
+        "these tasks report health but are never register()ed, so they do not "
+        f"appear on the Health page until their first success: {missing}"
+    )


### PR DESCRIPTION
Closes the one real residual gap in #157 Phase 1.

## Context: Phase 1 is largely already shipped

Worth recording, because the issue reads as untouched. Already in place: the `TaskHealthStore` supervision primitive, `/api/health/tasks`, the Health page with per-task rows and prefilled bug reports, the header pill that lights up when anything is unhealthy, and the `SUBARR_DEBUG` verbose knob. The issue is stale, not unstarted.

## The gap

**Five tasks recorded health but were never `register()`ed:** `telemetry`, `data-persistence`, `data-network-fs`, `db-integrity`, `single-process`.

`register()` exists to seed a row so a task shows as "never run yet" **before** its first cycle. Its own docstring says so. Without it a task only becomes visible once it has already succeeded once — so a loop that dies during startup, or never starts at all, has **no row** and is invisible on the Health page.

That is a *more* silent failure than the #79 regression this issue was opened for. #79 at least logged a warning every cycle. A task that never reaches its first success produces nothing, and the Health page cannot show an absence it does not know about.

`telemetry` is the one that matters: a genuine 24h loop, now registered with its cadence so the staleness branch works. The other four are one-shot startup checks, registered with `expected_interval_s=None` so the staleness branch never fires — they show "never run yet" if they never ran, with no false stale alarm. That matches how `audio-audit` and `forced-segment` are already handled.

## The test derives the invariant from source

Rather than listing five names that would rot, it walks the AST for `record_success`/`record_failure` calls, resolves task names passed via module constants (`FORCED_SEGMENT_TASK`, `TASK_NAME`, ...), and asserts each is registered. A task added later that reports without registering fails here instead of going quietly missing.

It also **guards itself**: if either scanner silently returned an empty set the real assertion would pass vacuously and the file would be decorative, so both scanners are asserted non-trivial first.

## Test plan

- [x] The invariant test failed with exactly the five missing names before the fix, passes after
- [x] 46 passed across the health/task_health suites
- [x] Both ruff gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)