### PR TITLE
fix(#473): name the /config-vs-/data mistake our own docs caused

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Kept here because 2.0 is the only release with breaking changes. Skip it if you 
 
 ## Five-minute install
 
+> **Copy [`docker-compose.yml`](./docker-compose.yml) from this repo** rather than retyping the
+> snippet below. Hand-copying is how the `/config` vs `/data` mistake in the v1.0.0 and v1.1.0
+> docs reached so many installs ([#473](https://github.com/coaxk/subarr/issues/473)).
+
 ```yaml
 # compose.yaml
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+# subarr — canonical compose file.
+#
+# Copy this file rather than retyping it. Until now the only setup example
+# lived in the README, and hand-copying is how a documentation error becomes
+# thousands of broken installs: the v1.0.0 and v1.1.0 README mounted /config
+# while subarr's database default has always been /data/subarr.db, so every
+# install that followed it silently lost all its data on each recreate (#473).
+#
+#   docker compose up -d
+#
+# Then open http://localhost:9922 and the setup wizard takes it from there.
+
+services:
+  subarr:
+    image: ghcr.io/coaxk/subarr:latest
+    container_name: subarr
+    restart: unless-stopped
+
+    ports:
+      - "9922:9922"
+
+    environment:
+      # Match the uid/gid that owns BOTH the data volume below and your media
+      # library. subarr writes .srt sidecars into the media tree, so a mismatch
+      # here shows up later as permission errors on write, not at boot.
+      PUID: 1000
+      PGID: 1000
+      TZ: Etc/UTC
+      UMASK: "022"
+
+      # Where the database lives. This default matches the volume below; if you
+      # change one, change both. Pointing this at your media tree is never
+      # correct — it is a separate mount subarr treats as your data.
+      SUBARR_DB_PATH: /data/subarr.db
+
+    volumes:
+      # REQUIRED, and the single most common thing to get wrong.
+      #
+      # Everything subarr learns lives here: audio-language verifications you
+      # confirmed by hand, queue state, coverage history, settings. Without a
+      # real volume at this path they sit on the container's writable layer and
+      # are destroyed on every recreate — silently, with no error.
+      #
+      # Keep it on LOCAL disk. SQLite over NFS/SMB/CIFS is a corruption vector;
+      # subarr detects a network filesystem here and warns, but local is the
+      # supported configuration.
+      - ./subarr/data:/data
+
+      # Your media library. Use the SAME path Bazarr, Sonarr/Radarr and subgen
+      # see, or the arrs and subarr will disagree about which file is which.
+      # Read-write because subarr writes subtitle sidecars beside the video.
+      - /path/to/media:/media/library:rw
+
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python -c "import urllib.request,sys;
+          sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9922/api/health',
+          timeout=3).status==200 else 1)"
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
+# ─── Verifying it worked ─────────────────────────────────────────────────────
+#
+# After the first start, check the Health page. If /data is not persistent
+# subarr says so there and in the log — it cannot fix your compose for you, but
+# it will not stay quiet about it either.
+#
+# The honest test is a restart: `docker compose down && docker compose up -d`.
+# If your settings survive, persistence is real. If the setup wizard reappears,
+# it is not, whatever the compose file appears to say.

--- a/src/subarr/data_persistence.py
+++ b/src/subarr/data_persistence.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -120,6 +121,63 @@ def data_dir_is_ephemeral(db_path: Path) -> bool | None:
         return None
 
 
+@dataclass(frozen=True)
+class LegacyConfigMount:
+    """[#473] The install followed our own v1.0.0/v1.1.0 docs and lost its data."""
+
+    legacy_db_path: Path
+    message: str
+
+
+def diagnose_legacy_config_mount(
+    *,
+    db_path: Path,
+    data_is_ephemeral: bool | None,
+    config_dir: Path = Path("/config"),
+) -> LegacyConfigMount | None:
+    """Detect the specific broken shape our v1.0.0 and v1.1.0 README produced.
+
+    That example mounted `./subarr/config:/config` and set no SUBARR_DB_PATH,
+    while the default has always been `/data/subarr.db`. So the volume the user
+    was told to mount is not the one subarr keeps its database in, `/data` sits
+    on the container's ephemeral layer, and every recreate wipes everything.
+
+    These people did not misconfigure anything -- they followed the docs. The
+    generic "mount a volume at /data" warning reads as wrong to them, because
+    they DID mount a volume. This names the actual mismatch instead.
+
+    Returns None unless all three hold: /data is definitely ephemeral, /config
+    exists, and a database is actually sitting in it. Anything less and the
+    generic warning is the honest one.
+
+    ⚠️ Deliberately does NOT advise copying the database into /data. If /data
+    is the ephemeral layer, a copy there is erased on the next recreate: it
+    would look like a migration and fix nothing. The data is already in the
+    persistent place; what is wrong is where subarr is looking.
+    """
+    if data_is_ephemeral is not True:
+        return None  # None (cannot tell) must never be read as broken
+    try:
+        legacy = Path(config_dir) / "subarr.db"
+        if not legacy.is_file():
+            return None
+    except OSError:
+        return None
+    return LegacyConfigMount(
+        legacy_db_path=legacy,
+        message=(
+            f"Your database is at {legacy}, but subarr is reading {db_path}, "
+            f"and /data is not a persistent volume so it is wiped on every "
+            f"recreate. This is the setup our v1.0.0 and v1.1.0 README "
+            f"documented -- it mounted /config while the database default has "
+            f"always been /data/subarr.db. Your data is safe where it is. "
+            f"Fix it with one line: set SUBARR_DB_PATH={legacy} in your "
+            f"environment, or add a persistent volume at /data and point "
+            f"SUBARR_DB_PATH at it."
+        ),
+    )
+
+
 def check_network_fs(db_path: Path, health) -> str | None:
     """Surface a network-FS `/data` on the Health page (not just a log line):
     SQLite over NFS/SMB is a corruption vector that sporadically loses history +
@@ -163,19 +221,31 @@ def check_data_persistence(db_path: Path, health) -> bool | None:
         if ephemeral:
             from .db_integrity import DatabaseCorruptionError  # reuse a loud error type
 
+            # [#473] If this is the shape our own v1.0.0/v1.1.0 docs produced,
+            # say THAT instead. Those users mounted a volume exactly as told, so
+            # "mount a volume at /data" reads as wrong and gets dismissed -- and
+            # their data is recoverable, which the generic message never says.
+            legacy = diagnose_legacy_config_mount(db_path=db_path, data_is_ephemeral=True)
             err = DatabaseCorruptionError(
-                "/data is NOT a persistent volume — your subtitle verifications, "
-                "language intents, and history will be LOST on the next container "
-                "recreate. Mount a named volume or host path at /data. See the "
-                "README 'Backing up your data' section."
+                legacy.message
+                if legacy
+                else (
+                    "/data is NOT a persistent volume — your subtitle verifications, "
+                    "language intents, and history will be LOST on the next container "
+                    "recreate. Mount a named volume or host path at /data. See the "
+                    "README 'Backing up your data' section."
+                )
             )
             health.record_failure(TASK_NAME, err, expected_interval_s=None)
-            log.error(
-                "DATA PERSISTENCE WARNING: /data appears to be the container's "
-                "ephemeral layer, not a mounted volume. Everything in /data "
-                "(verifications, intents, provenance) will be lost on recreate. "
-                "Add a volume for /data."
-            )
+            if legacy:
+                log.error("DATA PERSISTENCE WARNING: %s", legacy.message)
+            else:
+                log.error(
+                    "DATA PERSISTENCE WARNING: /data appears to be the container's "
+                    "ephemeral layer, not a mounted volume. Everything in /data "
+                    "(verifications, intents, provenance) will be lost on recreate. "
+                    "Add a volume for /data."
+                )
         else:
             health.record_success(TASK_NAME, expected_interval_s=None)
     except Exception:

--- a/tests/test_legacy_config_mount.py
+++ b/tests/test_legacy_config_mount.py
@@ -1,0 +1,126 @@
+"""#473: detect the exact broken shape our own v1.0.0 docs produced.
+
+The v1.0.0 and v1.1.0 README compose example was:
+
+    volumes:
+      - ./subarr/config:/config
+      - /path/to/media:/media/library:rw
+
+with no SUBARR_DB_PATH set. The default has always been /data/subarr.db, so
+following those instructions mounted a directory subarr does not keep its
+database in, and left /data on the container's ephemeral layer. Every recreate
+wiped the database and minted a fresh telemetry install_id, which is what
+produced ~99% single-ping installs in the fleet data.
+
+These users did not misconfigure anything. They followed our documentation. So
+the message has to name the actual mistake and the actual fix, not repeat the
+generic "mount something at /data" line they already satisfied in spirit.
+
+⚠️ Note what this deliberately does NOT do: copy the database from /config to
+/data. If /data is the ephemeral layer, a copy there is wiped on the next
+recreate -- it would look like a migration and fix nothing. The recoverable
+data is already in the persistent place; what is wrong is where subarr is
+looking.
+"""
+
+from __future__ import annotations
+
+from subarr.data_persistence import diagnose_legacy_config_mount
+
+
+def test_the_exact_v1_doc_shape_is_recognised(tmp_path):
+    """/config persistent and holding a db, /data ephemeral."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "subarr.db").write_bytes(b"SQLite format 3\x00")
+
+    d = diagnose_legacy_config_mount(
+        db_path=tmp_path / "data" / "subarr.db",
+        data_is_ephemeral=True,
+        config_dir=cfg,
+    )
+    assert d is not None
+    assert d.legacy_db_path == cfg / "subarr.db"
+    assert "/config" in d.message and "/data" in d.message
+    assert "SUBARR_DB_PATH" in d.message, "must name the one-line fix"
+
+
+def test_silent_when_data_is_already_persistent(tmp_path):
+    """Nothing to say to a correctly configured install, even if /config
+    happens to exist -- plenty of people mount both."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "subarr.db").write_bytes(b"SQLite format 3\x00")
+
+    assert (
+        diagnose_legacy_config_mount(
+            db_path=tmp_path / "data" / "subarr.db",
+            data_is_ephemeral=False,
+            config_dir=cfg,
+        )
+        is None
+    )
+
+
+def test_silent_when_there_is_no_legacy_database(tmp_path):
+    """Ephemeral /data with no /config db is the ordinary case the existing
+    generic warning already covers. Claiming a legacy mount here would send
+    the user hunting for data that does not exist."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+
+    assert (
+        diagnose_legacy_config_mount(
+            db_path=tmp_path / "data" / "subarr.db",
+            data_is_ephemeral=True,
+            config_dir=cfg,
+        )
+        is None
+    )
+
+
+def test_silent_when_config_does_not_exist(tmp_path):
+    assert (
+        diagnose_legacy_config_mount(
+            db_path=tmp_path / "data" / "subarr.db",
+            data_is_ephemeral=True,
+            config_dir=tmp_path / "nope",
+        )
+        is None
+    )
+
+
+def test_unknown_persistence_is_not_treated_as_ephemeral(tmp_path):
+    """None means we could not tell, which is normal outside a container.
+    Guessing here would fire this specific, confident message at bare-metal
+    users for whom it is simply wrong."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "subarr.db").write_bytes(b"SQLite format 3\x00")
+
+    assert (
+        diagnose_legacy_config_mount(
+            db_path=tmp_path / "data" / "subarr.db",
+            data_is_ephemeral=None,
+            config_dir=cfg,
+        )
+        is None
+    )
+
+
+def test_message_does_not_tell_them_to_copy_into_the_ephemeral_layer(tmp_path):
+    """The tempting-but-wrong advice.
+
+    Copying /config/subarr.db to /data would be erased on the next recreate.
+    The fix is to point subarr at the data that is already persistent.
+    """
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "subarr.db").write_bytes(b"SQLite format 3\x00")
+
+    msg = diagnose_legacy_config_mount(
+        db_path=tmp_path / "data" / "subarr.db",
+        data_is_ephemeral=True,
+        config_dir=cfg,
+    ).message.lower()
+    assert "copy" not in msg and "move" not in msg


### PR DESCRIPTION
Root-causes the phantom installs from the #202 data-dive, and does the three things agreed: **name the specific broken shape**, **address recovery honestly**, and **ship a canonical compose file**.

## The investigation

The `install_id` read-or-create logic is **correct in every version** and always has been. The database was disappearing underneath it.

The **v1.0.0 and v1.1.0 README** compose example, verbatim:

```yaml
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=Etc/UTC
      - UMASK=022
    volumes:
      - ./subarr/config:/config          # <- mounts /config
      - /path/to/media:/media/library:rw
```

No `SUBARR_DB_PATH` is set, and the default has **always** been `/data/subarr.db` — unchanged since v1.0.0, verified across tags. So following those instructions mounted a directory subarr does not keep its database in, and left `/data` on the container's ephemeral layer.

The telemetry loop comments *"Send once on start"* and then waits 24h. So each recreate: fresh database → fresh `install_id` → immediate ping. **Exactly 1.00 pings per install** — the signature seen across 1.5.2, 1.1.0, 1.0.0 and 1.6.0, and ~99% of distinct installs in the fleet.

Fixed in `6932cf1` (#202/#209), which is also where the README gained its `REQUIRED` annotation. But 1.5.2 still dominates the phantom count, because nobody re-reads a README after upgrading — their compose still says `/config`.

## These users did not misconfigure anything

They followed our documentation. That shapes the fix.

The existing warning says *"mount a named volume or host path at /data"* — which reads as **wrong** to someone who mounted exactly what the docs told them, and never mentions their data is still recoverable.

When the specific shape is present (`/data` definitely ephemeral, `/config` exists, a database actually in it), the message now names the real mismatch, says the data is safe where it is, and gives the one-line fix. Otherwise the generic message stands — claiming a legacy mount that isn't there would send someone hunting for data that doesn't exist.

## What it deliberately does NOT do

**It does not copy the database from `/config` into `/data`.** That was the originally-proposed migration and it doesn't work: if `/data` is the ephemeral layer, the copy is erased on the next recreate. It would *look* like a migration and fix nothing. The data is already in the persistent place; what's wrong is where subarr is looking. A test asserts the message never says "copy" or "move".

**Unknown persistence stays unknown.** Outside a container the check can't tell, and firing this specific, confident message at bare-metal users would be wrong most of the time.

## The compose file

The project never had one — users hand-copied from the README, and hand-copying is precisely how a documentation error becomes thousands of broken installs. `docker-compose.yml` now ships, the README points at it, and it explains *why* the data volume matters rather than just listing it.

Validated with `docker compose config`, and the healthcheck was **run against a live container** rather than assumed correct.

## Test plan

- [x] 6 tests: the exact v1 shape recognised; silent when `/data` persistent, when no legacy db, when `/config` absent, when persistence unknown; and that the message never advises copying into the ephemeral layer
- [x] 81 passed across persistence / legacy / onboarding / data suites
- [x] Both ruff gates clean

#473 stays open for the remaining question: whether anything should change about `install_id` durability itself now the cause is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)