### PR TITLE
feat(#479): record WHY a subgen probe failed, not just that it did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ breaking config changes.
 - **Run now could fail silently (#252).** A trigger that did not fire reported nothing at all. `fetch` does not reject on an HTTP error status, so a failed run took the success path and the page just reloaded unchanged. The button now says why it did not run, and confirms when it did. This mattered more once the jobs above were added, because a coverage refresh calls out to Bazarr, Sonarr and Plex, where not running is an ordinary outcome rather than an exceptional one.
 - **A job that raised could return a 500 (#252).** Triggering a job whose work threw propagated the exception straight out of the endpoint, despite the code promising otherwise. It is now caught and reported as a failed run, and the message is redacted first, because integrations carry their credential in the request URL and subarr serves its own recent log.
 
+### Changed
+- **The log now says WHY subgen is unreachable, not just that it is (#479).** The startup probe reported one undifferentiated failure for every cause, so `subgen unreachable` could mean the hostname does not resolve, nothing is listening on that port, a firewall is dropping the connection, or something answered that was not subgen at all. Those need four different fixes. The warning now names which one it was, for example `subgen capability probe: /status unreachable (dns)`. Anonymous telemetry carries the same single token, so we can finally tell an install with a genuinely broken connection from one that simply never configured subgen. It never carries your hostname, URL or port.
+
 ### Docs
 - **Tuning Lab settings reference expanded (#450).** Every setting is now described with what it does and when to change it, rather than only what it is called.
 

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -41,6 +41,43 @@ def _env_or(name: str, default: str) -> str:
     return raw
 
 
+# #479: the SUBGEN_URL fallback, named once so config and telemetry cannot
+# disagree about what "default" means. A duplicated literal here would make the
+# telemetry silently report the wrong thing while everything else kept working.
+DEFAULT_SUBGEN_URL = "http://subgen:9000"
+
+
+def subgen_url_is_default(url: object) -> bool:
+    """Is this install still on the shipped SUBGEN_URL?
+
+    #479: 108 genuine installs report subgen unreachable and 104 of them logged
+    no errors at all in 30 days. The default is `http://subgen:9000`, a hostname
+    that resolves only inside one specific compose topology, so an install that
+    never configured subgen probes a host that does not exist and reports
+    identically to one whose real subgen went down. This boolean separates the
+    two. It transmits no URL.
+
+    Empty counts as default because that is what the app actually does: `_env_or`
+    maps an empty SUBGEN_URL back to the fallback, so such an install genuinely
+    IS running on the default. Reporting otherwise would make this field
+    disagree with the behaviour it describes.
+
+    Never raises. It runs inside the telemetry payload build, where an exception
+    would take out the whole ping.
+    """
+    try:
+        if url is None:
+            return True
+        if not isinstance(url, str):
+            return False
+        raw = url.strip()
+        if not raw:
+            return True
+        return raw.rstrip("/").casefold() == DEFAULT_SUBGEN_URL.rstrip("/").casefold()
+    except Exception:
+        return False
+
+
 def _normalize_samesite(v: str) -> str:
     """#238: session-cookie SameSite — lax (default) / strict / none. Anything
     unrecognized falls back to the safe `lax` rather than erroring at boot."""
@@ -278,7 +315,7 @@ def load() -> Settings:
     _s = Settings(
         media_root=Path(_env_or("SUBARR_MEDIA_ROOT", "/media/library")),
         subgen_compose_path=Path(_env_or("SUBGEN_COMPOSE_PATH", "/dockercontainers/subgen/compose.yaml")),
-        subgen_url=_env_or("SUBGEN_URL", "http://subgen:9000"),
+        subgen_url=_env_or("SUBGEN_URL", DEFAULT_SUBGEN_URL),
         subgen_container=_env_or("SUBGEN_CONTAINER", "subgen"),
         subgen_media_prefix=_env_or("SUBGEN_MEDIA_PREFIX", "/media"),
         db_path=Path(_env_or("SUBARR_DB_PATH", "/data/subarr.db")),

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import json
 import logging
+import socket
+import ssl
 from dataclasses import dataclass
 from typing import Any
 
@@ -32,6 +34,73 @@ _DEFAULT_TIMEOUT = httpx.Timeout(connect=3.0, read=120.0, write=10.0, pool=3.0)
 
 class SubgenUnavailable(RuntimeError):
     """Subgen container isn't reachable or returned an unparseable response."""
+
+
+# #479: a closed vocabulary describing WHY a subgen probe failed.
+#
+# unreachable() used to be returned from two structurally different conditions
+# with the difference discarded at the point it was known: a transport error,
+# and a non-200 response meaning something IS listening but is not a healthy
+# subgen. Telemetry then showed one bucket over 108 installs with no way to
+# tell "nothing is there" from "the wrong thing is there".
+#
+# ⚠️ This value is TRANSMITTED. It carries no hostname, URL, port or exception
+# text, only which of a fixed set of shapes the failure had.
+_PROBE_CHAIN_MAX = 8
+
+
+def classify_probe_failure(exc: Exception | None = None, *, status: int | None = None) -> str:
+    """Bucket a probe failure. Pass `exc` for a transport error, `status` for a
+    non-200 response.
+
+    ⚠️ The chain is walked rather than the top-level class inspected, because
+    DNS failure and connection-refused BOTH surface as httpx.ConnectError. The
+    discriminator (socket.gaierror vs ConnectionRefusedError) sits underneath,
+    and classifying on the outer type collapses exactly the two cases this
+    exists to separate.
+
+    ⚠️ The chain shapes here were measured on Linux, which is what runs in
+    production. On Windows httpx does not surface socket.gaierror at all, so a
+    classifier written against a Windows observation would have mislabelled
+    every real install while passing its own tests.
+    """
+    if status is not None:
+        return f"http_{status}" if 100 <= status <= 599 else "http_other"
+
+    # Walk __cause__/__context__, guarding against a cycle: this runs in the
+    # app lifespan and must not hang it.
+    seen: set[int] = set()
+    chain: list[BaseException] = []
+    cur: BaseException | None = exc
+    while cur is not None and len(chain) < _PROBE_CHAIN_MAX and id(cur) not in seen:
+        seen.add(id(cur))
+        chain.append(cur)
+        cur = cur.__cause__ or cur.__context__
+
+    for e in chain:
+        if isinstance(e, socket.gaierror):
+            return "dns"
+        if isinstance(e, ConnectionRefusedError):
+            return "refused"
+        if isinstance(e, ssl.SSLError):
+            return "tls"
+
+    if isinstance(exc, httpx.ConnectTimeout):
+        return "connect_timeout"
+    if isinstance(exc, httpx.ReadTimeout):
+        return "read_timeout"
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+
+    # Message is INSPECTED, never emitted: some SSL failures arrive as a bare
+    # ConnectError with no ssl.SSLError in the chain.
+    text = str(exc or "")
+    if "SSL" in text or "certificate" in text.lower():
+        return "tls"
+
+    # Anything unrecognised still gets a bucket. Returning None would put it
+    # back in the undifferentiated hole this replaces.
+    return "transport"
 
 
 @dataclass(frozen=True)
@@ -161,6 +230,11 @@ class SubgenCapabilities:
     # query param and would re-skip the forced-only file. Distinct from
     # ignore_forced_subtitles above, which is subgen's GLOBAL runtime value.
     request_ignore_forced: bool = False
+    # #479: WHY the probe failed, from a closed vocabulary (see
+    # classify_probe_failure). None when reachable. Declared explicitly
+    # because this dataclass is FROZEN: #458 shipped a gate that could never
+    # open because it read an undeclared field via getattr with a default.
+    probe_failure: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -188,11 +262,15 @@ class SubgenCapabilities:
             "release_tag": self.release_tag,
             "concurrent_transcriptions": self.concurrent_transcriptions,
             "request_ignore_forced": self.request_ignore_forced,
+            "probe_failure": self.probe_failure,
         }
 
     @classmethod
-    def unreachable(cls) -> "SubgenCapabilities":
+    def unreachable(cls, reason: str | None = None) -> "SubgenCapabilities":
+        """#479: `reason` records WHICH failure this was. Optional so the
+        existing no-argument callers keep working unchanged."""
         return cls(
+            probe_failure=reason,
             reachable=False,
             version=None,
             has_queue=False,
@@ -315,11 +393,14 @@ class SubgenClient:
         try:
             r = await self._client.get("/status")
         except httpx.HTTPError as e:
-            log.warning("subgen capability probe: /status unreachable: %s", e)
-            return SubgenCapabilities.unreachable()
+            reason = classify_probe_failure(e)
+            log.warning("subgen capability probe: /status unreachable (%s): %s", reason, e)
+            return SubgenCapabilities.unreachable(reason)
         if r.status_code != 200:
+            # Something IS listening and answered. A completely different
+            # diagnosis from "nothing is there", and previously indistinguishable.
             log.warning("subgen capability probe: /status returned %d", r.status_code)
-            return SubgenCapabilities.unreachable()
+            return SubgenCapabilities.unreachable(classify_probe_failure(status=r.status_code))
 
         # Extract version from the body. Patched + vanilla both use the
         # 'version' key but the shape may vary across upstream versions.

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -95,6 +95,22 @@ class TelemetryPayload:
     # the wizard was finished. Lets us see WHERE installs drop off.
     onboarding_step: int | None = None
     onboarding_complete: bool = False
+    # #479: split the `unreachable` bucket, which covered 108 genuine installs
+    # with no way to tell any of its causes apart.
+    #   subgen_probe_failure  WHY the probe failed, from a closed vocabulary
+    #                         (see subgen_client.classify_probe_failure).
+    #                         'not_probed' when the probe never ran, which is
+    #                         NOT the same as a failure. None when reachable.
+    #   subgen_target_is_default is this install still on http://subgen:9000,
+    #                         i.e. never configured. Carries no URL.
+    # ⚠️ The wire field says 'target' while its producer is named
+    # subgen_url_is_default. That is DELIBERATE, not an oversight: the
+    # payload smoke test rejects any field name containing 'url', and a
+    # field called subgen_url_* would trip it. Do not 'fix' the mismatch.
+    # Both use None for UNKNOWN, following data_persistent. Defaulting either
+    # to a real value would report a confident wrong answer fleet-wide.
+    subgen_probe_failure: str | None = None
+    subgen_target_is_default: bool | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -117,6 +133,8 @@ class TelemetryPayload:
             "docker_tier": self.docker_tier,
             "onboarding_step": self.onboarding_step,
             "onboarding_complete": self.onboarding_complete,
+            "subgen_probe_failure": self.subgen_probe_failure,
+            "subgen_target_is_default": self.subgen_target_is_default,
         }
 
 
@@ -250,15 +268,26 @@ class TelemetryCollector:
         stats = self._stats_provider() or {}
         caps = self._subgen_caps_provider()
 
-        if caps is None or not caps.reachable:
+        if caps is None:
+            # The probe never ran. Distinct from a probe that ran and
+            # failed: collapsing the two is the conflation #479 is about.
             subgen_kind = "unreachable"
             subgen_version = None
+            subgen_probe_failure = "not_probed"
+        elif not caps.reachable:
+            subgen_kind = "unreachable"
+            subgen_version = None
+            # getattr with a default because a caps object from an older
+            # path may not carry the field; a missing reason is unknown.
+            subgen_probe_failure = getattr(caps, "probe_failure", None)
         elif caps.is_subarr_subgen:
             subgen_kind = "subarr-subgen"
             subgen_version = caps.version
+            subgen_probe_failure = None
         else:
             subgen_kind = "vanilla"
             subgen_version = caps.version
+            subgen_probe_failure = None
 
         return TelemetryPayload(
             install_id=st.install_id,
@@ -268,6 +297,8 @@ class TelemetryCollector:
             os_arch=f"{platform.system()}/{platform.machine()}",
             subgen_kind=subgen_kind,
             subgen_version=subgen_version,
+            subgen_probe_failure=subgen_probe_failure,
+            subgen_target_is_default=stats.get("subgen_target_is_default"),
             integrations=stats.get("integrations") or {},
             library_bucket=stats.get("library_bucket") or "unknown",
             scheduler_enabled=bool(stats.get("scheduler_enabled")),
@@ -467,7 +498,7 @@ def make_default_stats_provider(app_state) -> Any:
     """Returns a callable suitable for TelemetryCollector(stats_provider=...)
     that pulls live data off app.state. Kept separate so tests can swap
     in a deterministic mock dict instead."""
-    from .config import settings
+    from .config import settings, subgen_url_is_default
 
     def _provider() -> dict[str, Any]:
         # Library size bucket — pulled from probe_store row count as a
@@ -551,6 +582,11 @@ def make_default_stats_provider(app_state) -> Any:
             # #202 activation funnel.
             "onboarding_step": _onboarding_step(app_state),
             "onboarding_complete": _onboarding_complete(app_state),
+            # #479: is this install still on the shipped SUBGEN_URL, i.e.
+            # never configured. Separates that from a real subgen that is
+            # down, which the single `unreachable` bucket could not. Sends
+            # no URL, only the boolean.
+            "subgen_target_is_default": subgen_url_is_default(settings.subgen_url),
         }
 
     return _provider

--- a/tests/test_subgen_probe_failure.py
+++ b/tests/test_subgen_probe_failure.py
@@ -1,0 +1,182 @@
+"""#479: why a subgen probe failed, not merely that it did.
+
+`SubgenCapabilities.unreachable()` was returned from two structurally different
+conditions and the difference was discarded at the point it was known: a
+transport error (DNS, refused, timeout, TLS) and a non-200 response, which means
+something IS listening and answering but is not a healthy subgen. Telemetry then
+showed one `unreachable` bucket covering 108 installs with no way to tell which.
+
+The vocabulary is deliberately small and closed. It carries no hostname, URL,
+port or exception message, because this value is transmitted.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import httpx
+import pytest
+
+from subarr.subgen_client import SubgenCapabilities, classify_probe_failure
+
+
+def _chain(top: Exception, *causes: Exception) -> Exception:
+    """Build an exception with a __cause__ chain, the shape httpx produces."""
+    cur = top
+    for c in causes:
+        cur.__cause__ = c
+        cur = c
+    return top
+
+
+class TestTransportClassification:
+    """The chains here are the ones MEASURED on Linux, which is what runs in
+    production. On Windows httpx does not surface socket.gaierror at all, so a
+    classifier written against a Windows observation would have silently
+    mislabelled every real install."""
+
+    def test_dns_failure(self):
+        # httpx.ConnectError <- httpcore.ConnectError <- socket.gaierror
+        exc = _chain(
+            httpx.ConnectError("All connection attempts failed"),
+            socket.gaierror(-2, "Name or service not known"),
+        )
+        assert classify_probe_failure(exc) == "dns"
+
+    def test_connection_refused(self):
+        exc = _chain(
+            httpx.ConnectError("All connection attempts failed"),
+            ConnectionRefusedError(111, "Connection refused"),
+        )
+        assert classify_probe_failure(exc) == "refused"
+
+    def test_dns_wins_over_the_generic_connect_error_wrapping_it(self):
+        # The outer type is identical for DNS and refused, so classifying on the
+        # top-level class alone collapses exactly the two cases this exists to
+        # separate.
+        dns = _chain(httpx.ConnectError("x"), socket.gaierror(-2, "y"))
+        refused = _chain(httpx.ConnectError("x"), ConnectionRefusedError(111, "y"))
+        assert classify_probe_failure(dns) != classify_probe_failure(refused)
+
+    def test_connect_timeout(self):
+        assert classify_probe_failure(httpx.ConnectTimeout("timed out")) == "connect_timeout"
+
+    def test_read_timeout(self):
+        assert classify_probe_failure(httpx.ReadTimeout("timed out")) == "read_timeout"
+
+    def test_tls_failure(self):
+        assert classify_probe_failure(httpx.ConnectError("[SSL] bad certificate")) == "tls"
+
+    def test_unknown_transport_error_is_labelled_not_dropped(self):
+        # An unrecognised error must still produce a bucket. Returning None here
+        # would put it back in the same undifferentiated hole this replaces.
+        assert classify_probe_failure(httpx.HTTPError("something new")) == "transport"
+
+    def test_a_deep_chain_is_still_walked(self):
+        exc = _chain(
+            httpx.ConnectError("outer"),
+            OSError("middle"),
+            ConnectionRefusedError(111, "inner"),
+        )
+        assert classify_probe_failure(exc) == "refused"
+
+    def test_a_cyclic_or_absurdly_deep_chain_terminates(self):
+        # Defensive: a self-referential __cause__ must not hang the probe, which
+        # runs in the app lifespan.
+        a = httpx.ConnectError("a")
+        b = httpx.ConnectError("b")
+        a.__cause__ = b
+        b.__cause__ = a
+        assert classify_probe_failure(a) == "transport"
+
+
+class TestStatusClassification:
+    def test_http_status_is_carried_with_its_code(self):
+        # "Something answered but was not subgen" is a completely different
+        # diagnosis from "nothing is there", and the code says which kind.
+        assert classify_probe_failure(status=401) == "http_401"
+        assert classify_probe_failure(status=502) == "http_502"
+
+    def test_status_takes_a_bounded_shape(self):
+        # HTTP status space is closed, so this cannot become high-cardinality
+        # or carry anything user-specific.
+        for code in (400, 401, 403, 404, 500, 502, 503):
+            assert classify_probe_failure(status=code) == f"http_{code}"
+
+    def test_a_nonsense_status_does_not_produce_a_junk_bucket(self):
+        assert classify_probe_failure(status=99) == "http_other"
+        assert classify_probe_failure(status=700) == "http_other"
+
+
+class TestNeverLeaksTheTarget:
+    """This value is transmitted. It must never carry a hostname, URL, port or
+    raw exception text."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("connection to media-nas.home.arpa:9000 failed"),
+            httpx.ReadTimeout("timeout reading from http://10.0.0.7:9000/status"),
+            httpx.HTTPError("failed for user@secret-host"),
+        ],
+    )
+    def test_no_part_of_the_message_survives(self, exc):
+        out = classify_probe_failure(exc)
+        for leak in ("media-nas", "10.0.0.7", "secret-host", "9000", "arpa", "@"):
+            assert leak not in out
+
+    def test_every_output_is_from_the_closed_vocabulary(self):
+        allowed = {
+            "dns",
+            "refused",
+            "connect_timeout",
+            "read_timeout",
+            "timeout",
+            "tls",
+            "transport",
+            "http_other",
+        }
+        samples = [
+            httpx.ConnectError("x"),
+            httpx.ConnectTimeout("x"),
+            httpx.ReadTimeout("x"),
+            httpx.PoolTimeout("x"),
+            httpx.HTTPError("x"),
+            _chain(httpx.ConnectError("x"), socket.gaierror(-2, "y")),
+        ]
+        for exc in samples:
+            out = classify_probe_failure(exc)
+            assert out in allowed, out
+        assert classify_probe_failure(status=418).startswith("http_")
+
+
+class TestCapabilitiesCarryTheReason:
+    def test_unreachable_records_why(self):
+        caps = SubgenCapabilities.unreachable("dns")
+        assert caps.reachable is False
+        assert caps.probe_failure == "dns"
+
+    def test_unreachable_without_a_reason_is_still_valid(self):
+        # Back-compat: existing callers pass nothing.
+        assert SubgenCapabilities.unreachable().probe_failure is None
+
+    def test_a_reachable_probe_has_no_failure(self):
+        caps = SubgenCapabilities(
+            reachable=True,
+            version="2026.08.1",
+            has_queue=True,
+            has_batch=True,
+            is_subarr_subgen=True,
+        )
+        assert caps.probe_failure is None
+
+    def test_probe_failure_is_a_real_field_not_a_getattr_default(self):
+        # SubgenCapabilities is a FROZEN dataclass. #458 shipped a gate that
+        # could never open because it read a field that did not exist via
+        # getattr with a default. Assert the field is declared.
+        assert "probe_failure" in SubgenCapabilities.__dataclass_fields__
+
+    def test_it_is_serialised(self):
+        # If to_dict drops it, the UI and every consumer see nothing while the
+        # object looks correct in a debugger.
+        assert SubgenCapabilities.unreachable("refused").to_dict()["probe_failure"] == "refused"

--- a/tests/test_subgen_url_default.py
+++ b/tests/test_subgen_url_default.py
@@ -1,0 +1,96 @@
+"""#479: is the install still on the default SUBGEN_URL?
+
+108 genuine installs report subgen `unreachable`, and 104 of them logged no
+errors at all in 30 days. The leading explanation is that they never configured
+subgen: SUBGEN_URL defaults to `http://subgen:9000`, a hostname that resolves
+only if you happen to run a container called `subgen` on the same docker
+network, so an install that never touched the setting probes a host that does
+not exist and reports identically to one whose real subgen died.
+
+⚠️ Worse, `subgen_url` goes through `_env_or`, so `SUBGEN_URL=` falls back to
+the default too. There is currently no way to express "I do not use subgen".
+
+One boolean settles which it is. It transmits no URL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from subarr.config import DEFAULT_SUBGEN_URL, subgen_url_is_default
+
+
+class TestTheDefaultIsOneDefinition:
+    def test_the_constant_is_what_config_actually_falls_back_to(self):
+        # If these ever drift, the telemetry silently reports the wrong thing
+        # and nothing else breaks, which is the worst failure shape.
+        import inspect
+
+        from subarr import config
+
+        src = inspect.getsource(config)
+        assert 'subgen_url=_env_or("SUBGEN_URL", DEFAULT_SUBGEN_URL)' in src, (
+            "config must use the shared constant, not a duplicated literal"
+        )
+
+    def test_the_value_is_the_documented_one(self):
+        assert DEFAULT_SUBGEN_URL == "http://subgen:9000"
+
+
+class TestRecognisingTheDefault:
+    def test_the_bare_default(self):
+        assert subgen_url_is_default("http://subgen:9000") is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://subgen:9000/",
+            "  http://subgen:9000  ",
+            "HTTP://SUBGEN:9000",
+            "http://Subgen:9000/",
+        ],
+    )
+    def test_trivial_variations_still_count_as_default(self, url):
+        # A user who pasted the default back with a trailing slash has still not
+        # configured anything. Treating that as "configured" would understate
+        # the never-configured population, which is the number this exists to
+        # measure.
+        assert subgen_url_is_default(url) is True
+
+    def test_empty_counts_as_default_because_that_is_what_config_does(self):
+        # ⚠️ Not an arbitrary choice. _env_or maps empty to the default, so an
+        # install with SUBGEN_URL= genuinely IS running on the default. Saying
+        # otherwise here would make the field disagree with the app's behaviour.
+        assert subgen_url_is_default("") is True
+        assert subgen_url_is_default("   ") is True
+        assert subgen_url_is_default(None) is True
+
+
+class TestRecognisingRealConfiguration:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://subgen-next:9000",
+            "http://192.168.1.105:9000",
+            "http://subgen:9008",
+            "https://subgen:9000",
+            "http://subgen.lan:9000",
+            "http://subgen:9000/api",
+        ],
+    )
+    def test_anything_the_user_actually_chose_is_not_default(self, url):
+        assert subgen_url_is_default(url) is False
+
+    def test_a_different_port_on_the_same_host_is_configured(self):
+        # The common real case: subgen-next on 9008. Missing this would fold
+        # deliberate users into the never-configured bucket.
+        assert subgen_url_is_default("http://subgen:9008") is False
+
+
+class TestNeverRaises:
+    @pytest.mark.parametrize("url", ["://nonsense", "http://[oops", 12345, object()])
+    def test_garbage_is_reported_as_not_default_rather_than_crashing(self, url):
+        # This runs inside the telemetry payload build. An exception here would
+        # take out the whole ping, and a malformed URL is certainly not the
+        # default anyway.
+        assert subgen_url_is_default(url) is False

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -368,6 +368,15 @@ _EXPECTED_PAYLOAD_KEYS: frozenset[str] = frozenset(
         "docker_tier",
         "onboarding_step",
         "onboarding_complete",
+        # #479 privacy review: both carry NO user-identifying data.
+        # subgen_probe_failure is one token from a CLOSED vocabulary
+        # (dns / refused / connect_timeout / read_timeout / timeout /
+        # tls / transport / not_probed / http_<code>) with no hostname,
+        # URL, port or exception text. subgen_target_is_default is a
+        # bool saying whether SUBGEN_URL is still the shipped default;
+        # it never carries the URL itself.
+        "subgen_probe_failure",
+        "subgen_target_is_default",
     }
 )
 

--- a/tests/test_telemetry_subgen_cause.py
+++ b/tests/test_telemetry_subgen_cause.py
@@ -1,0 +1,121 @@
+"""#479: the two fields that split the `unreachable` bucket.
+
+`subgen_kind='unreachable'` covered 108 genuine installs with no way to tell
+"never configured" from "configured and broken", or "nothing is listening" from
+"something answered that was not subgen".
+
+⚠️ Both fields follow `data_persistent`'s precedent and use None for UNKNOWN.
+An absent result and a negative result looking identical is the failure that
+produced this issue in the first place; repeating it in the fix would be
+particularly poor.
+"""
+
+from __future__ import annotations
+
+import types
+
+from subarr.telemetry import TelemetryCollector, TelemetryPayload
+
+
+def _caps(**kw):
+    base = dict(reachable=True, is_subarr_subgen=True, version="2026.08.1", probe_failure=None)
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def _collector(caps, stats=None, tmp_path=None):
+    from subarr.migrate import run_migrations
+
+    db = tmp_path / "t.db"
+    run_migrations(db)
+    return TelemetryCollector(
+        db_path=db,
+        stats_provider=lambda: stats or {},
+        subgen_caps_provider=lambda: caps,
+        subarr_version="9.9.9",
+    )
+
+
+class TestProbeFailureReachesThePayload:
+    def test_a_failed_probe_carries_its_reason(self, tmp_path):
+        p = _collector(_caps(reachable=False, probe_failure="dns"), tmp_path=tmp_path).build_payload()
+        assert p.subgen_kind == "unreachable"
+        assert p.subgen_probe_failure == "dns"
+
+    def test_a_reachable_subgen_reports_no_failure(self, tmp_path):
+        p = _collector(_caps(), tmp_path=tmp_path).build_payload()
+        assert p.subgen_kind == "subarr-subgen"
+        assert p.subgen_probe_failure is None
+
+    def test_never_probed_is_distinct_from_probed_and_failed(self, tmp_path):
+        # caps is None means the probe never ran. Reporting that as the same
+        # thing as a failure is precisely the conflation this issue is about.
+        p = _collector(None, tmp_path=tmp_path).build_payload()
+        assert p.subgen_kind == "unreachable"
+        assert p.subgen_probe_failure == "not_probed"
+
+    def test_an_http_status_reason_survives_intact(self, tmp_path):
+        p = _collector(_caps(reachable=False, probe_failure="http_502"), tmp_path=tmp_path).build_payload()
+        assert p.subgen_probe_failure == "http_502"
+
+    def test_missing_attribute_on_caps_does_not_crash_the_ping(self, tmp_path):
+        # A caps object from an older code path may not carry the field at all.
+        legacy = types.SimpleNamespace(reachable=False, is_subarr_subgen=False, version=None)
+        p = _collector(legacy, tmp_path=tmp_path).build_payload()
+        assert p.subgen_kind == "unreachable"
+        assert p.subgen_probe_failure is None
+
+
+class TestTargetIsDefaultReachesThePayload:
+    def test_true_when_the_stats_provider_says_so(self, tmp_path):
+        p = _collector(_caps(), {"subgen_target_is_default": True}, tmp_path=tmp_path).build_payload()
+        assert p.subgen_target_is_default is True
+
+    def test_false_when_configured(self, tmp_path):
+        p = _collector(_caps(), {"subgen_target_is_default": False}, tmp_path=tmp_path).build_payload()
+        assert p.subgen_target_is_default is False
+
+    def test_absent_is_None_meaning_unknown_not_False(self, tmp_path):
+        # Defaulting to False would silently report every install as
+        # "configured"; defaulting to True would report every install as
+        # "never configured". Both are a confident wrong answer.
+        p = _collector(_caps(), {}, tmp_path=tmp_path).build_payload()
+        assert p.subgen_target_is_default is None
+
+
+class TestSerialisation:
+    def test_both_fields_are_in_to_dict(self, tmp_path):
+        # If to_dict drops them the payload looks correct in a debugger and the
+        # worker never receives them.
+        d = TelemetryPayload(
+            install_id="a" * 32,
+            sent_at=0.0,
+            subarr_version="1",
+            python_version="3",
+            os_arch="Linux/x86_64",
+            subgen_kind="unreachable",
+            subgen_version=None,
+            integrations={},
+            library_bucket="unknown",
+            scheduler_enabled=False,
+            scheduler_mode=None,
+            walks_per_day_30d=0.0,
+            subgen_probe_failure="dns",
+            subgen_target_is_default=True,
+        ).to_dict()
+        assert d["subgen_probe_failure"] == "dns"
+        assert d["subgen_target_is_default"] is True
+
+    def test_neither_field_can_carry_a_url_or_host(self, tmp_path):
+        # The whole point is to answer the question WITHOUT transmitting the
+        # target. probe_failure comes from a closed vocabulary; the other is a
+        # bool.
+        from subarr.subgen_client import classify_probe_failure
+
+        import httpx
+
+        reason = classify_probe_failure(httpx.ConnectError("connect to nas.private.lan:9000 failed"))
+        p = _collector(_caps(reachable=False, probe_failure=reason), tmp_path=tmp_path).build_payload()
+        blob = str(p.to_dict())
+        for leak in ("nas.private", "9000", ".lan"):
+            assert leak not in blob


### PR DESCRIPTION
Client side of #479. Receiver side is coaxk/subarr-telemetry#50, already merged and deployed.

## The problem

`subgen_kind='unreachable'` covers **108 genuine installs, 50.5% of the real userbase**, with no way to tell any of its causes apart.

`probe_capabilities()` returned the same sentinel from two structurally different conditions, discarding the difference at the exact point it was known:

1. `httpx.HTTPError` on `GET /status` — a transport failure, itself covering DNS, refused, connect timeout, read timeout and TLS.
2. `r.status_code != 200` — something IS listening and answered; it is just not a healthy subgen. A reverse-proxy 502, an auth wall, a wrong port hitting a different service.

Those need different fixes, and we were reporting them identically.

## Two fields

**`subgen_probe_failure`** — one token from a closed vocabulary: `dns`, `refused`, `connect_timeout`, `read_timeout`, `timeout`, `tls`, `transport`, `not_probed`, `http_<code>`.

`classify_probe_failure()` **walks the exception chain** rather than reading the top-level class, because DNS failure and connection-refused both arrive as `httpx.ConnectError` and the discriminator sits underneath. Classifying on the outer type would collapse exactly the two cases this exists to separate.

⚠️ **The chain shapes were measured on Linux**, which is what runs in production. On Windows httpx never surfaces `socket.gaierror` at all, so a classifier written against a Windows observation would have mislabelled every real install while passing its own tests. Verified with real probes:

```
http://subgen:9000  ->  (False, 'dns')      <- the shipped default
http://127.0.0.1:9  ->  (False, 'refused')
```

**`subgen_target_is_default`** — answers what the first cannot. `SUBGEN_URL` defaults to `http://subgen:9000`, a hostname that resolves only inside one compose topology. Worse, `_env_or` maps an empty `SUBGEN_URL` back to that default, so **there is currently no way to express "I do not use subgen"**. Every such install probes a host that does not exist and reports identically to one whose real subgen died. A boolean separates them, and transmits no URL.

Both use `None` for UNKNOWN, following `data_persistent`'s precedent, and `not_probed` is deliberately distinct from a probe that ran and failed. An absent result and a negative result looking identical is what produced this issue; repeating it in the fix would be poor.

## Two guards caught mistakes before they shipped

**The payload smoke test rejected `subgen_url_is_default`** for containing `url`. The wire field is therefore `subgen_target_is_default`, while its producer keeps the honest internal name (it does take a URL), with a comment so nobody "fixes" the mismatch and reintroduces the blocked name.

For the record: I first said that name would have 400'd every ping fleet-wide. **That was wrong** — the worker's patterns are anchored (`/^url$/i`) and would have accepted it. It was subarr's own stricter substring check, doing defence-in-depth exactly as intended.

**`test_payload_shape_locked` failed as designed**, forcing an explicit privacy review before either key could be added. Both are recorded there.

## Also user-visible

The startup warning now names the cause: `subgen capability probe: /status unreachable (dns)`. Four causes needing four different fixes previously produced one indistinguishable line.

## Test plan

- `test_subgen_probe_failure.py` (21) — classification including deep and **cyclic** chains, the closed vocabulary, and that no hostname, port or message text can survive into the output.
- `test_subgen_url_default.py` (19) — including that empty counts as default, because that is what `_env_or` actually does, and that a different port on the same host is *configured*.
- `test_telemetry_subgen_cause.py` (10) — payload wiring, `not_probed` vs failure, and unknown-is-None.
- **1945 passed, 6 skipped**; `ruff check` and `ruff format --check` clean.