### PR TITLE
fix(#483): a shared library root must not silently drop the @slug

### DIFF
--- a/src/subarr/paths.py
+++ b/src/subarr/paths.py
@@ -96,6 +96,37 @@ def canonical_to_fs(canonical: str) -> Path:
     return target
 
 
+# #483: roots already reported as ambiguous, so a hot path does not log on
+# every call. Process-local and best-effort; the point is that the operator
+# sees it once, not that the count is exact.
+_warned_ambiguous_roots: set[str] = set()
+
+
+def _warn_ambiguous_root(root: Path, a: Library, b: Library) -> None:
+    """Surface two libraries sharing a filesystem root.
+
+    The tie-break below is a reasonable guess, not a truth: from the path
+    alone these libraries are indistinguishable. build_libraries rejects a
+    duplicate arr_prefix for exactly this reason, but cannot reject a
+    duplicate fs_root, because invalid library config is handled fail-soft
+    by falling back to the single default library, which would silently
+    delete the user's second library instead of fixing it.
+    """
+    key = str(root)
+    if key in _warned_ambiguous_roots:
+        return
+    _warned_ambiguous_roots.add(key)
+    log.warning(
+        "libraries %r and %r share fs_root %s; a path under it cannot be "
+        "attributed from the filesystem alone. Preferring the configured "
+        "library over the default. Give them distinct roots to remove the "
+        "ambiguity.",
+        a.slug or "(default)",
+        b.slug or "(default)",
+        key,
+    )
+
+
 def fs_to_canonical(p: Path) -> str:
     """Inverse of canonical_to_fs: find the owning library (longest-matching
     fs_root) and emit its canonical, prefixing '@<slug>/' for non-default
@@ -109,8 +140,30 @@ def fs_to_canonical(p: Path) -> str:
             rel = PurePosixPath(rp.relative_to(root).as_posix())
         except ValueError:
             continue
-        if best is None or len(root.parts) > len(best[0].parts):
+        if best is None:
             best = (root, rel, lib)
+            continue
+        best_root, _best_rel, best_lib = best
+        depth, best_depth = len(root.parts), len(best_root.parts)
+        if depth > best_depth:
+            best = (root, rel, lib)
+        elif depth == best_depth:
+            # #483: an EQUAL-length match is genuinely ambiguous. This used to
+            # be decided by list order, and library 0 is always first, so two
+            # libraries sharing an fs_root handed every path to the default and
+            # silently dropped the '@<slug>/' head. That head selects the
+            # library, hence the subgen_prefix, so losing it produced a
+            # wrong-but-plausible subgen path, a 404, and subarr reporting
+            # "file removed" for a file that was sitting right there.
+            #
+            # Prefer the EXPLICITLY configured library over the catch-all
+            # default: a user who created a second library rooted at the same
+            # place clearly meant files there to belong to it. Between two
+            # slugged libraries it stays list-ordered, which is arbitrary but
+            # deterministic; nothing in the path can distinguish them.
+            _warn_ambiguous_root(root, best_lib, lib)
+            if lib.slug and not best_lib.slug:
+                best = (root, rel, lib)
     if best is None:
         raise PathOutsideRootError(str(p))
     _, rel, lib = best

--- a/tests/test_library_root_ambiguity.py
+++ b/tests/test_library_root_ambiguity.py
@@ -1,0 +1,275 @@
+"""#483: a filesystem-root tie must not silently re-home a file to library 0.
+
+`fs_to_canonical` picks the library with the LONGEST matching `fs_root` and
+broke ties with a strictly-greater comparison. Library 0 is always first in the
+list, so two libraries sharing a root handed every path to library 0 and dropped
+the `@<slug>/` head.
+
+That head is not decoration: it selects the library, and therefore the
+subgen_prefix. Losing it produces a wrong-but-plausible subgen path, a 404, and
+subarr then reporting "file removed, no longer on disk" for a file that is
+sitting right there. Reported by AztecGuyGDL after a Requeue.
+
+⚠️ There is a uniqueness guard on `arr_prefix` for exactly this hazard, whose
+comment calls it "a real #161 multi-instance footgun". There was none on
+`fs_root`, and the consequence is the same.
+
+⚠️ Rejecting a duplicate root at config time was the first instinct and is
+WRONG here: invalid library config is handled fail-soft by falling back to the
+single default library, so raising would silently delete the user's second
+library rather than fix it. Preserving the setup and resolving the ambiguity is
+the better trade.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+
+def _configure(tmp_path: Path, monkeypatch, extras: list[dict], media_root: Path):
+    """Reload config+paths with a chosen library set. Mirrors conftest's
+    two_libraries fixture, but lets each test choose the roots."""
+    store = tmp_path / "ov.json"
+    store.write_text(json.dumps({"libraries": extras}))
+    monkeypatch.setenv("SUBARR_CONFIG_STORE", str(store))
+    monkeypatch.setenv("SUBARR_MEDIA_ROOT", str(media_root))
+    from subarr import config, paths
+
+    importlib.reload(config)
+    importlib.reload(paths)
+    return config, paths
+
+
+@pytest.fixture(autouse=True)
+def _restore_modules():
+    # Reloading config/paths leaks into other tests unless restored.
+    yield
+    import importlib
+
+    from subarr import config, paths
+
+    importlib.reload(config)
+    importlib.reload(paths)
+
+
+class TestDuplicateRootKeepsTheSlug:
+    def test_the_explicit_library_wins_over_the_catch_all_default(self, tmp_path, monkeypatch):
+        media = tmp_path / "media"
+        (media / "tv_shows").mkdir(parents=True)
+        f = media / "tv_shows" / "ep.mkv"
+        f.write_bytes(b"")
+
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "tv",
+                    "name": "TV",
+                    "fs_root": str(media),
+                    "subgen_prefix": "/media/tv_shows",
+                    "arr_prefix": "/tv/",
+                }
+            ],
+            media_root=media,
+        )
+        # Before the fix this returned 'tv_shows/ep.mkv': library 0 won the tie
+        # and the file was re-homed, taking library 0's subgen_prefix with it.
+        assert paths.fs_to_canonical(f) == "@tv/tv_shows/ep.mkv"
+
+    def test_the_canonical_round_trips_back_to_the_same_file(self, tmp_path, monkeypatch):
+        # The real damage was the round trip: canonical -> fs -> canonical came
+        # back different, so a requeue targeted a path that does not exist.
+        media = tmp_path / "media"
+        (media / "tv_shows").mkdir(parents=True)
+        f = media / "tv_shows" / "ep.mkv"
+        f.write_bytes(b"")
+
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "tv",
+                    "name": "TV",
+                    "fs_root": str(media),
+                    "subgen_prefix": "/media/tv_shows",
+                    "arr_prefix": "/tv/",
+                }
+            ],
+            media_root=media,
+        )
+        canon = paths.fs_to_canonical(f)
+        assert paths.canonical_to_fs(canon).resolve() == f.resolve()
+        assert paths.fs_to_canonical(paths.canonical_to_fs(canon)) == canon
+
+    def test_the_subgen_path_is_the_configured_one(self, tmp_path, monkeypatch):
+        # What the user actually saw: the wrong prefix reached subgen.
+        media = tmp_path / "media"
+        (media / "tv_shows").mkdir(parents=True)
+        f = media / "tv_shows" / "ep.mkv"
+        f.write_bytes(b"")
+
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "tv",
+                    "name": "TV",
+                    "fs_root": str(media),
+                    "subgen_prefix": "/media/tv_shows",
+                    "arr_prefix": "/tv/",
+                }
+            ],
+            media_root=media,
+        )
+        sub = paths.canonical_to_subgen_batch(paths.fs_to_canonical(f))
+        assert sub == "/media/tv_shows/tv_shows/ep.mkv", sub
+
+
+class TestSpecificityStillOutranksTheSlugPreference:
+    def test_a_deeper_default_root_still_wins(self, tmp_path, monkeypatch):
+        # The tie-break must apply ONLY on an equal-length match. A library
+        # whose root is genuinely deeper is the more specific owner and must
+        # keep winning, slug or not, or this fix would break normal nesting.
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        inner.mkdir(parents=True)
+        f = inner / "ep.mkv"
+        f.write_bytes(b"")
+
+        # library 0 rooted DEEPER than the slugged one.
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "outer",
+                    "name": "Outer",
+                    "fs_root": str(outer),
+                    "subgen_prefix": "/m-outer",
+                    "arr_prefix": "/outer/",
+                }
+            ],
+            media_root=inner,
+        )
+        assert paths.fs_to_canonical(f) == "ep.mkv"
+
+
+class TestUnchangedBehaviour:
+    def test_single_library_is_untouched(self, tmp_path, monkeypatch):
+        media = tmp_path / "media"
+        media.mkdir()
+        f = media / "ep.mkv"
+        f.write_bytes(b"")
+
+        _cfg, paths = _configure(tmp_path, monkeypatch, [], media_root=media)
+        assert paths.fs_to_canonical(f) == "ep.mkv"
+
+    def test_distinct_roots_are_untouched(self, tmp_path, monkeypatch):
+        media = tmp_path / "media"
+        media.mkdir()
+        d2 = tmp_path / "disk2"
+        d2.mkdir()
+        f = d2 / "ep.mkv"
+        f.write_bytes(b"")
+
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "disk2",
+                    "name": "Disk 2",
+                    "fs_root": str(d2),
+                    "subgen_prefix": "/media2",
+                    "arr_prefix": "/data/d2/",
+                }
+            ],
+            media_root=media,
+        )
+        assert paths.fs_to_canonical(f) == "@disk2/ep.mkv"
+
+
+class TestTheAmbiguityIsSurfaced:
+    def test_a_duplicate_root_is_logged_once_not_silently_resolved(self, tmp_path, monkeypatch, caplog):
+        # The tie-break is a best guess, not a truth. Two libraries rooted at
+        # the same place are genuinely ambiguous from the path alone, so the
+        # config deserves to be visible rather than quietly papered over.
+        media = tmp_path / "media"
+        media.mkdir()
+        f = media / "ep.mkv"
+        f.write_bytes(b"")
+
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "tv",
+                    "name": "TV",
+                    "fs_root": str(media),
+                    "subgen_prefix": "/m",
+                    "arr_prefix": "/tv/",
+                }
+            ],
+            media_root=media,
+        )
+        with caplog.at_level(logging.WARNING):
+            paths.fs_to_canonical(f)
+        assert any("fs_root" in r.message or "fs_root" in str(r.args) for r in caplog.records), (
+            "an ambiguous library root should be surfaced, not silently guessed"
+        )
+
+
+class TestTheOtherWayToGetAWrongCanonical:
+    """#483 has a SECOND candidate mechanism, deliberately left unchanged for
+    now, and pinned here so a future change to it is a decision rather than an
+    accident.
+
+    strip_arr_prefix documents that "a path matching no library passes through
+    slash-stripped". So an *arr path whose prefix matches nothing configured
+    becomes a library-0 canonical verbatim, which then resolves against library
+    0's subgen_prefix. That produces exactly the reporter's string, and nothing
+    complains.
+
+    ⚠️ This is NOT asserted to be correct behaviour. It is asserted to be the
+    CURRENT behaviour. Turning the silent pass-through into an error could break
+    installs working today, and it is not yet known whether it is what bit the
+    reporter, so it waits on their configuration.
+    """
+
+    def test_an_unmatched_arr_prefix_passes_through_as_a_library_0_canonical(self, tmp_path, monkeypatch):
+        media = tmp_path / "media"
+        media.mkdir()
+        _cfg, paths = _configure(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    "slug": "tv",
+                    "name": "TV",
+                    "fs_root": str(tmp_path / "tv"),
+                    "subgen_prefix": "/media/tv_shows",
+                    "arr_prefix": "/tv/",
+                }
+            ],
+            media_root=media,
+        )
+        # Matches the 'tv' library: stripped and qualified, as intended.
+        assert paths.strip_arr_prefix("/tv/Show/ep.mkv") == "@tv/Show/ep.mkv"
+
+        # Matches NOTHING: passes through slash-stripped, and is now
+        # indistinguishable from a genuine library-0 relative path.
+        orphan = paths.strip_arr_prefix("/somewhere-else/Show/ep.mkv")
+        assert orphan == "somewhere-else/Show/ep.mkv"
+        assert not orphan.startswith("@"), (
+            "an unmatched arr path silently becomes a library-0 canonical; "
+            "if this ever changes, #483's second mechanism has been addressed"
+        )


### PR DESCRIPTION
Fixes the subarr half of #483, reported by AztecGuyGDL. The subgen half shipped as coaxk/subarr-subgen v4.24 (`2026.08.1-r5`) and is filed upstream as McCloudS/subgen#358.

## The bug

Requeue submitted a path with the `@` head missing, subgen 404'd, and subarr then reported **"file removed, no longer on disk"** for a file sitting right there.

The `@<slug>/` head is not decoration: it selects the library, and therefore the `subgen_prefix`. `fs_to_canonical` picks the library with the longest matching `fs_root` and broke ties with a strictly-greater comparison, while **library 0 is always first in the list**. So two libraries sharing a root handed every path to the default and dropped the slug, producing a wrong-but-plausible subgen path that nothing complained about.

Reproduced before fixing:

```
libraries: [('', '/tmp/x/media'), ('tv', '/tmp/x/media')]
fs_to_canonical('/tmp/x/media/tv_shows/ep.mkv')
  expected '@tv/tv_shows/ep.mkv'
  got      'tv_shows/ep.mkv'
```

## The fix

On an **equal-length** match, prefer the explicitly configured library over the catch-all default. A user who created a second library rooted at the same place meant files there to belong to it.

Deeper roots still win outright, so ordinary nesting is untouched. There is a test with library 0 rooted *deeper* than the slugged one, because a naive "prefer slug" rule would have broken exactly that case.

## Why not reject duplicate roots at config time

That was my first instinct, and it is what `build_libraries` already does for a duplicate `arr_prefix` — whose comment calls this class of problem "a real #161 multi-instance footgun".

It is wrong here. Invalid library config is handled **fail-soft**, by falling back to the single default library. So raising would silently **delete the user's second library** rather than fix it. The ambiguity is logged once per root instead, because the tie-break is a reasonable guess and not a truth: from the path alone these libraries are genuinely indistinguishable.

## Two things worth knowing about the tests

**The round-trip test does not catch this.** `canonical -> fs -> canonical` is self-consistent even when wrong, so it passes happily. Only a direct assertion on the expected string catches it. That is a test that reads like coverage and is not.

**The second candidate mechanism is pinned as a characterization test**, asserting *current* behaviour rather than correct behaviour, and saying so in the docstring. `strip_arr_prefix` passes an unmatched arr path through as a library-0 canonical, which produces the same wrong-canonical shape by a different route and fits the reporter's exact string slightly better. It is left unchanged pending their configuration, since turning that silent pass-through into an error could break installs working today. If it ever changes, that should be a decision rather than an accident.

## Status

⚠️ This fixes a mechanism I **reproduced**, but I have not yet confirmed it is the one that bit the reporter. I have asked for their two filesystem roots; if those differ, mechanism two is the likelier culprit and will need separate work.

**1953 passed, 6 skipped**; `ruff check` and `ruff format --check` clean.