### PR TITLE
fix(#485): a forced sidecar is not full subtitle coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes.
 
 ## [Unreleased]
 
+### Fixed
+- **subarr counted its own forced subtitles as full coverage (#485).** A `.en.forced.srt` sidecar next to a video was read as English coverage, so Coverage under-reported the gap and the manual queue refused the file with "An English subtitle already exists on disk". This is a closed loop rather than a corner case: subarr's own forced-segment feature writes exactly those files, and the previous release made that the default naming. So subarr produced a forced sidecar, counted it as coverage, and then declined to produce the full subtitle you actually wanted. Forced sidecars no longer count, in either naming order, matching how subarr has always treated forced tracks embedded in the video. Verified against 3,820 real subtitle filenames from a live library with no change to any other result.
+
 ## [2.6.0] - 2026-09-01
 
 **Image subtitles are fillable, and our own setup docs were losing your data.**

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -533,6 +533,21 @@ def _langs_in_sidecars(sidecars: list[str]) -> set[str]:
         "syn",
     }
 
+    # [#485] A FORCED sidecar is not full coverage. subarr already treats
+    # embedded forced tracks this way (has_usable_embedded_english excludes
+    # them, coverage reports EN(forced), #79 built forced_only_subgen_will_skip
+    # around it) but sidecars never got the same rule, so `<stem>.en.forced.srt`
+    # counted as English coverage.
+    #
+    # That is a closed loop rather than a theoretical gap: subarr's own #364
+    # WRITES `.en.forced.srt`, and #475 made that the default naming. So subarr
+    # produced a forced sidecar, counted it as coverage, and then refused to
+    # queue the full transcription the user actually wanted.
+    #
+    # Same bug fixed on the subgen side in subarr-subgen v4.24, reported
+    # upstream as McCloudS/subgen#358.
+    from .forced_segment import _FORCED_TOKEN
+
     langs: set[str] = set()
     for p in sidecars:
         name = p.rsplit("/", 1)[-1].lower()
@@ -541,6 +556,11 @@ def _langs_in_sidecars(sidecars: list[str]) -> set[str]:
         # Strip .srt, then split on dots AND hyphens to extract every
         # potential lang-shaped token regardless of separator style.
         tokens = re.split(r"[.\-]", name[:-4])
+        # Checked against TOKENS, never as a substring: a real episode in the
+        # test library is titled "Forced Labour", and a substring test would
+        # silently stop counting its subtitles.
+        if _FORCED_TOKEN in tokens:
+            continue
         found_lang = None
         for tok in reversed(tokens):
             if 2 <= len(tok) <= 3 and tok.isalpha():

--- a/tests/test_forced_sidecar_not_coverage.py
+++ b/tests/test_forced_sidecar_not_coverage.py
@@ -1,0 +1,94 @@
+"""A forced sidecar is not full subtitle coverage.
+
+subarr handles this meticulously for EMBEDDED tracks: `has_usable_embedded_english`
+excludes forced, coverage reports `EN(forced)`, and #79 built a whole
+`forced_only_subgen_will_skip` machinery around it. Sidecars were never given the
+same treatment. `_langs_in_sidecars` returned `en` for `<stem>.en.forced.srt`,
+so a forced sidecar counted as full English coverage.
+
+⚠️ It is a CLOSED LOOP, and #475 made it likely rather than theoretical. subarr's
+own forced-segment feature (#364) WRITES `.en.forced.srt`, and #475 made that the
+default naming two days ago. So subarr writes a forced sidecar, then counts it as
+English coverage, then refuses to queue the full transcription the user wanted:
+
+    "An English subtitle already exists on disk -- not queued
+     (subgen would skip it)."
+
+Same conceptual bug fixed on the subgen side in coaxk/subarr-subgen v4.24 and
+reported upstream as McCloudS/subgen#358. This is the subarr half of it.
+
+⚠️ The parser is otherwise healthy and was NOT the problem. Run over 3,820 real
+sidecar filenames from a live library it produced 3,612 `en`, correct
+`da`/`fi`/`no`/`sv`, 13 `und` and no false positives. Only the forced dimension
+was missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from subarr.coverage_engine import _langs_in_sidecars
+
+
+class TestForcedSidecarsAreNotCoverage:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Show - S01E01 - Title.en.forced.srt",  # what subarr writes since #475
+            "Show - S01E01 - Title.forced.en.srt",  # what it wrote before #475
+            "Show - S01E01 - Title.eng.forced.srt",  # 3-letter code
+            "Show - S01E01 - Title.en.forced.alass.srt",  # re-synced by a tool
+            "Show - S01E01 - Title.EN.FORCED.srt",  # case
+        ],
+    )
+    def test_a_forced_sidecar_contributes_no_language(self, name):
+        # Not 'und' either: it is not an unknown language, it is a known
+        # language in a form that does not constitute coverage. Returning 'und'
+        # would leak into the "only sidecar is untagged" branch downstream.
+        assert _langs_in_sidecars([name]) == set()
+
+    def test_a_full_sidecar_still_counts(self):
+        assert _langs_in_sidecars(["Show - S01E01 - Title.en.srt"]) == {"en"}
+
+    def test_a_full_sidecar_beside_a_forced_one_still_counts(self):
+        # The common real state once #364 has run: both exist. The full one is
+        # coverage; the forced one must not mask it or add noise.
+        got = _langs_in_sidecars(
+            [
+                "Show - S01E01 - Title.en.srt",
+                "Show - S01E01 - Title.en.forced.srt",
+            ]
+        )
+        assert got == {"en"}
+
+    def test_a_forced_sidecar_in_another_language_is_also_excluded(self):
+        assert _langs_in_sidecars(["Show - S01E01 - Title.de.forced.srt"]) == set()
+
+    def test_a_title_containing_the_word_forced_is_not_affected(self):
+        # ⚠️ The reason this checks TOKENS and not a substring. A real episode
+        # in the test library is literally titled "Forced Labour"; a naive
+        # `"forced" in name` would silently stop counting its subtitles.
+        assert _langs_in_sidecars(["A French Village - S05E01 - Forced Labour WEBDL-1080p -SbR.en.srt"]) == {
+            "en"
+        }
+
+
+class TestUnchangedBehaviour:
+    """The parser was healthy apart from the forced dimension. These pin the
+    shapes measured across 3,820 real filenames so the fix cannot regress them."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("The Roots Of Evil - S01E03 - TBA WEBDL-1080p -GER.en.srt", {"en"}),
+            ("The Roots Of Evil - S01E03 - TBA WEBDL-1080p -GER.en.alass.srt", {"en"}),
+            ("The Halcyon - S01E02 - Episode 2 WEBDL-1080p -DKV.da.srt", {"da"}),
+            ("The Halcyon - S01E05 - Episode 5 WEBDL-1080p -DKV.no.alass.srt", {"no"}),
+            ("Show - S01E01 - Title.srt", {"und"}),
+        ],
+    )
+    def test_real_world_names_parse_as_before(self, name, expected):
+        assert _langs_in_sidecars([name]) == expected
+
+    def test_a_non_srt_is_still_ignored(self):
+        assert _langs_in_sidecars(["Show - S01E01 - Title.en.ass"]) == set()


### PR DESCRIPTION
Found while investigating #485. ⚠️ **It is probably not #485's cause** (see below), but it is a real bug and a closed loop we are actively shipping into.

## The bug

`_langs_in_sidecars` returned `en` for `<stem>.en.forced.srt`, so a forced sidecar counted as full English coverage. Coverage under-reported the gap, and the manual queue refused the file with:

> An English subtitle already exists on disk — not queued (subgen would skip it).

subarr already handles this correctly for **embedded** tracks: `has_usable_embedded_english` excludes forced, coverage reports `EN(forced)`, and #79 built the entire `forced_only_subgen_will_skip` machinery around it. Sidecars never got the same rule.

## Why it is a closed loop rather than a corner case

subarr's own forced-segment feature (#364) **writes** `.en.forced.srt`, and #475 made that the default naming two days ago.

So subarr produces a forced sidecar, counts it as coverage, and then declines to produce the full subtitle the user wanted. Same conceptual bug fixed on the subgen side as v4.24 and reported upstream as McCloudS/subgen#358; this is the subarr half of it.

## Matched on tokens, not substring

A real episode in the test library is literally titled **"Forced Labour"**. A naive `"forced" in name` would silently stop counting its subtitles. There is a test for exactly that case.

Reuses `_FORCED_TOKEN` from `forced_segment` rather than adding a third spelling of "forced" to drift against.

## The parser was NOT the problem, which is worth recording

It was my leading suspect for #485, and clearing it took real evidence rather than reading. Run over **3,820 real sidecar filenames** from a live library:

| verdict | count |
|---|---|
| `en` | 3,612 |
| `da` / `fi` / `no` / `sv` | 78 / 39 / 39 / 39 |
| `und` | 13 |

No false positives, and **the distribution is byte-identical after this change**. Only the forced dimension was missing.

That also means this is unlikely to be #485's cause: that reporter has no `.srt` sidecars at all, and their episode title parses as `und`, not `en`. #485 stays open pending their directory listing.

## Verification

- End to end on the actual guard: `_file_has_target_sub` now returns `False` for a forced-only sidecar and still `True` when a full sub is present.
- 15 new tests covering both naming orders, 3-letter codes, tool suffixes, case, the mixed forced-plus-full case, and the "Forced Labour" title.
- **1968 passed, 6 skipped**; `ruff check` and `ruff format --check` clean.