### PR TITLE
security: stop shipping pip in the runtime image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,16 @@
 *.bundle.js.map text eol=lf
 src/subarr/static/v1/**/*.html text eol=lf
 
+# Every shell script here is executed on Linux: docker-entrypoint.sh is COPYd
+# into the image, deploy/scripts/install.sh is run by users, the rest are
+# dev/ops helpers run under WSL. A Windows checkout with core.autocrlf=true
+# rewrites them to CRLF, which turns the shebang into `#!/bin/sh\r` and makes
+# the kernel look for an interpreter that does not exist. The image then dies
+# with `exec /usr/local/bin/docker-entrypoint.sh: no such file or directory`,
+# naming the script rather than the cause. CI checks out LF so it never sees
+# this; only local builds break. Same reasoning as the .githooks pin below.
+*.sh text eol=lf
+
 # Git hooks are POSIX sh — pin to LF so a CRLF shebang (#!/bin/sh\r) can't
 # break execution on Linux/macOS (incl. CI clones).
 .githooks/* text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes.
 
 ## [Unreleased]
 
+### Security
+- **The published image no longer ships pip.** Nothing in a running subarr container installs packages, so pip was only ever needed while the image was being built, but it stayed in the finished image carrying six published advisories. The most serious of them lets a malicious package overwrite files outside its install directory during an install. It was invisible to the patching already in place: the build refreshes Debian packages every time, and pip is not a Debian package here, so that refresh could never see it. Upgrading pip does not fix it either, because pip carries its own dependencies bundled inside itself and every release to date pins a version of one of them with its own unfixed advisory, so an upgrade trades six findings for two. pip is now removed once it has finished installing subarr, which clears all six and introduces none. Verified by scanning the published image, an upgrade-only build and this one. The application itself is completely unchanged.
+
 ## [2.6.1] - 2026-09-03
 
 **Multi-library and multi-Sonarr setups could act on the wrong file.**

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,26 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 PIP_NO_CACHE_DIR=1
 # fixed in +deb13u3 while the cached layer still had u2). CI passes the current
 # UTC date, so this layer expires once a day and every scan + published image
 # gets current packages. Referenced in the RUN so the value actually busts it.
+#
+# The trailing `pip install --upgrade pip` is BUILD-TIME hygiene, not a
+# shipped-image fix (pip is deleted again after the app install below). The
+# `apt-get upgrade` above structurally CANNOT reach it: python:3.12-slim
+# installs pip into /usr/local/lib/python3.12/site-packages via get-pip, so no
+# Debian package owns it (`dpkg -S` on that path finds no match) and apt has
+# nothing to upgrade. Debian's own python3-pip is 25.1.1 anyway, below the
+# 26.2.0 floor. Several of the pip CVEs are wheel-install path traversals
+# (CVE-2026-8643 lets a malicious entry point name overwrite arbitrary files),
+# and installing wheels from PyPI is exactly what the next layer does, so the
+# build runs under a patched resolver. Unpinned on purpose, same reasoning as
+# `apt-get upgrade -y`: a pin goes stale and re-opens the class. It rides the
+# APT_REFRESH layer so it inherits the daily cache-bust.
 ARG APT_REFRESH=0
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg mkvtoolnix passwd util-linux \
     && apt-get upgrade -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir --upgrade pip
 
 WORKDIR /app
 
@@ -49,7 +63,24 @@ COPY src/ ./src/
 # onnxruntime/numpy pair as [vad], listed separately so it can diverge later).
 # The small silero-lang95 model is NOT baked; pulled + checksum-verified lazily
 # on first forced-segment scan, same opt-in pattern as [vad]'s silero VAD model.
-RUN pip install --no-cache-dir ".[vad,qe-onnx,lid]"
+# Nothing in a running subarr container installs packages: the entrypoint is
+# shell, the healthcheck and CMD are `python`. So pip is build-time-only, and
+# shipping it is pure attack surface plus a permanent CVE feed. Deleting it
+# beats upgrading it, because upgrading CANNOT win: pip carries its
+# dependencies vendored, `pip/_vendor/vendor.txt` pins setuptools==70.3.0 in
+# every version to date, and CVE-2025-47273 against it is not fixed until
+# setuptools 78.1.1. pip 26.2.1 also ships a licenses/ tree that makes those
+# vendored pins visible to trivy for the first time, so merely upgrading
+# TRADED six pip CVEs for two fixable HIGHs (setuptools + msgpack) and turned
+# the trivy gate red. Measured, not assumed: trivy on the published image, an
+# upgrade-only build and this one gave 6 / 3 / 0 pip-family findings, with
+# fixable HIGH/CRITICAL at 0 / 2 / 0.
+# ensurepip is cleared too, or `python -m ensurepip` restores pip 25.0.1 from
+# the wheel bundled in the stdlib — the ORIGINAL vulnerable version, which
+# trivy never flagged because it does not scan inside .whl files.
+RUN pip install --no-cache-dir ".[vad,qe-onnx,lid]" \
+    && pip uninstall -y pip \
+    && rm -rf /usr/local/lib/python3.12/ensurepip/_bundled
 
 # #237: non-root runtime. Create a default subarr user/group (1000:1000,
 # overridable at runtime via PUID/PGID by the entrypoint). HF_HOME moves the QE


### PR DESCRIPTION
Closes the last of the open Trivy alerts on this repo, and fixes a latent build defect found on the way.

`security-drift` has been red for **72 consecutive days** (last green 2026-06-23, 72 failures against 10 successes). It was correct the whole time. Three open HIGH alerts: six pip CVEs collapsed into one Trivy finding, plus two CodeQL findings that are being triaged separately.

## Why the release pipeline stayed green

`security.yml` has passed throughout. The two gates read different severities for the same CVE:

- the trivy **table** step filters on Trivy's own vendor severity, which is `MEDIUM` for CVE-2026-8643, so the gate never fired
- the **SARIF** step scans at all severities (the `severity` filter does not propagate, as that workflow's own comment notes), so every pip CVE reached code scanning, where GitHub re-buckets by CVSS to `high` and `security-drift` sees it

## Why apt never caught it

The image already runs `apt-get upgrade -y` specifically to patch base-image CVEs. It could not possibly have covered this one: `python:3.12-slim` installs pip into `site-packages` via get-pip, so no Debian package owns it and `dpkg -S` on that path finds no match. Debian's own `python3-pip` is 25.1.1 anyway, below the 26.2.0 floor these six need.

## Why removal and not an upgrade

I tried the upgrade first and scanned the result rather than trusting it. pip vendors its dependencies, and `pip/_vendor/vendor.txt` pins `setuptools==70.3.0` in every release to date while CVE-2025-47273 against setuptools is not fixed until 78.1.1. pip 26.2.1 also ships a `licenses/` tree that exposes those vendored pins to Trivy for the first time.

| variant | total vulns | fixable HIGH/CRITICAL | pip-family |
|---|---|---|---|
| published image (pip 25.0.1) | 630 | 0 | 6 |
| upgrade only (pip 26.2.1) | 627 | **2, gate red** | 3 |
| pip removed (this PR) | 624 | **0** | **0** |

So an upgrade alone would have traded six findings for two and broken the trivy gate. No pip version can pass it.

Nothing in a running container installs packages: the entrypoint is shell, the healthcheck and CMD are `python`. pip is therefore build-time-only. It is now upgraded for build-time wheel-install safety, then removed once it has installed subarr. `ensurepip/_bundled` goes too, or `python -m ensurepip` would restore pip 25.0.1 from the stdlib wheel, which Trivy never flagged because it does not scan inside wheels.

## Second commit: shell scripts pinned to LF

Found because the container would not start at all locally. All six tracked `.sh` files are stored LF, but a Windows checkout with `core.autocrlf=true` rewrites them to CRLF, turning every shebang into one the kernel cannot resolve. The image then dies with

```
exec /usr/local/bin/docker-entrypoint.sh: no such file or directory
```

which names the script rather than the cause. `deploy/scripts/install.sh` is run directly by users and has the same defect. CI checks out LF so it never sees this, and published images have always been fine. `.gitattributes` already pins `.githooks/*` for exactly this reason; this extends it to `*.sh`.

## Verification

- built the image, ran it, Docker health status reaches `healthy`
- `GET /api/health` returns 200
- `onnxruntime`, `numpy`, `tokenizers`, `huggingface_hub` all import, so `[vad,qe-onnx,lid]` is intact
- pip confirmed absent, `ensurepip/_bundled` gone
- entrypoint logs `starting as subarr (1000:1000)`, so the privilege drop still runs
- before the LF pin the same build exited immediately with the error above

Application behaviour is unchanged.
