### PR TITLE
perf: stop the ollama health probe fetching /api/tags twice per poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ breaking config changes.
 ### Security
 - **The published image no longer ships pip.** Nothing in a running subarr container installs packages, so pip was only ever needed while the image was being built, but it stayed in the finished image carrying six published advisories. The most serious of them lets a malicious package overwrite files outside its install directory during an install. It was invisible to the patching already in place: the build refreshes Debian packages every time, and pip is not a Debian package here, so that refresh could never see it. Upgrading pip does not fix it either, because pip carries its own dependencies bundled inside itself and every release to date pins a version of one of them with its own unfixed advisory, so an upgrade trades six findings for two. pip is now removed once it has finished installing subarr, which clears all six and introduces none. Verified by scanning the published image, an upgrade-only build and this one. The application itself is completely unchanged.
 
+### Fixed
+- **The Settings page asked Ollama for the same model list twice on every refresh.** The integrations health check reads your installed models for the status panel, then worked out which vision model to use by asking Ollama for that exact list a second time. That page refreshes every 8 seconds, so it was a permanently doubled request rate for data it was already holding. It now reuses what it just fetched. Nothing you see changes, and it still notices a model you pull outside subarr.
+
 ## [2.6.1] - 2026-09-03
 
 **Multi-library and multi-Sonarr setups could act on the wrong file.**

--- a/src/subarr/integrations/ollama.py
+++ b/src/subarr/integrations/ollama.py
@@ -201,7 +201,7 @@ class OllamaClient:
         models = data.get("models", []) if isinstance(data, dict) else []
         return [m.get("name", "") for m in models if isinstance(m, dict)]
 
-    async def resolve_vision_model(self) -> str | None:
+    async def resolve_vision_model(self, installed: list[str] | None = None) -> str | None:
         """#232: figure out which vision-capable model to use right now.
 
         Logic:
@@ -216,13 +216,21 @@ class OllamaClient:
              state, the text model would hallucinate.
 
         Result is cached on the instance until reset_vision_cache() is
-        called (Settings save / model pull completion clears it)."""
+        called (Settings save / model pull completion clears it).
+
+        `installed` lets a caller that has ALREADY fetched /api/tags hand the
+        model names in rather than making us fetch the identical payload a
+        second time. The integrations-health probe does exactly that: it reads
+        the model list for its badges, resets this cache so an externally
+        pulled model is noticed, and would otherwise re-GET /api/tags on every
+        poll for data it is already holding."""
         if self._vision_model_resolved is not None:
             return self._vision_model_resolved or None
         if not self._configured:
             self._vision_model_resolved = ""
             return None
-        installed = await self.installed_models()
+        if installed is None:
+            installed = await self.installed_models()
         if not installed:
             self._vision_model_resolved = ""
             return None

--- a/src/subarr/routers/integrations.py
+++ b/src/subarr/routers/integrations.py
@@ -219,8 +219,14 @@ async def _probe(name: str, client, summary_kind: str = "version") -> dict[str, 
             # panel can show "Vision pre-filter active / inactive" with
             # the resolved model name, instead of users discovering it
             # only when a vision call fails.
+            # Reset so a model pulled outside subarr is picked up, then hand
+            # resolve_vision_model the names from the tags call above. Without
+            # that argument it re-GETs /api/tags for the same payload, which at
+            # the Settings page's 8s poll doubled the request rate forever.
             client.reset_vision_cache()
-            vision_resolved = await client.resolve_vision_model()
+            vision_resolved = await client.resolve_vision_model(
+                installed=[m.get("name", "") for m in models if isinstance(m, dict)]
+            )
             return {
                 "name": name,
                 "online": True,

--- a/tests/test_integrations_health_probe.py
+++ b/tests/test_integrations_health_probe.py
@@ -6,9 +6,11 @@ fire-and-forget fix.
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from subarr.integrations import IntegrationError
+from subarr.integrations.ollama import OllamaClient
 from subarr.routers.integrations import _probe
 
 
@@ -84,3 +86,42 @@ async def test_both_fail_marks_offline_no_dangling_task():
         "bazarr_badges",
     )
     assert out["online"] is False
+
+
+# The ollama probe must cost ONE /api/tags per poll, not two.
+
+
+@pytest.mark.asyncio
+async def test_ollama_probe_fetches_tags_once():
+    """The ollama probe used to GET /api/tags TWICE on every poll: once for the
+    model list, then it reset the vision cache and called resolve_vision_model(),
+    which re-fetched the identical payload through installed_models(). The
+    Settings page polls this every 8s, so that is a doubled request forever for
+    data already in hand. The resolution itself must still work, hence the
+    vision_model_resolved assertion below."""
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path == "/api/tags":
+            return httpx.Response(
+                200,
+                json={"models": [{"name": "qwen2.5vl:7b"}, {"name": "qwen2.5:7b"}]},
+            )
+        if request.url.path == "/api/version":
+            return httpx.Response(200, json={"version": "0.33.3"})
+        return httpx.Response(404)
+
+    c = OllamaClient(base_url="http://ollama.test", model="qwen2.5:7b", vision_model="auto")
+    c._configured = True
+    c._client = httpx.AsyncClient(base_url="http://ollama.test", transport=httpx.MockTransport(handler))
+
+    out = await _probe("ollama", c, "ollama_models")
+
+    assert out["online"] is True
+    assert out["badges"]["models"] == 2
+    assert out["badges"]["vision_model_resolved"] == "qwen2.5vl:7b"
+    assert calls.count("/api/tags") == 1, "expected 1 /api/tags per probe, got %d: %r" % (
+        calls.count("/api/tags"),
+        calls,
+    )


### PR DESCRIPTION
Spotted from the ollama side: `subarr-next` was hitting `/api/tags` far more often than the poll interval alone explains. It is not one call per poll, it is two.

## The defect

```python
tags = await client.tags()          # call #1, already contains the model list
client.reset_vision_cache()         # clears the cache that exists to prevent this
vision_resolved = await client.resolve_vision_model()
    -> installed_models() -> self.tags()   # call #2, identical payload
```

`reset_vision_cache()`'s own docstring says it is for "Settings save + model-pull completion". The health probe is neither, so it invalidated the cache on every poll and the resolver re-fetched what the probe was already holding. Settings polls every 8s, so the cost per poll was 2x `/api/tags` plus 1x `/api/version`, indefinitely.

## The fix

`resolve_vision_model()` takes an optional `installed` list; the probe passes the names it just derived from its own `tags()` call.

Behaviour is deliberately unchanged in both directions:

- the cache is **still** reset each poll, so a model pulled outside subarr is still picked up within one refresh
- any caller passing nothing fetches exactly as before, which is why the existing `test_vision_capability.py` suite needed no edits at all

Simply dropping the `reset_vision_cache()` call would have been a smaller diff but would have stopped noticing externally pulled models, so it was rejected.

## Verification

The test pins the cost and the behaviour together, so neither can regress on its own: it asserts exactly one `GET /api/tags` **and** that the vision model still resolves.

Confirmed red before the fix, for the right reason:

```
AssertionError: expected 1 /api/tags per probe, got 2:
['/api/tags', '/api/tags', '/api/version']
```

- affected tests: 28 passed (new test plus the whole existing vision suite)
- full suite: **1985 passed, 6 skipped**
- `ruff check` and `ruff format --check` clean
