### PR TITLE
fix: the onboarding STEP_* constants had silently drifted out of the wizard

### DIFF
--- a/src/subarr/onboarding.py
+++ b/src/subarr/onboarding.py
@@ -21,9 +21,9 @@ Design choices:
 
 - **Step numbering** is a contiguous resume cursor 0..MAX_STEP. The wizard
   frontend owns the rendering and the exact step list; the backend only tracks
-  the integer and clamps it. Two steps are frontend-only and not separately
-  numbered here (subgen-setup, and the #378 "More stacks" pointer), so the
-  named STEP_* constants below are documentation, not a 1:1 index map.
+  the integer and clamps it. The named STEP_* constants mirror that list
+  exactly and a test parses the frontend array to keep them honest, because
+  they silently drifted twice when steps were inserted mid-list.
 """
 
 from __future__ import annotations
@@ -39,24 +39,33 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
-# Canonical step indices — keep in sync with frontend.
+# Canonical step indices — a true 1:1 map of the frontend STEPS array in
+# static/v1/home-hifi/onboarding.jsx, guarded by
+# tests/test_onboarding.py::test_step_constants_match_frontend_steps, which
+# parses that array rather than trusting a copy of it.
+#
+# These drifted twice before that guard existed. #231 inserted subgen-setup and
+# #384 inserted stacks, and every constant after each insertion point silently
+# became wrong. Nothing broke at runtime, because only MAX_STEP and STEP_DONE
+# are actually read, so the error stayed invisible until the #480 telemetry cut
+# tried to name the step an install had stopped on. A stale index there does not
+# fail, it answers confidently and wrongly about which screen loses users.
 STEP_WELCOME = 0
 STEP_MEDIA = 1
 STEP_BAZARR = 2
 STEP_SONARR = 3
 STEP_RADARR = 4
-STEP_TAUTULLI = 5
-STEP_SUBGEN = 6
-STEP_OLLAMA = 7
-STEP_GPU = 8
-STEP_SPEECH = 9  # #111 — speech-aware audio (silero VAD) opt-in
-STEP_FIRST_WALK = 10
-# #378 Phase 5: the wizard gained the optional frontend-only "More stacks" step,
-# so the last reachable frontend index is now 12. Two frontend-only steps are
-# interspersed among the named constants below (subgen-setup after STEP_SUBGEN,
-# stacks after STEP_RADARR), so those names are documentation, not a 1:1 index
-# map — only MAX_STEP and STEP_DONE are read at runtime. STEP_DONE is the resume
-# cursor's resting index after completion = the final step index.
+STEP_STACKS = 5  # #384 — optional pointer to Settings ▸ Instances
+STEP_TAUTULLI = 6
+STEP_SUBGEN = 7
+STEP_SUBGEN_SETUP = 8  # #231 — guided hardware-matched model setup
+STEP_OLLAMA = 9
+STEP_GPU = 10
+STEP_SPEECH = 11  # #111 — speech-aware audio (silero VAD) opt-in
+STEP_FIRST_WALK = 12
+
+# The resume cursor's resting index after completion = the final step index,
+# hence equal to STEP_FIRST_WALK.
 STEP_DONE = 12
 
 # Maximum step value the API accepts. STEP_DONE marks completion.

--- a/src/subarr/telemetry.py
+++ b/src/subarr/telemetry.py
@@ -448,7 +448,14 @@ class TelemetryCollector:
 
 
 def _onboarding_step(app_state) -> int | None:
-    """#202: coarse furthest/current onboarding step (0-11). Best-effort."""
+    """#202: coarse furthest/current onboarding step (0..MAX_STEP, currently 0-12). Best-effort.
+
+    The range moves whenever the wizard gains a step, and has twice: the
+    stored integer means a different screen before and after each
+    insertion. Any analysis of this field has to bucket by subarr_version
+    first, so do not treat the numbers as comparable across releases.
+    See onboarding.STEP_* and the frontend-parity test beside them.
+    """
     try:
         return int(app_state.onboarding.get().step)
     except Exception:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -25,6 +25,17 @@ from subarr.onboarding import (
     MAX_STEP,
     STEP_BAZARR,
     STEP_DONE,
+    STEP_FIRST_WALK,
+    STEP_GPU,
+    STEP_MEDIA,
+    STEP_OLLAMA,
+    STEP_RADARR,
+    STEP_SONARR,
+    STEP_SPEECH,
+    STEP_STACKS,
+    STEP_SUBGEN,
+    STEP_SUBGEN_SETUP,
+    STEP_TAUTULLI,
     STEP_WELCOME,
     OnboardingStore,
 )
@@ -198,3 +209,61 @@ def test_probe_paths_not_a_directory(tmp_path: Path):
     r = probe_paths(ProbePathsRequest(media_root=str(f)), _MockRequest())
     assert r["ok"] is False
     assert "not a directory" in r["error"]
+
+
+# ─── STEP_* constants must match the frontend wizard ────────────────
+
+
+def test_step_constants_match_frontend_steps():
+    """The backend STEP_* names are only meaningful if they index the same
+    list the wizard renders. They drifted twice without anyone noticing:
+    #231 inserted subgen-setup and #384 inserted stacks, and every constant
+    after the insertion point silently became wrong. That is invisible at
+    runtime, because only MAX_STEP and STEP_DONE are read, so it surfaced
+    only when the #480 telemetry cut tried to name the step an install had
+    stopped on and got a confident wrong answer.
+
+    Parsing the JSX is deliberate: the frontend STEPS array is the authority
+    on numbering, so the test has to read it rather than a copy of it."""
+    import re
+
+    jsx = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "subarr"
+        / "static"
+        / "v1"
+        / "home-hifi"
+        / "onboarding.jsx"
+    )
+    src = jsx.read_text(encoding="utf-8")
+    block = re.search(r"const STEPS = \[(.*?)\n\];", src, re.S)
+    assert block, "could not find the STEPS array in onboarding.jsx"
+    ids = re.findall(r"id: '([a-z-]+)'", block.group(1))
+    assert ids, "parsed no step ids out of STEPS"
+
+    index = {name: i for i, name in enumerate(ids)}
+    expected = {
+        "welcome": STEP_WELCOME,
+        "paths": STEP_MEDIA,
+        "bazarr": STEP_BAZARR,
+        "sonarr": STEP_SONARR,
+        "radarr": STEP_RADARR,
+        "stacks": STEP_STACKS,
+        "tautulli": STEP_TAUTULLI,
+        "subgen": STEP_SUBGEN,
+        "subgen-setup": STEP_SUBGEN_SETUP,
+        "ollama": STEP_OLLAMA,
+        "gpu": STEP_GPU,
+        "speech": STEP_SPEECH,
+        "walk": STEP_FIRST_WALK,
+    }
+    for step_id, constant in expected.items():
+        assert step_id in index, f"{step_id} vanished from the frontend STEPS"
+        assert index[step_id] == constant, (
+            f"{step_id}: frontend index {index[step_id]} != constant {constant}"
+        )
+
+    # STEP_DONE is the resting cursor after completion = the last index.
+    assert STEP_DONE == len(ids) - 1
+    assert MAX_STEP == STEP_DONE


### PR DESCRIPTION
Found while running the #480 onboarding funnel cut, which was deliberately held until the step numbering could be verified. It could not be: six of the thirteen constants pointed at the wrong screen.

## What drifted

`#231` inserted `subgen-setup` and `#384` inserted `stacks`, both **mid-list**, so every constant after each insertion point shifted:

| constant | was | should be |
|---|---|---|
| `STEP_TAUTULLI` | 5 | **6** |
| `STEP_SUBGEN` | 6 | **7** |
| `STEP_OLLAMA` | 7 | **9** |
| `STEP_GPU` | 8 | **10** |
| `STEP_SPEECH` | 9 | **11** |
| `STEP_FIRST_WALK` | 10 | **12** |

`STEP_WELCOME`, `STEP_MEDIA`, `STEP_BAZARR`, `STEP_SONARR`, `STEP_RADARR` and `STEP_DONE` were unaffected, which is why the existing tests using them kept passing.

## Why it survived

Only `MAX_STEP` and `STEP_DONE` are read at runtime, so the wrong values sat there inert. The file had even noticed, describing the names as "documentation, not a 1:1 index map" — an accurate description of the defect rather than a fix for it.

It surfaced only when #480 tried to name the step an install had stopped on. A stale index there does not fail; it answers **confidently and wrongly** about which wizard screen loses users. That is the whole reason #480 was held.

## The fix

Constants corrected, and the two unnamed steps added as `STEP_STACKS` and `STEP_SUBGEN_SETUP`, so the map is genuinely 1:1.

The part that matters is the guard. `test_step_constants_match_frontend_steps` parses the `STEPS` array straight out of `onboarding.jsx` and asserts every constant against it. It reads the frontend rather than a copy, because the frontend owns the numbering and a copy would drift exactly the same way.

**Negative-tested rather than assumed:** reverting `STEP_OLLAMA` to its stale value 7 fails with `assert 9 == 7`; restoring it passes. A guard nobody has watched fail is not a guard.

## Also

`_onboarding_step`'s docstring claimed `0-11`. The range has been 0-10, then 0-11, now 0-12. It now states that the bound moves and that any analysis of the field must bucket by `subarr_version` first, since the same integer names a different screen across releases.

The matching stale comment in the telemetry worker is fixed in coaxk/subarr-telemetry#52. No data was lost there: its validation bounds at 99, not 11, so step 12 was always stored.

## Verification

- full suite **1986 passed, 6 skipped** (one more than baseline: the new test)
- `ruff check` and `ruff format --check` clean
