### PR TITLE
fix(review): order pending results by media type and title

### DIFF
--- a/src/subarr/routers/audio_lang.py
+++ b/src/subarr/routers/audio_lang.py
@@ -10,6 +10,7 @@ GET  /api/audio-lang/pending-review?search=&limit=&offset= — coverage rows nee
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -777,6 +778,10 @@ async def pending_review(
     }
     if flag_filter != "all":
         pending = [p for p in pending if p.get("flag") == flag_filter]
+    # Sort the fully-classified, searched, filtered set into the authoritative
+    # Review order (TV first, then movies; titles case-insensitively alphabetical)
+    # immediately before slicing so page membership is deterministic (see helper).
+    pending = _sort_pending_review_rows(pending)
     total = len(pending)
     return {
         "count": total,
@@ -798,6 +803,44 @@ def _matches_pending_search(row: dict[str, Any], needle: str) -> bool:
         f"{(row.get('file_canonical_path') or row.get('canonical_path') or '')}"
     ).lower()
     return needle in hay
+
+
+def _sort_pending_review_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return `rows` in the authoritative Review ordering WITHOUT mutating any row.
+
+    Page membership must not depend on coverage-snapshot traversal order: that
+    order is itself non-deterministic across snapshots, so relying on a stable
+    sort against the CURRENT input order cannot fix page membership. The client
+    (review.jsx) only reorders rows within an already-fetched page — grouping by
+    title, splitting TV Shows vs Movies, numeric episode sort, and sinking
+    auto-multilingual rows last — so it cannot repair page membership either.
+    This helper therefore establishes an authoritative total order BEFORE the
+    offset/limit slice:
+
+      1. Media rank first: `media_type == "movie"` (rank 1) sorts AFTER every
+         other value — missing/None, "episode", "show", "series", and any
+         unknown/legacy value are all rank 0 and treated as TV, mirroring the
+         review.jsx TV/movie split (`g.media_type !== 'movie'` → TV Shows). Only
+         one TV bucket exists; no third category is introduced.
+      2. Title, compared case-insensitively via Unicode-safe `str.casefold()`.
+      3. Deterministic row identity (`file_canonical_path`, falling back to
+         `canonical_path`) breaks normalized-title ties. When both paths are
+         empty (practically impossible on real snapshot rows), a canonical JSON
+         fingerprint of the row provides a stable, orderable final fallback, so
+         equal-titled rows can never reorder on snapshot traversal.
+    """
+
+    def sort_key(row: dict[str, Any]) -> tuple[Any, ...]:
+        identity = row.get("file_canonical_path") or row.get("canonical_path") or ""
+        if not identity:
+            identity = json.dumps(row, sort_keys=True, default=str)
+        return (
+            0 if row.get("media_type") != "movie" else 1,
+            (row.get("title") or "").casefold(),
+            identity,
+        )
+
+    return sorted(rows, key=sort_key)
 
 
 # ─── v1.2 Layer 3: robust Whisper detection (subarr-subgen v4.5+) ───

--- a/tests/test_pending_review_pagination.py
+++ b/tests/test_pending_review_pagination.py
@@ -91,3 +91,127 @@ def test_default_request_still_works_for_existing_callers(app_with_stub):
     body = app_with_stub.get(PENDING).json()
     assert body["count"] == 450
     assert 0 < len(body["items"]) <= 450
+
+
+# ── Server-side Review ordering (#448/#449 follow-on) regressions ───────────
+# Phase 2 pins down `_sort_pending_review_rows` in audio_lang.py: media rank
+# (only media_type == "movie" is rank 1/last; every missing / episode / show /
+# legacy / unknown value is TV), case-insensitive casefold title order, and a
+# deterministic canonical-identity tie-break that ignores snapshot traversal.
+
+
+def _review_item(title, media_type, path):
+    """A suspect snapshot item -> exactly one pending Review row. `media_type`
+    None omits the key (models 'missing/unknown'); 'movie' sorts after every
+    TV-ish value. `path` is both the file and canonical identity."""
+    item = {
+        "file_canonical_path": path,
+        "canonical_path": path,
+        "title": title,
+        "audio_label_suspect": True,
+    }
+    if media_type is not None:
+        item["media_type"] = media_type
+    return item
+
+
+def test_mixed_media_and_case_insensitive_title_ordering(app_with_stub):
+    # TV/episode plus missing/legacy-media rows all sort BEFORE movies, and
+    # titles are alphabetical case-insensitively within each bucket — even when
+    # the snapshot traversal order is deliberately unsorted (movies interleaved
+    # with TV, titles out of order, mixed case).
+    rows = [
+        _review_item("mango", "movie", "Movies/mango.mkv"),
+        _review_item("Zulu", "episode", "TV/Ep/Zulu.mkv"),
+        _review_item("Hotel", "movie", "Movies/Hotel.mkv"),
+        _review_item("India", "movie", "Movies/India.mkv"),
+        _review_item("apple", "episode", "TV/Ep/apple.mkv"),
+        _review_item("Bravo", "show", "TV/Show/Bravo.mkv"),
+        _review_item("echo", "series", "TV/Legacy/echo.mkv"),  # legacy media value
+        _review_item("Delta", None, "TV/Season/Delta.mkv"),  # missing media_type
+    ]
+    app_with_stub.app.state.coverage_cache = _SnapCache(rows)
+
+    items = app_with_stub.get(PENDING, params={"limit": 100, "offset": 0}).json()["items"]
+    got = [it["canonical_path"] for it in items]
+    assert got == [
+        # TV bucket (rank 0) first — casefold-alphabetical:
+        "TV/Ep/apple.mkv",  # lowercase 'a' sorts before uppercase-leading titles
+        "TV/Show/Bravo.mkv",
+        "TV/Season/Delta.mkv",  # missing media_type -> TV
+        "TV/Legacy/echo.mkv",  # legacy "series" value -> TV
+        "TV/Ep/Zulu.mkv",
+        # then all movies (rank 1), casefold-alphabetical:
+        "Movies/Hotel.mkv",
+        "Movies/India.mkv",
+        "Movies/mango.mkv",
+    ]
+    # Explicit case-insensitivity proofs (raw ASCII ordering would differ):
+    # 'Z'(90) < 'a'(97), so a case-sensitive sort would place Zulu before apple…
+    assert got.index("TV/Ep/apple.mkv") < got.index("TV/Ep/Zulu.mkv")
+    # …and a lowercase-leading title must not sink behind uppercase-leading ones.
+    assert got.index("TV/Ep/apple.mkv") == 0
+    # Media rank beats title: movie "Hotel" still trails every TV row incl. "Zulu".
+    assert got.index("TV/Ep/Zulu.mkv") < got.index("Movies/Hotel.mkv")
+
+
+def test_equal_titles_break_deterministically_by_canonical_identity(app_with_stub):
+    # Rows that normalize to the SAME title ("the show") must order by canonical
+    # identity ascending — never by snapshot traversal order. The traversal is
+    # seeded in the OPPOSITE (descending-identity) order to prove the tie-break
+    # (not the input order) decides; a synthetic row with a None file path
+    # exercises the canonical_path fallback.
+    rows = [
+        _review_item("THE SHOW", None, "ZZZ.mkv"),
+        {
+            # Bazarr-synthetic: file_canonical_path is None, keyed only on canonical.
+            "file_canonical_path": None,
+            "canonical_path": "MMM.mkv",
+            "title": "The Show",
+            "audio_label_suspect": True,
+        },
+        _review_item("the show", None, "AAA.mkv"),
+    ]
+    app_with_stub.app.state.coverage_cache = _SnapCache(rows)
+
+    items = app_with_stub.get(PENDING, params={"limit": 100, "offset": 0}).json()["items"]
+    got = [it["canonical_path"] for it in items]
+    # Identities ascend AAA.mkv < MMM.mkv < ZZZ.mkv, independent of the ZZZ/MMM/AAA
+    # traversal order above.
+    assert got == ["AAA.mkv", "MMM.mkv", "ZZZ.mkv"]
+    assert got != ["ZZZ.mkv", "MMM.mkv", "AAA.mkv"], "must not follow snapshot order"
+
+
+def test_server_side_order_is_stable_across_small_pages(app_with_stub):
+    # The authoritative order must be applied BEFORE offset/limit slicing, so
+    # page membership is deterministic: paging a mixed set in small pages and
+    # concatenating must reproduce the full sorted order (disjoint + exhaustive).
+    tv_titles = ["apple", "Bravo", "Charlie", "delta", "EchoEp", "foxtrot", "GolfShow", "hotel"]
+    mv_titles = [
+        "AppleMovie",
+        "bananaMovie",
+        "CherryMovie",
+        "deltaMovie",
+        "EchoMovie",
+        "figMovie",
+        "GrapeMovie",
+        "honeyMovie",
+    ]
+    tv_rows = [
+        _review_item(t, {1: "show", 3: None, 5: "series"}.get(i, "episode"), f"TV/{t}.mkv")
+        for i, t in enumerate(tv_titles)
+    ]
+    mv_rows = [_review_item(t, "movie", f"Movies/{t}.mkv") for t in mv_titles]
+    # Traversal deliberately unsorted: movies (which must sort last) are fed
+    # first and the TV rows are reversed, so input order is nowhere near output.
+    rows = mv_rows + list(reversed(tv_rows))
+    app_with_stub.app.state.coverage_cache = _SnapCache(rows)
+
+    expected = [f"TV/{t}.mkv" for t in tv_titles] + [f"Movies/{m}.mkv" for m in mv_titles]
+    seen: list[str] = []
+    for off in range(0, len(expected), 4):
+        page = app_with_stub.get(PENDING, params={"limit": 4, "offset": off}).json()["items"]
+        seen += [it["canonical_path"] for it in page]
+    assert seen == expected
+    assert len(seen) == len(expected)
+    assert len(set(seen)) == len(expected), "no row duplicated or skipped across pages"


### PR DESCRIPTION
## What changed
- Sort pending Review rows server-side before limit/offset slicing.
- Order TV/episode/unknown/legacy media before movies, then case-insensitively by title.
- Use canonical identity as a deterministic tie-breaker.
- Add regression coverage for mixed media, title ordering, deterministic ties, and pagination consistency.

## Why
Review rows previously retained coverage-snapshot traversal order, so paginated results could have inconsistent media/title ordering.

## Testing
- `pytest -q`
- `npm run test:frontend`
- `python -m compileall -q src/subarr`
- `ruff format --check src/subarr/routers/audio_lang.py tests/test_pending_review_pagination.py`
- `ruff check src/subarr/routers/audio_lang.py tests/test_pending_review_pagination.py` (pre-existing S110 findings only in unchanged code)

## Migration impact
None. Existing response shape, schema, pagination semantics, filters, and actions are unchanged.

## Compat-mode impact
None.

## Telemetry impact
None.

## Screenshots
Not applicable; no frontend source changed.

## Scope
Group-vs-file limiting/count semantics remain intentionally deferred to a separate follow-up PR. No generated frontend bundles or source maps were needed.