### PR TITLE
fix: compat-mode diagnostics sent the operator to the wrong place

### DIFF
--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -235,12 +235,22 @@ class CompletionWatcher:
         caps = self._caps_provider()
         if caps is not None and caps.reachable and not caps.has_queue:
             if not self._warned_no_queue:
+                # A missing /queue means the running CODE is vanilla, which is
+                # NOT the same as "the image is vanilla" -- and saying the
+                # latter sends the operator looking in the wrong place. See
+                # coaxk/subarr-subgen#59, where subarr-subgen was pulled
+                # correctly and UPDATE=True made its launcher download vanilla
+                # subgen.py over our patched one at every start.
                 log.warning(
                     "completion watcher: subgen has no /queue endpoint "
-                    "(compat mode — vanilla subgen). %d pending provenance "
-                    "entries won't auto-complete via queue polling. "
-                    "File-watch fallback is v1.x; for now, restart subgen "
-                    "or use subarr-subgen image for auto-completion.",
+                    "(compat mode). %d pending provenance entries won't "
+                    "auto-complete via queue polling. Either subgen is the "
+                    "vanilla upstream image, or it IS subarr-subgen but is "
+                    "running vanilla code because UPDATE / LAUNCHER_UPDATE / "
+                    "BRANCH made its launcher re-download subgen.py over the "
+                    "patched one (subarr-subgen#59; fixed in image "
+                    "2026.08.1-r7, and unsetting those vars fixes it on any "
+                    "build). File-watch fallback is v1.x.",
                     len(pending),
                 )
                 self._warned_no_queue = True

--- a/src/subarr/scan_runner.py
+++ b/src/subarr/scan_runner.py
@@ -157,6 +157,11 @@ class ScanRunner:
                 "Scan submission requires the /batch endpoint, which "
                 "vanilla mccloud/subgen doesn't ship. Switch to "
                 "ghcr.io/coaxk/subarr-subgen for full functionality. "
+                "If you are ALREADY on that image, check the subgen "
+                "container for UPDATE / LAUNCHER_UPDATE / BRANCH: upstream's "
+                "launcher re-downloads subgen.py over the patched one at "
+                "startup, so the image is right and the running code is not "
+                "(subarr-subgen#59). "
                 "See docs at https://github.com/coaxk/subarr#compat-mode"
             )
 


### PR DESCRIPTION
Companion to coaxk/subarr-subgen#60. Fixes the diagnostic half of coaxk/subarr-subgen#59.

## What was wrong

subarr infers "vanilla subgen" from a 404 on `/queue`. What that actually tells us is that the running **code** is vanilla, which is not the same thing as the **image** being vanilla. Both compat-mode messages asserted the latter.

In subarr-subgen#59 the reporter had pulled `ghcr.io/coaxk/subarr-subgen` correctly and kept `UPDATE=True` from their previous upstream compose file. Upstream's launcher re-downloads `subgen.py` from McCloudS/subgen at every container start, so the image was right and the running code was vanilla.

The advice subarr gave them was:

> for now, restart subgen or use subarr-subgen image for auto-completion.

They were already using the subarr-subgen image, and restarting made it worse, because every restart re-ran the download. We sent them away from the answer.

## What changed

Both messages now name the second cause and the environment variables that produce it:

- `completion_watcher` compat-mode warning
- `scan_runner`'s `CompatModeError` for the missing `/batch` endpoint

Nothing about detection changes. `caps.reachable` stays `True` and this is still correctly classified as compat mode, so **this is unrelated to the "subgen unreachable" measurement in #479** — that bucket counts instances subarr cannot reach at all, and these are reachable.

## Why not detect it properly

I looked at having subarr compare the container's `subarr.subgen.patch_rev` OCI label against the runtime capability, which would let it say "your image says patched, your running code says vanilla" directly. Decided against it for now:

- it needs docker socket access, which not every install has
- there is no cheap universal discriminator otherwise, since vanilla and patched `/status` responses are indistinguishable

The message is the fix that works for everyone. Worth revisiting if this recurs in a form the message does not cover.

## Testing

- `pytest tests/ -k "completion_watcher or scan_runner or compat"` -> 19 passed
- `ruff format --check` and `ruff check` clean on both files
- No test pinned the previous wording, so nothing needed updating

## Migration impact

None. Log and error text only.

## Compat-mode impact

None functionally. The compat-mode path is unchanged; only what it says about itself.

## Telemetry impact

None.
