### PR TITLE
fix(#498): stop discarding a user-verified English audio language

### DIFF
--- a/src/subarr/audio_lang_store.py
+++ b/src/subarr/audio_lang_store.py
@@ -492,6 +492,7 @@ def resolve_audio_language_override(
     *,
     caller: str = "queue",
     log: "logging.Logger | None" = None,
+    skip_audio_languages: "tuple[str, ...] | list[str] | None" = None,
 ) -> str | None:
     """Look up the user-verified audio language for `canonical` and
     decide whether to forward it to subgen as audio_language_override.
@@ -500,11 +501,16 @@ def resolve_audio_language_override(
     verification passes the evidence gate, else None. (#358: was 3-letter;
     subgen parses the override via LanguageCode.from_string which accepts any
     form, so the 2-letter canonical the store now holds is forwarded as-is.)
-    None means "let subgen detect from audio" — never returns an English code
-    because subgen's default SKIP_IF_AUDIO_LANGUAGES=eng makes it redundant.
+    None means "let subgen detect from audio".
+
+    `skip_audio_languages` is the connected subgen's effective
+    SKIP_IF_AUDIO_LANGUAGES list (subarr-subgen v4.28+ advertises it on /queue).
+    None means the build does not advertise it, i.e. we cannot tell.
 
     Evidence gate (#105):
-      - lang missing or 'en'/'eng' → no override (no point)
+      - lang missing → no override
+      - lang is English → forwarded ONLY when we can see subgen does not skip
+        English audio; withheld when it does, and withheld when unknown (#498)
       - source field empty → REFUSE (corrupt store entry)
       - confidence < 0.5 → REFUSE (likely Tautulli-signal-only guess)
       - else → forward, with structured log at INFO
@@ -547,8 +553,45 @@ def resolve_audio_language_override(
     src = (verification.source or "").strip().lower()
     conf = float(getattr(verification, "confidence", 0.0) or 0.0)
 
-    if not lang or lang in ("en", "eng"):
+    if not lang:
         return None
+
+    # #498: English is special, and not for the reason the old guard implied.
+    # subgen's audio_language_override SUBSTITUTES the declared language into the
+    # skip check rather than bypassing it:
+    #
+    #     if audio_language_override is not None:
+    #         audio_langs = [audio_language_override]
+    #     ...
+    #     if any(lang in skip_audio_languages for lang in audio_langs):
+    #         return True   # skip
+    #
+    # So forwarding 'en' to an install running SKIP_IF_AUDIO_LANGUAGES=eng puts
+    # the file ON the skip list, which is the opposite of what the user who
+    # verified it wanted. It was therefore excluded outright, at the cost of
+    # silently discarding that verification on installs that skip nothing.
+    #
+    # Forward it only when we can SEE that the connected subgen will not skip it
+    # (subarr-subgen v4.28+ advertises the effective list via /queue). Unknown
+    # means withhold: guessing wrong in that direction stops transcription
+    # silently, which is far worse than merely failing to start it.
+    #
+    # Deliberately scoped to English. A verified non-English language is
+    # forwarded exactly as before even when subgen would skip it, because
+    # changing that alters behaviour well beyond the reported bug.
+    if lang in ("en", "eng"):
+        if skip_audio_languages is None:
+            return None
+        skips = {str(code).strip().lower() for code in skip_audio_languages}
+        if skips & {"en", "eng"}:
+            _log.info(
+                "%s: no override for %s — verified English, but this subgen skips "
+                "English audio (%s), so declaring it would skip the file",
+                caller,
+                scrub(canonical),
+                sorted(skips & {"en", "eng"}),
+            )
+            return None
 
     if not src:
         _log.warning(

--- a/src/subarr/routers/aftercare.py
+++ b/src/subarr/routers/aftercare.py
@@ -164,7 +164,16 @@ async def regenerate(result_id: int, request: Request) -> dict[str, Any]:
     except PathOutsideRootError:
         raise HTTPException(400, detail="media file is outside the media root")
     audio_language_override = resolve_audio_language_override(
-        getattr(request.app.state, "audio_lang", None), canonical, caller="regenerate", log=log
+        getattr(request.app.state, "audio_lang", None),
+        canonical,
+        caller="regenerate",
+        log=log,
+        # [#498] Let the resolver see whether this subgen would skip the
+        # language it is about to declare. None on builds that do not
+        # advertise it, which the resolver treats as 'cannot tell'.
+        skip_audio_languages=getattr(
+            getattr(request.app.state, "subgen_caps", None), "skip_audio_languages", None
+        ),
     )
     pending = request.app.state.pending_queue
     job = pending.enqueue(canonical, source="manual", audio_language_override=audio_language_override)

--- a/src/subarr/routers/coverage_actions.py
+++ b/src/subarr/routers/coverage_actions.py
@@ -175,6 +175,12 @@ async def coverage_queue(req: CoverageQueueRequest, request: Request) -> dict:
         canonical,
         caller="coverage_queue",
         log=log,
+        # [#498] Let the resolver see whether this subgen would skip the
+        # language it is about to declare. None on builds that do not
+        # advertise it, which the resolver treats as 'cannot tell'.
+        skip_audio_languages=getattr(
+            getattr(request.app.state, "subgen_caps", None), "skip_audio_languages", None
+        ),
     )
 
     # #66/#116 slice 6: route through the pending queue (throttled), instead of

--- a/src/subarr/routers/queue.py
+++ b/src/subarr/routers/queue.py
@@ -595,6 +595,12 @@ async def requeue(req: RequeueRequest, request: Request) -> dict:
         canonical,
         caller="requeue",
         log=log,
+        # [#498] Let the resolver see whether this subgen would skip the
+        # language it is about to declare. None on builds that do not
+        # advertise it, which the resolver treats as 'cannot tell'.
+        skip_audio_languages=getattr(
+            getattr(request.app.state, "subgen_caps", None), "skip_audio_languages", None
+        ),
     )
     # #169: route through the pending queue like manual submit. enqueue carries
     # the #229 audio_language_override on the row; the feeder applies it at

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -129,8 +129,11 @@ class SubgenCapabilities:
     has_queue: bool
     has_batch: bool
     is_subarr_subgen: bool
-    # v4.3 capability: POST /batch accepts audio_language_override query
-    # param that bypasses SKIP_IF_AUDIO_LANGUAGES + seeds Whisper source.
+    # v4.3 capability: POST /batch accepts an audio_language_override query
+    # param. NOTE it SUBSTITUTES the declared language into the
+    # SKIP_IF_AUDIO_LANGUAGES check rather than bypassing it (#498), so
+    # declaring a language subgen skips will SKIP the file. It also seeds
+    # the Whisper source language.
     # Detected via the /queue response's capabilities.audio_language_override
     # flag (only the v4.3+ patch ships it). Vanilla and v4.2 → False.
     audio_language_override: bool = False
@@ -223,6 +226,13 @@ class SubgenCapabilities:
     # gate on (see subgen_capacity). None on older subgen that doesn't publish
     # it → the gate stays disabled (dormant-safe).
     concurrent_transcriptions: int | None = None
+    # [#498] The connected subgen's effective SKIP_IF_AUDIO_LANGUAGES list as
+    # 2-letter ISO-639-1 codes (subarr-subgen v4.28+). None means the build
+    # does not advertise it, which is NOT the same as an empty list: empty
+    # means 'skips nothing', None means 'cannot tell'. The override resolver
+    # relies on that distinction to decide whether forwarding a verified
+    # English value would skip the file rather than transcribe it.
+    skip_audio_languages: tuple[str, ...] | None = None
     # v4.15 capability (#317 Slice B): subgen honours a per-REQUEST
     # ignore_forced flag on POST /batch (overrides the global
     # IGNORE_FORCED_SUBTITLES for one job). subarr gates its "transcribe a full
@@ -261,6 +271,7 @@ class SubgenCapabilities:
             "subarr_subgen_patch_rev": self.subarr_subgen_patch_rev,
             "release_tag": self.release_tag,
             "concurrent_transcriptions": self.concurrent_transcriptions,
+            "skip_audio_languages": self.skip_audio_languages,
             "request_ignore_forced": self.request_ignore_forced,
             "probe_failure": self.probe_failure,
         }
@@ -433,6 +444,7 @@ class SubgenClient:
         bypass_skip = False
         runtime_config = False
         concurrent_transcriptions: int | None = None
+        skip_audio_languages: tuple[str, ...] | None = None
         request_ignore_forced = False
         patch_rev: str | None = None
         release_tag: str | None = None
@@ -478,6 +490,15 @@ class SubgenClient:
                                 if isinstance(_ct, int) and not isinstance(_ct, bool) and _ct > 0
                                 else None
                             )
+                            # [#498] Absent on pre-v4.28 builds, and absent must
+                            # stay None rather than becoming () -- () would read
+                            # as 'this subgen skips nothing', which is exactly the
+                            # optimistic guess that silently stops transcription.
+                            _sal = caps_block.get("skip_audio_languages")
+                            if isinstance(_sal, list):
+                                skip_audio_languages = tuple(
+                                    str(c).strip().lower() for c in _sal if isinstance(c, str) and c.strip()
+                                )
                 except ValueError:
                     pass
         except httpx.HTTPError:
@@ -492,6 +513,7 @@ class SubgenClient:
             reachable=True,
             version=version,
             has_queue=has_queue,
+            skip_audio_languages=skip_audio_languages,
             has_batch=has_batch,
             is_subarr_subgen=is_subarr_subgen,
             audio_language_override=audio_language_override,

--- a/tests/test_audio_lang_override_english_498.py
+++ b/tests/test_audio_lang_override_english_498.py
@@ -1,0 +1,104 @@
+"""#498: a user-verified ENGLISH audio language must reach subgen when doing so
+cannot cause a skip.
+
+Background, because the mechanism is counter-intuitive: subgen's
+`audio_language_override` SUBSTITUTES the declared language into the skip check
+rather than bypassing it:
+
+    if audio_language_override is not None:
+        audio_langs = [audio_language_override]
+    ...
+    if any(lang in skip_audio_languages for lang in audio_langs):
+        return True   # skip
+
+So forwarding `en` to an install running SKIP_IF_AUDIO_LANGUAGES=eng makes the
+file SKIP, the opposite of what the verifying user wanted. That is why English
+was excluded outright. The cost was that installs which skip nothing silently
+discarded a verification the user had explicitly made.
+
+subarr can now see the effective list (subarr-subgen patch 0048 advertises it),
+so the exclusion becomes conditional rather than absolute.
+"""
+
+from __future__ import annotations
+
+
+def _store(tmp_path):
+    from subarr.audio_lang_store import AudioLangStore
+    from subarr.migrate import run_migrations
+
+    db = tmp_path / "subarr.db"
+    run_migrations(db)
+    return AudioLangStore(db)
+
+
+def _verified_en(tmp_path):
+    s = _store(tmp_path)
+    s.upsert(canonical_path="e.mkv", lang_code="en", source="user", confidence=1.0)
+    return s
+
+
+def test_english_forwarded_when_subgen_skips_nothing(tmp_path):
+    """The reported case: no English skip configured, so declaring `en` cannot
+    cause a skip and it seeds the Whisper source language instead."""
+    from subarr.audio_lang_store import resolve_audio_language_override
+
+    s = _verified_en(tmp_path)
+    assert resolve_audio_language_override(s, "e.mkv", skip_audio_languages=()) == "en"
+
+
+def test_english_withheld_when_subgen_skips_english(tmp_path):
+    """The regression this fix must not cause. Forwarding `en` here would put the
+    file ON the skip list, so it stays withheld."""
+    from subarr.audio_lang_store import resolve_audio_language_override
+
+    s = _verified_en(tmp_path)
+    assert resolve_audio_language_override(s, "e.mkv", skip_audio_languages=("en",)) is None
+
+
+def test_english_withheld_when_capability_absent(tmp_path):
+    """Older subgen does not advertise the list. Unknown must mean the
+    pre-#498 behaviour, never an optimistic guess: guessing wrong here silently
+    stops transcription rather than merely failing to start it."""
+    from subarr.audio_lang_store import resolve_audio_language_override
+
+    s = _verified_en(tmp_path)
+    assert resolve_audio_language_override(s, "e.mkv", skip_audio_languages=None) is None
+    # And the default argument must behave the same as an explicit None.
+    assert resolve_audio_language_override(s, "e.mkv") is None
+
+
+def test_non_english_is_unaffected_by_the_skip_list(tmp_path):
+    """Deliberately scoped. A verified non-English language is forwarded exactly
+    as before, even when subgen would skip it, because changing that would alter
+    behaviour well beyond the reported bug. Pinned so the scoping is a decision
+    rather than an accident."""
+    from subarr.audio_lang_store import resolve_audio_language_override
+
+    s = _store(tmp_path)
+    s.upsert(canonical_path="j.mkv", lang_code="ja", source="user", confidence=1.0)
+    assert resolve_audio_language_override(s, "j.mkv", skip_audio_languages=("ja",)) == "ja"
+    assert resolve_audio_language_override(s, "j.mkv", skip_audio_languages=()) == "ja"
+    assert resolve_audio_language_override(s, "j.mkv") == "ja"
+
+
+def test_english_still_gated_by_the_evidence_rules(tmp_path):
+    """Relaxing the English exclusion must not weaken the #105 evidence gate: a
+    low-confidence English verification is still refused even with no skip list."""
+    from subarr.audio_lang_store import resolve_audio_language_override
+
+    s = _store(tmp_path)
+    s.upsert(canonical_path="w.mkv", lang_code="en", source="tautulli", confidence=0.2)
+    assert resolve_audio_language_override(s, "w.mkv", skip_audio_languages=()) is None
+
+
+def test_eng_three_letter_form_also_honoured(tmp_path):
+    """The store normalises to 2-letter, but the guard historically matched both
+    forms. Whichever the store yields, an English verification must be treated
+    consistently against the skip list."""
+    from subarr.audio_lang_store import resolve_audio_language_override
+
+    s = _store(tmp_path)
+    s.upsert(canonical_path="x.mkv", lang_code="eng", source="user", confidence=1.0)
+    assert resolve_audio_language_override(s, "x.mkv", skip_audio_languages=("en",)) is None
+    assert resolve_audio_language_override(s, "x.mkv", skip_audio_languages=()) == "en"


### PR DESCRIPTION
Closes #498. Reported by @IdahoRC with the root cause already traced to `resolve_audio_language_override()`. Pairs with coaxk/subarr-subgen#62.

## The bug

A file with no audio-language metadata, verified by the user as English (`source='user'`, `confidence=1.0`), had that verification silently thrown away because the helper treated `en`/`eng` as "no override".

## Why the one-line fix was not safe

The exclusion was not arbitrary. subgen's `audio_language_override` **substitutes** the declared language into the skip check rather than bypassing it:

```python
if audio_language_override is not None:
    audio_langs = [audio_language_override]
...
if any(lang in skip_audio_languages for lang in audio_langs):
    return True   # skip
```

Forwarding `en` to an install running `SKIP_IF_AUDIO_LANGUAGES=eng` puts the file **on** the skip list. The reporter's fix works because they do not set that; applied unconditionally it would have silently stopped transcription on every install using the recommended config, including the reference deployment.

## What this does instead

Makes the exclusion conditional. subarr reads the effective skip list that subarr-subgen v4.28 advertises on `/queue`, and forwards a verified English value only when it can see the file will not then be skipped.

| verification | subgen | result |
|---|---|---|
| `en` | skips nothing | **forward** (the reported bug, fixed) |
| `en` | skips English | withhold (no regression) |
| `en` | capability absent | withhold (unchanged) |
| non-English | anything | entirely unchanged |

`None` and `()` are deliberately different and the distinction is load-bearing: empty means "skips nothing", `None` means "cannot tell". Collapsing them into a falsy check is the optimistic guess, and guessing wrong there stops transcription silently rather than merely failing to start it.

Scoped to English on purpose, pinned by a test: a verified non-English language is still forwarded even when subgen would skip it, because changing that reaches well beyond the reported bug.

## Also

Corrects an inherited comment in `subgen_client.py` that repeated subgen's own false claim that the override bypasses `SKIP_IF_AUDIO_LANGUAGES`. It never did, and that wording is exactly what led the reporter to conclude the mechanism was safe for English. The subgen-side log line is fixed in the paired PR.

## Merge order

Safe to merge ahead of the subgen release. Until a subgen that advertises the capability is deployed the list reads `None` everywhere and behaviour is byte-for-byte what it is today. The fix activates when r8 ships.

## Testing

Tests written first and confirmed red for the right reason (`TypeError: unexpected keyword argument`), then implemented. Six new cases covering forward, withhold-on-skip, withhold-on-unknown, default-equals-None, non-English unchanged, evidence gate still enforced, and the 3-letter form.

```
208 passed, 1793 deselected in 200.19s
```

Includes the pre-existing `test_override_still_skips_english`, which still passes because the default path is unchanged.

## Migration / compat / telemetry impact

None, none, and none.