### PR TITLE
fix(#497): require an exact file match before attaching a movie probe

### DIFF
--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -961,6 +961,23 @@ def _attach_probe_movie(
     if not item.canonical_path:
         return
     candidates = idx.get(item.canonical_path) or []
+    # [#497] The index is keyed by the movie DIRECTORY, so a renamed or replaced
+    # movie can leave a probe entry for the OLD file sitting beside the current
+    # one. Taking candidates[0] unconditionally could therefore attach the old
+    # file's audio and subtitle facts to this row and mark it verified.
+    #
+    # Where the row already knows its own file, require the probe to be for that
+    # file. The Radarr construction path sets file_canonical_path explicitly; the
+    # Bazarr-wanted path does not, and with nothing to match against the first
+    # candidate still wins exactly as before. This is the movie-side parity of
+    # the filename filter the episode path has always had.
+    #
+    # Filtered BEFORE the emptiness check on purpose: a probe of a different file
+    # must leave the row unprobed (so it can be probed properly) rather than
+    # verified against the wrong data, while a genuinely recorded probe FAILURE
+    # still surfaces as probe_failed.
+    if item.file_canonical_path:
+        candidates = [c for c in candidates if c[0] == item.file_canonical_path]
     if not candidates:
         if (failed_idx or {}).get(item.canonical_path):
             item.verification_state = "probe_failed"

--- a/tests/test_probe_movie_exact_match_497.py
+++ b/tests/test_probe_movie_exact_match_497.py
@@ -1,0 +1,102 @@
+"""#497: a movie row must not inherit ffprobe data from a DIFFERENT file.
+
+`_attach_probe_movie()` looked up candidates by the movie's canonical directory
+and took `candidates[0]` unconditionally. When a movie has been renamed or
+replaced and a probe entry for the old file still sits under the same prefix,
+the row could be marked `verified` carrying the old file's audio/subtitle facts.
+
+Reported by IdahoRC from a live Unraid deployment.
+
+The episode path already filters candidates by filename; movies did not. Where
+the row knows its own file (the Radarr construction path sets
+`file_canonical_path` explicitly), that knowledge is now used.
+"""
+
+from __future__ import annotations
+
+
+def _probe(path, langs=None):
+    from subarr.media_probe import ProbeResult
+
+    return ProbeResult(canonical_path=path)
+
+
+def _movie(canonical="Movies/M (2024)", file_canonical=None):
+    from subarr.coverage_engine import CoverageItem
+
+    return CoverageItem(
+        media_type="movie",
+        title="M",
+        canonical_path=canonical,
+        file_canonical_path=file_canonical,
+    )
+
+
+CANON = "Movies/M (2024)"
+CURRENT = "Movies/M (2024)/M (2024) Remux.mkv"
+STALE = "Movies/M (2024)/M (2024) OLD 720p.mkv"
+
+
+def test_stale_candidate_is_not_attached_when_the_row_knows_its_file():
+    """The reported case. The stale entry sorts first, so `candidates[0]` would
+    attach the wrong file's probe."""
+    from subarr.coverage_engine import _attach_probe_movie
+
+    item = _movie(file_canonical=CURRENT)
+    idx = {CANON: [(STALE, _probe(STALE)), (CURRENT, _probe(CURRENT))]}
+    _attach_probe_movie(item, idx, failed_idx={})
+
+    assert item.file_canonical_path == CURRENT, "must not be repointed at the stale file"
+    assert item.verification_state == "verified"
+
+
+def test_row_is_left_unprobed_when_no_candidate_matches_its_file():
+    """Only the old file has been probed. Attaching it would describe a file that
+    is no longer there, so the row stays unprobed and can be probed properly."""
+    from subarr.coverage_engine import _attach_probe_movie
+
+    item = _movie(file_canonical=CURRENT)
+    idx = {CANON: [(STALE, _probe(STALE))]}
+    _attach_probe_movie(item, idx, failed_idx={})
+
+    assert item.file_canonical_path == CURRENT, "must keep its own file path"
+    assert item.verification_state == "unprobed", (
+        "a probe for a different file must not mark this row verified"
+    )
+
+
+def test_unchanged_when_the_row_does_not_know_its_file():
+    """The Bazarr-wanted construction path does not set file_canonical_path.
+    With nothing to match against, the first candidate still wins exactly as
+    before, so this fix does not change that path."""
+    from subarr.coverage_engine import _attach_probe_movie
+
+    item = _movie(file_canonical=None)
+    idx = {CANON: [(STALE, _probe(STALE)), (CURRENT, _probe(CURRENT))]}
+    _attach_probe_movie(item, idx, failed_idx={})
+
+    assert item.file_canonical_path == STALE
+    assert item.verification_state == "verified"
+
+
+def test_single_matching_candidate_still_verifies():
+    """The ordinary case must keep working: one probe, and it is this file."""
+    from subarr.coverage_engine import _attach_probe_movie
+
+    item = _movie(file_canonical=CURRENT)
+    idx = {CANON: [(CURRENT, _probe(CURRENT))]}
+    _attach_probe_movie(item, idx, failed_idx={})
+
+    assert item.file_canonical_path == CURRENT
+    assert item.verification_state == "verified"
+
+
+def test_probe_failed_still_reported_for_a_known_file():
+    """A recorded probe FAILURE is a different state from a mismatched probe and
+    must still surface, otherwise the row silently reads unprobed forever."""
+    from subarr.coverage_engine import _attach_probe_movie
+
+    item = _movie(file_canonical=CURRENT)
+    _attach_probe_movie(item, {}, failed_idx={CANON: [CURRENT]})
+
+    assert item.verification_state == "probe_failed"


### PR DESCRIPTION
Closes #497. Reported by @IdahoRC from a live Unraid deployment, with the root cause already traced to `_attach_probe_movie()`.

## The bug

The probe index is keyed by the movie **directory**, and the function took `candidates[0]` unconditionally:

```python
candidates = idx.get(item.canonical_path) or []
...
file_canonical, probe = candidates[0]
item.file_canonical_path = file_canonical
```

When a movie has been renamed or replaced and a probe entry for the old file still sits under the same prefix, the row could be marked `verified` while carrying the **old file's** audio and subtitle facts.

The episode path has always filtered candidates by filename. Movies never did. This is that parity.

## The fix

Where the row already knows its own file, the probe must be for that file.

- The **Radarr** construction path sets `file_canonical_path` explicitly (its own comment says "parity: lets eager-probe ffprobe the file") and now gets an exact match.
- The **Bazarr-wanted** path does not set it, and with nothing to match against the first candidate still wins exactly as before, so that path is untouched.

Filtered **before** the emptiness check deliberately: a probe of a different file now leaves the row `unprobed`, so it can be probed properly, rather than `verified` against the wrong data. A genuinely recorded probe **failure** still surfaces as `probe_failed` — those are different states and conflating them would hide the failure.

## Testing

Tests written first. The two that demonstrate the bug failed; the three asserting unchanged behaviour passed from the start, which is what shows the fix is surgical rather than broad.

```
329 passed, 1680 deselected in 195.15s
```

## Migration / compat / telemetry impact

None, none, and none. Rows that were being verified against a stale probe will now read `unprobed` until the correct file is probed, which is the intended correction.