### PR TITLE
fix(#499): score the sidecar subgen wrote, not an arbitrary sibling .srt

### DIFF
--- a/src/subarr/completion_watcher.py
+++ b/src/subarr/completion_watcher.py
@@ -41,6 +41,57 @@ from .subtitle_retime import retime_srt
 
 log = logging.getLogger(__name__)
 
+
+def choose_srt_sidecar(stem: str, names: list[str]) -> str | None:
+    """Pick which sibling .srt is the one subgen just wrote, from `names`.
+
+    [#499] This used to be "prefer <stem>.en.srt, else the first glob hit".
+    Both halves were wrong in practice:
+
+    - Subgen can embed its own name and the model into the filename
+      (SHOW_IN_SUBNAME_SUBGEN / SHOW_IN_SUBNAME_MODEL), producing
+      `<stem>.subgen.large-v3.eng.srt`. That is not `<stem>.en.srt`, so the
+      real output fell through to the fallback.
+    - The fallback was glob order, i.e. filesystem order. With any other
+      sibling present, which file got scored was effectively arbitrary. The
+      reporter measured aftercare grading a stale 763-cue file while subgen's
+      actual 1,317-cue output sat beside it.
+
+    Ranking, best first:
+      0. the exact `<stem>.en.srt` (unchanged; what most installs produce)
+      1. carries subgen's marker AND an English tag (`.en.` or `.eng.`)
+      2. carries subgen's marker, language unknown
+      3. any other sibling
+      4. a `.forced.` sidecar, which subarr writes itself (#364) and which is a
+         handful of foreign-dialogue cues, never a full transcript
+
+    Ties break on the sorted name so the answer never depends on the order the
+    filesystem happened to return.
+    """
+    prefix = f"{stem}."
+    siblings = [n for n in names if n.startswith(prefix) and n.lower().endswith(".srt")]
+    if not siblings:
+        return None
+
+    exact = f"{stem}.en.srt"
+    if exact in siblings:
+        return exact
+
+    def rank(name: str) -> tuple[int, str]:
+        tail = name[len(stem) :].lower()
+        if ".forced." in tail:
+            return (4, name)
+        subgen = ".subgen." in tail or tail.startswith(".subgen.")
+        english = ".en." in tail or ".eng." in tail
+        if subgen and english:
+            return (1, name)
+        if subgen:
+            return (2, name)
+        return (3, name)
+
+    return min(siblings, key=rank)
+
+
 WATCHER_INTERVAL_S = 30
 # Bazarr task IDs vary across versions. Discovered at runtime by matching
 # both job_id AND name fields. Hint order = priority: first match wins.
@@ -525,9 +576,8 @@ class CompletionWatcher:
             log.warning("forced-segment at-import scan failed for %s: %s", canonical_path, e)
 
     def _find_srt_sidecar(self, video_canonical: str) -> str | None:
-        """Locate the .srt subgen wrote next to the video. Subgen's default
-        naming is <basename>.en.srt; fall back to any .srt sharing the
-        basename if the language tag differs."""
+        """Locate the .srt subgen wrote next to the video. See
+        choose_srt_sidecar() for the ranking and why it is not just a glob."""
         try:
             # #134: library-aware resolve (@slug/ heads).
             full = canonical_to_fs(video_canonical)
@@ -537,17 +587,12 @@ class CompletionWatcher:
             return None
         stem = full.stem
         parent = full.parent
-        # Preferred: <stem>.en.srt
-        candidate = parent / f"{stem}.en.srt"
-        if candidate.exists():
-            return str(candidate)
-        # Fallback: any sibling .srt sharing the stem
         try:
-            for p in parent.glob(f"{stem}*.srt"):
-                return str(p)
+            names = [p.name for p in parent.glob(f"{stem}*.srt")]
         except OSError:
-            pass
-        return None
+            return None
+        chosen = choose_srt_sidecar(stem, names)
+        return str(parent / chosen) if chosen else None
 
     async def _trigger_bazarr_scan(self, ledger_id: int, series_id: int, canonical_path: str) -> None:
         bz = self._bazarr_for(canonical_path)

--- a/tests/test_srt_sidecar_choice_499.py
+++ b/tests/test_srt_sidecar_choice_499.py
@@ -1,0 +1,82 @@
+"""#499: aftercare must evaluate the sidecar SUBGEN wrote, not an arbitrary
+sibling .srt.
+
+The selector preferred `<stem>.en.srt` and otherwise took the first result of
+`parent.glob(f"{stem}*.srt")`. Two problems:
+
+  1. Subgen can be configured to embed its own name and the model into the
+     filename (SHOW_IN_SUBNAME_SUBGEN / SHOW_IN_SUBNAME_MODEL), producing
+     `<stem>.subgen.large-v3.eng.srt`. That does not match `<stem>.en.srt`, so
+     selection fell through to the generic fallback.
+  2. The fallback is glob order, which is filesystem-dependent. With any other
+     sibling .srt present, which file got evaluated was effectively arbitrary.
+
+Reported by IdahoRC, who measured it: the current subgen output had 1,317 cues
+while aftercare had scored a different 763-cue file.
+"""
+
+from __future__ import annotations
+
+STEM = "Movie (2024)"
+
+
+def _choose(names):
+    from subarr.completion_watcher import choose_srt_sidecar
+
+    return choose_srt_sidecar(STEM, names)
+
+
+def test_exact_en_srt_still_wins():
+    """Unchanged for the common case, which is what most installs produce."""
+    assert _choose([f"{STEM}.en.srt", f"{STEM}.subgen.large-v3.eng.srt"]) == f"{STEM}.en.srt"
+
+
+def test_subgen_english_sidecar_beats_an_unrelated_sibling():
+    """The reported case: no plain .en.srt, and a stale sibling sorts first."""
+    names = [f"{STEM}.aaa-stale.srt", f"{STEM}.subgen.large-v3.eng.srt"]
+    assert _choose(names) == f"{STEM}.subgen.large-v3.eng.srt"
+
+
+def test_subgen_english_preferred_over_subgen_other_language():
+    """A subgen sidecar in another language must not be scored as the English
+    output just because it carries the subgen marker."""
+    names = [f"{STEM}.subgen.large-v3.fre.srt", f"{STEM}.subgen.large-v3.eng.srt"]
+    assert _choose(names) == f"{STEM}.subgen.large-v3.eng.srt"
+
+
+def test_two_letter_en_tag_also_recognised():
+    """Subgen can emit either ISO form depending on SUBTITLE_LANGUAGE_NAMING_TYPE."""
+    names = [f"{STEM}.zzz.srt", f"{STEM}.subgen.large-v3.en.srt"]
+    assert _choose(names) == f"{STEM}.subgen.large-v3.en.srt"
+
+
+def test_subgen_marker_without_language_still_beats_a_stranger():
+    """Better a subgen sidecar of unknown language than an unrelated file."""
+    names = [f"{STEM}.aaa.srt", f"{STEM}.subgen.srt"]
+    assert _choose(names) == f"{STEM}.subgen.srt"
+
+
+def test_fallback_is_deterministic_not_filesystem_order():
+    """With nothing distinguishable, the choice must not depend on the order the
+    filesystem happened to return. Same list, two orders, one answer."""
+    a = [f"{STEM}.zzz.srt", f"{STEM}.aaa.srt", f"{STEM}.mmm.srt"]
+    assert _choose(a) == _choose(list(reversed(a)))
+    assert _choose(a) == f"{STEM}.aaa.srt"
+
+
+def test_unrelated_stems_are_ignored():
+    """Only siblings sharing this video's stem are candidates."""
+    names = ["Another Movie.en.srt", f"{STEM}.subgen.large-v3.eng.srt"]
+    assert _choose(names) == f"{STEM}.subgen.large-v3.eng.srt"
+
+
+def test_no_candidates_returns_none():
+    assert _choose([]) is None
+    assert _choose(["Something Else.srt"]) is None
+
+
+def test_forced_sidecar_is_not_chosen_as_the_full_transcript():
+    """subarr writes .forced sidecars itself (#364). A forced segment file is a
+    handful of cues and must never be scored as the full transcript."""
+    names = [f"{STEM}.en.forced.srt", f"{STEM}.subgen.large-v3.eng.srt"]
+    assert _choose(names) == f"{STEM}.subgen.large-v3.eng.srt"


### PR DESCRIPTION
Closes #499. Reported by @IdahoRC, who measured it: aftercare had graded a stale **763-cue** file while subgen's current **1,317-cue** output sat beside it.

## Two bugs, not one

**1. Subgen's own naming was not recognised.** The selector preferred `<stem>.en.srt`, which is right for most installs. But subgen can embed its own name and the model into the filename via `SHOW_IN_SUBNAME_SUBGEN` / `SHOW_IN_SUBNAME_MODEL`, producing `<stem>.subgen.large-v3.eng.srt`. That is not `<stem>.en.srt`, so the real output fell through to the fallback. This is the half the reporter identified.

**2. The fallback was filesystem order.** Underneath it:

```python
for p in parent.glob(f"{stem}*.srt"):
    return str(p)
```

First hit wins, in whatever order the filesystem returned. With any other sibling present, which file got scored was effectively arbitrary — and it would not reproduce reliably, which is what makes this kind of bug expensive to chase. Same nondeterminism class as the Review ordering fixed in #493.

## The fix

The choice is extracted into a pure `choose_srt_sidecar(stem, names)` so it is testable without touching a filesystem. Ranked, best first:

| rank | match |
|---|---|
| 0 | exact `<stem>.en.srt` (unchanged, what most installs produce) |
| 1 | subgen marker **and** an English tag (`.en.` or `.eng.`) |
| 2 | subgen marker, language unknown |
| 3 | any other sibling |
| 4 | a `.forced.` sidecar |

Forced sidecars rank last because **subarr writes those itself** (#364) and they are a handful of foreign-dialogue cues, never a full transcript. Scoring one as the transcript would report a badly wrong result rather than merely the wrong file.

Ties break on the sorted name, so the answer never depends on filesystem order. One test asserts exactly that: the same list in two orders must give one answer.

## Testing

Nine cases written first, all failing, covering each rank plus the ordering guarantee, unrelated stems, and the empty case.

```
329 passed, 1680 deselected in 195.15s
```

## Migration / compat / telemetry impact

None, none, and none. Installs producing plain `.en.srt` see identical behaviour; installs with subgen-named sidecars start scoring the correct file.