### PR TITLE
fix(#505): the auto-queue filter never consulted forced_only_subgen_will_skip

### DIFF
--- a/src/subarr/auto_queue.py
+++ b/src/subarr/auto_queue.py
@@ -188,6 +188,19 @@ def _filter_reason(item: CoverageItem, rules: AutoQueueRules) -> str | None:
     # capability, so this clears itself the moment subgen can actually fill it.
     if item.image_only_subgen_will_skip:
         return "embedded English is image-based (PGS/VobSub); subgen will skip it"
+    # [#505] Exactly the same shape, and it was missing. A forced-only English
+    # track is NOT coverage, so the row is correctly eligible -- but subgen
+    # counts it as an existing English subtitle and refuses unless
+    # IGNORE_FORCED_SUBTITLES is on. The flag was already computed during
+    # scoring, serialised, and shown in Coverage as `forced_skip`; nothing
+    # consulted it here, so these rows were queued every scheduled walk and
+    # refused every time. Reported by AztecGuyGDL: ~15 files requeued on a
+    # 15-minute cycle, forever, with both sides behaving as designed.
+    #
+    # Set from subgen's RUNTIME capability like its image sibling, so it clears
+    # itself the moment the operator turns IGNORE_FORCED_SUBTITLES on.
+    if item.forced_only_subgen_will_skip:
+        return "embedded English is forced-only; subgen will skip it"
     if rules.require_monitored and item.monitored is False:
         return "not monitored"
     if item.score < rules.min_score:

--- a/tests/test_forced_auto_queue_gating_505.py
+++ b/tests/test_forced_auto_queue_gating_505.py
@@ -1,0 +1,103 @@
+"""#505: the auto-queue filter never consulted `forced_only_subgen_will_skip`.
+
+The flag was already computed during scoring, serialised into the coverage
+payload, rendered in the Coverage UI as `forced_skip`, and covered by
+`test_forced_sub_gating.py` with a dozen assertions. Nothing consumed it where
+it mattered: `auto_queue._filter_reason()` checked the IMAGE sibling
+(`image_only_subgen_will_skip`) and not this one.
+
+So a forced-only row was marked "subgen will skip this", shown as such, and then
+queued anyway. subgen refused it, the next scheduled walk queued it again, and
+the loop never ended because both sides were behaving as designed. The image
+case had already been solved this exact way for #458; its comment describes the
+symptom precisely: "Queueing it would turn a silent skip into a queue full of
+instant rejections."
+
+⚠️ The tests that existed asserted the FLAG and never asserted that anything
+consumed it, which is why a dozen green assertions sat beside a dead guard.
+These tests assert the consumption.
+"""
+
+from __future__ import annotations
+
+
+def _item(embedded_en=None):
+    from subarr.coverage_engine import CoverageItem
+
+    return CoverageItem(
+        media_type="episode",
+        title="Some Show",
+        canonical_path="TV/Some Show",
+        episode_number="1x1",
+        embedded_en=embedded_en,
+        audio_langs=["eng"],
+    )
+
+
+def _rules(**kw):
+    """Rules with the unrelated gates opened, so these tests exercise the
+    subgen-will-refuse flags rather than the score/monitored gates. Defaults are
+    min_score=200 and require_monitored=True, which reject a bare item before it
+    ever reaches the flag checks."""
+    from subarr.schedule_store import AutoQueueRules
+
+    kw.setdefault("min_score", 0)
+    kw.setdefault("require_monitored", False)
+    return AutoQueueRules(**kw)
+
+
+def test_auto_queue_skips_a_forced_only_row_subgen_would_refuse():
+    """The bug. A forced-only row must not be queued when the connected subgen
+    would refuse it."""
+    from subarr.auto_queue import _filter_reason
+
+    it = _item("EN(forced)")
+    it.forced_only_subgen_will_skip = True
+    reason = _filter_reason(it, _rules())
+    assert reason is not None, "forced-only row was queued despite subgen refusing it"
+    assert "forced" in reason.lower()
+
+
+def test_auto_queue_allows_forced_only_once_subgen_can_fill_it():
+    """The flag is set from subgen's RUNTIME capability, so turning on
+    IGNORE_FORCED_SUBTITLES must make the row actionable again with no change
+    here. Guards against fixing the loop by permanently excluding these files."""
+    from subarr.auto_queue import _filter_reason
+
+    it = _item("EN(forced)")
+    it.forced_only_subgen_will_skip = False
+    reason = _filter_reason(it, _rules())
+    assert reason is None, f"forced row blocked even though subgen would fill it: {reason}"
+
+
+def test_forced_and_image_are_independent_gates():
+    """Neither flag may shadow the other: each must block on its own."""
+    from subarr.auto_queue import _filter_reason
+
+    forced = _item("EN(forced)")
+    forced.forced_only_subgen_will_skip = True
+    forced.image_only_subgen_will_skip = False
+    assert "forced" in (_filter_reason(forced, _rules()) or "").lower()
+
+    image = _item("EN(image)")
+    image.forced_only_subgen_will_skip = False
+    image.image_only_subgen_will_skip = True
+    assert "image" in (_filter_reason(image, _rules()) or "").lower()
+
+
+def test_full_english_still_skipped_by_the_ordinary_rule():
+    """Unchanged: a real embedded English track is skipped by skip_embedded_en,
+    which this fix must not disturb."""
+    from subarr.auto_queue import _filter_reason
+
+    it = _item("EN")
+    reason = _filter_reason(it, _rules())
+    assert reason is not None and "embedded english" in reason.lower()
+
+
+def test_a_clean_row_is_still_queueable():
+    """The filter must not have become a blanket refusal."""
+    from subarr.auto_queue import _filter_reason
+
+    it = _item(None)
+    assert _filter_reason(it, _rules()) is None


### PR DESCRIPTION
Partial fix for #505, reported by @AztecGuyGDL.

## The loop

A forced-only English track is **not** full coverage, so subarr correctly leaves the row eligible. subgen counts it as an existing English subtitle and refuses unless `IGNORE_FORCED_SUBTITLES` is on. Nothing reconciled the two, so the row was queued on every scheduled walk and refused every time — about 15 files on a 15-minute cycle, indefinitely, **with both sides behaving exactly as designed**.

## The flag was not missing. Nothing consumed it.

`forced_only_subgen_will_skip` was already:

- computed during scoring (`coverage_engine.py:1475`)
- serialised into the coverage payload
- rendered in the Coverage UI as `forced_skip`
- covered by `tests/test_forced_sub_gating.py` with a dozen assertions

And `_filter_reason()` checked the **image** sibling on the line above and never this one. So a row was marked "subgen will skip this", displayed as such, and queued anyway.

Worth recording why a dozen green tests sat beside a dead guard: **every one of them asserted the flag, and none asserted that anything consumed it.** The tests added here assert the consumption, which is the part that was actually broken.

This was already solved once for the image case in #458, and its comment describes the symptom precisely: *"Queueing it would turn a silent skip into a queue full of instant rejections."*

## Not a permanent exclusion

The flag is set from subgen's **runtime capability**, so it clears itself the moment the operator enables `IGNORE_FORCED_SUBTITLES` and subgen will actually fill those files. A test pins that, so a future change cannot quietly turn this into a blanket refusal.

## Scope — this does not close the issue

The two rows the reporter sampled have **no embedded subtitle streams at all** (`"streams": []`) and `IGNORE_FORCED_SUBTITLES=True`, so they are not this bug. They look like a separate language-mismatch case: subgen's "External subtitles in English already exist" refers to *its own* globally-configured output language, while subarr's stale-disk check is language-aware and correctly does not count an English sidecar for a non-English wanted row. That is still under investigation on the issue and needs one more answer from the reporter.

This fix stands on its own and may account for some of the other 13 rows.

## Testing

Tests written first. The two that demonstrate the bug failed; three asserting unchanged behaviour passed from the start.

One correction worth noting: two of my tests initially failed for the wrong reason. `AutoQueueRules` defaults to `min_score=200` and `require_monitored=True`, so a bare item is rejected on **score** before reaching the flag checks at all. The helper now opens those unrelated gates so these tests exercise what they claim to.

```
282 passed, 1744 deselected in 192.26s
```

## Migration / compat / telemetry impact

None, none, and none. Rows that were being queued and instantly refused now stay out of the queue and are shown as non-actionable, which is what Coverage already displayed.