### PR TITLE
fix(#500): a 4xx from subgen detect was returned as if it were a result

### DIFF
--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -361,7 +361,18 @@ class SubgenClient:
             r = await self._client.post("/detect_language_robust", params=params)
         except httpx.HTTPError as e:
             raise SubgenUnavailable(f"subgen /detect_language_robust failed: {e}") from e
-        if r.status_code >= 500:
+        # [#500] Was `>= 500`, which let every 4xx through as if it were a
+        # detection. subgen answers 403 when the path falls outside its allowed
+        # media root (patch 0025) and 400 when the path is empty, both as a JSON
+        # body carrying only `error`. That was returned to the router, which
+        # answered 200, and the Review UI, expecting chunks and a vote, rendered
+        # nothing at all -- reported as "the detection button doesn't do
+        # anything". A path or mount misconfiguration is the single most likely
+        # cause of that 403, and it is precisely what the operator needs told.
+        #
+        # Every sibling method in this client already used `!= 200` or `>= 400`;
+        # this one was the outlier.
+        if r.status_code >= 400:
             raise SubgenUnavailable(
                 f"subgen /detect_language_robust returned {r.status_code}: {r.text[:200]}"
             )

--- a/tests/test_subgen_client.py
+++ b/tests/test_subgen_client.py
@@ -139,3 +139,61 @@ async def test_status_non_json_200_raises_subgen_unavailable():
 
     with pytest.raises(SubgenUnavailable):
         await _client(handler).status()
+
+
+# ── #500: a 4xx from /detect_language_robust must not read as a result ───────
+# The method gated on `status_code >= 500`, so subgen's 403 ("path is outside
+# the allowed media root") and 400 ("path is required") were returned straight
+# through as if they were detections. subarr answered 200 with an object
+# carrying only `error`, and the Review UI, expecting chunks and a vote,
+# rendered nothing. Reported by Jorman as "the detection button doesn't do
+# anything". Every sibling method in this client already used `!= 200` or
+# `>= 400`; this one was the outlier.
+
+
+def _detect_handler(status: int, body: dict):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.url.path == "/detect_language_robust":
+            return httpx.Response(status, json=body)
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        (403, {"error": "the path is outside the allowed media root"}),
+        (400, {"error": "path is required"}),
+        (404, {"detail": "Not Found"}),
+    ],
+)
+async def test_detect_language_robust_raises_on_4xx(status, body):
+    from subarr.subgen_client import SubgenUnavailable
+
+    c = _client(_detect_handler(status, body))
+    with pytest.raises(SubgenUnavailable) as ei:
+        await c.detect_language_robust("/media/TV/x.avi")
+    await c.aclose()
+    # The status and subgen's own words must survive into the message, or the
+    # operator is told "unavailable" with no way to find out why.
+    assert str(status) in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_detect_language_robust_still_returns_a_real_detection():
+    c = _client(_detect_handler(200, {"detected_language": "en", "chunks": [], "confidence": 0.9}))
+    out = await c.detect_language_robust("/media/TV/x.avi")
+    await c.aclose()
+    assert out["detected_language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_detect_language_robust_still_raises_on_5xx():
+    from subarr.subgen_client import SubgenUnavailable
+
+    c = _client(_detect_handler(503, {"error": "model loading"}))
+    with pytest.raises(SubgenUnavailable):
+        await c.detect_language_robust("/media/TV/x.avi")
+    await c.aclose()


### PR DESCRIPTION
Fixes the "detection button doesn't do anything" report on #500 from @Jorman.

## What was happening

`SubgenClient.detect_language_robust()` gated on `status_code >= 500`:

```python
if r.status_code >= 500:
    raise SubgenUnavailable(...)
try:
    return r.json()
```

So **every 4xx passed straight through as a successful detection.** subgen answers:

- **403** when the path falls outside its allowed media root (patch 0025's containment guard)
- **400** when the path is empty

both as a JSON body carrying only `error`. That reached the router, which answered **HTTP 200**, and the Review UI — expecting chunks and an aggregate vote — rendered nothing.

The button did exactly nothing, which is exactly what was reported.

## An outlier, not a pattern

Every sibling method in this client already guarded properly:

```
line 322  != 200
line 364  >= 500   <- this one
line 378  != 200
line 410  != 200
line 770  >= 400
```

Now `>= 400`, keeping the status code and subgen's own message in the raised error so the operator is told **why** rather than just "unavailable".

## Why this matters beyond the silence

A path or mount mismatch is the most likely cause of that 403, and it is the single most useful thing to tell someone whose detection is failing. The reporter's compose has `USE_PATH_MAPPING=False` with `PATH_MAPPING_FROM=/data` while subarr runs `SUBARR_MEDIA_ROOT=/data/Multimedia`, which is exactly the shape that produces it. There is already a comment in the router noting that a bare unmapped path "made subgen's ffprobe fail and silently return und for every detect" — same class, different symptom.

This does not yet prove the reporter's specific failure is the 403. It proves the silence was real and is gone: when they next click it, the cause will be named.

## Testing

Tests written first. The three 4xx cases (403 / 400 / 404) failed; the 200 and 503 cases passed from the start, which is what shows the change is narrow rather than broad.

```
320 passed, 1711 deselected in 303.32s
```

## Migration / compat / telemetry impact

None, none, and none. A detection that previously appeared to do nothing now surfaces an error. No successful detection changes behaviour.