### PR TITLE
feat(#506): force a re-probe that bypasses the mtime/size cache

### DIFF
--- a/src/subarr/probe_walker.py
+++ b/src/subarr/probe_walker.py
@@ -277,9 +277,23 @@ class ProbeWalker:
     # ------------------------------------------------------------------
     _EAGER_LABEL = "__eager__"
 
-    async def probe_paths(self, canonical_paths: list[str]) -> WalkState:
+    async def probe_paths(self, canonical_paths: list[str], force: bool = False) -> WalkState:
         """Probe a specific set of canonical paths. Skips files already
-        cached (mtime/size match) and records failures. Deduped: if an
+        cached (mtime/size match) and records failures.
+
+        [#506] `force` skips the cache READ, so a file whose mtime and size are
+        unchanged is probed anyway. The cache is keyed on (path, mtime, size) and
+        self-invalidates when either moves, which covers most edits -- but a
+        language-tag correction is the case it cannot see: 'und' -> 'eng' is the
+        same byte length, so an in-place tag edit can leave size identical, and a
+        tool that preserves mtime leaves both matching. The entry then stands
+        forever and Review keeps showing the old language.
+
+        Deliberately skips the READ rather than deleting the entry first: deleting
+        up front destroys good data if the re-probe then fails, so the old entry
+        survives until a new one replaces it.
+
+        Deduped: if an
         eager walk is already running, the existing WalkState is returned
         instead of starting a parallel one (so back-to-back coverage
         refreshes don't stack identical probe passes)."""
@@ -304,12 +318,14 @@ class ProbeWalker:
         walk_id = uuid.uuid4().hex[:16]
         state = WalkState(walk_id, self._EAGER_LABEL)
         self._walks[walk_id] = state
-        task = asyncio.create_task(self._run_targeted(state, paths), name=f"probe-eager-{walk_id}")
+        task = asyncio.create_task(
+            self._run_targeted(state, paths, force=force), name=f"probe-eager-{walk_id}"
+        )
         self._tasks[walk_id] = task
         task.add_done_callback(lambda t, wid=walk_id: self._tasks.pop(wid, None))
         return state
 
-    async def _run_targeted(self, state: WalkState, canonical_paths: list[str]) -> None:
+    async def _run_targeted(self, state: WalkState, canonical_paths: list[str], force: bool = False) -> None:
         try:
             state.total_files = len(canonical_paths)
             log.info("eager probe %s: %d wanted files", state.id, state.total_files)
@@ -329,11 +345,14 @@ class ProbeWalker:
                         state.errors.append({"path": canonical, "error": f"stat: {e}"})
                         state.processed += 1
                         return
-                    cached = self._store.get(canonical, mtime=st.st_mtime, size=st.st_size)
-                    if cached is not None:
-                        state.cached_hits += 1
-                        state.processed += 1
-                        return
+                    # [#506] force skips the cache read entirely, so a tag-only
+                    # edit that left mtime and size untouched is still re-probed.
+                    if not force:
+                        cached = self._store.get(canonical, mtime=st.st_mtime, size=st.st_size)
+                        if cached is not None:
+                            state.cached_hits += 1
+                            state.processed += 1
+                            return
                     await self._probe_and_record(state, canonical, p, st)
 
             await asyncio.gather(*(_one(c) for c in canonical_paths))

--- a/src/subarr/routers/probe.py
+++ b/src/subarr/routers/probe.py
@@ -22,6 +22,16 @@ class WalkRequest(BaseModel):
     recursive: bool = True  # currently always recursive; kept for future
 
 
+# [#506] Bounded so one click cannot queue the whole library. 500 matches the
+# rollup walker's own per-folder ceiling, and a Review page selection is far
+# smaller than that in practice.
+MAX_REPROBE_PATHS = 500
+
+
+class ReprobeRequest(BaseModel):
+    canonical_paths: list[str]
+
+
 @router.get("/probe")
 async def probe_endpoint(request: Request, path: str = Query("")) -> dict:
     canonical = path.strip().strip("/")
@@ -66,6 +76,51 @@ async def start_walk(req: WalkRequest, request: Request) -> dict:
         raise HTTPException(404, detail=f"not a directory: {canonical!r}")
     walker = request.app.state.probe_walker
     state = await walker.start_walk(canonical)
+    return state.to_dict()
+
+
+@router.post("/probe/reprobe")
+async def force_reprobe(req: ReprobeRequest, request: Request) -> dict:
+    """[#506] Re-probe specific files, bypassing the mtime/size cache.
+
+    The cache is keyed on (path, mtime, size) and self-invalidates when either
+    moves, so an ordinary re-walk already picks up most edits. It cannot see a
+    language-tag correction: 'und' -> 'eng' is the same byte length, so an
+    in-place tag edit can leave size identical, and a tool that preserves mtime
+    leaves both matching. The row then keeps reporting the old language with no
+    way to refresh it, which is what this endpoint is for.
+
+    Returns the same WalkState shape as /probe/walk, so the existing
+    /probe/walk/{id} and /probe/walk/{id}/events endpoints track it unchanged.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for raw in req.canonical_paths:
+        c = (raw or "").strip().strip("/")
+        if not c or c in seen:
+            continue
+        seen.add(c)
+        paths.append(c)
+    if not paths:
+        raise HTTPException(400, detail="canonical_paths must contain at least one path")
+    if len(paths) > MAX_REPROBE_PATHS:
+        raise HTTPException(
+            400,
+            detail=(
+                f"too many paths: {len(paths)} > {MAX_REPROBE_PATHS}. "
+                "Re-probe a smaller selection, or run a full walk."
+            ),
+        )
+    # Containment check up front: one bad path fails the whole request rather
+    # than silently probing the rest, so the caller is not left guessing which
+    # of their selection was dropped.
+    for c in paths:
+        try:
+            canonical_to_fs(c)
+        except PathOutsideRootError:
+            raise HTTPException(400, detail=f"path escapes media root: {c!r}")
+    walker = request.app.state.probe_walker
+    state = await walker.probe_paths(paths, force=True)
     return state.to_dict()
 
 

--- a/tests/test_force_reprobe_506.py
+++ b/tests/test_force_reprobe_506.py
@@ -1,0 +1,129 @@
+"""#506: force a re-probe that bypasses the mtime/size cache.
+
+The probe cache is keyed on (canonical_path, mtime, size) and self-invalidates
+when either changes, which covers most edits. A LANGUAGE TAG correction is the
+pathological case it cannot see: `und` -> `eng` is the same byte length, so an
+in-place tag edit can leave size identical, and a tool that preserves mtime
+leaves both matching. The entry then stands forever and Review keeps showing
+`audio: und` against a file whose metadata is already correct.
+
+Targeted probes hit the same early return in `_run_targeted`, which is what the
+reporter (AztecGuyGDL, after correcting files with Tdarr) means by "a normal
+re-walk is cache-aware and does not provide a reliable way to force ffprobe".
+
+Design note pinned by these tests: forcing SKIPS THE CACHE READ rather than
+deleting the entry first. Deleting up front destroys good data if the re-probe
+then fails; this way the old entry survives until a new one replaces it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeStore:
+    """Records whether the cache was consulted, and always reports a hit."""
+
+    def __init__(self):
+        self.get_calls = 0
+        self.deleted: list[str] = []
+        self.upserts: list[str] = []
+
+    def get(self, canonical, mtime=None, size=None):
+        self.get_calls += 1
+
+        class _Hit:
+            cached = True
+
+        return _Hit()
+
+    def delete(self, canonical):
+        self.deleted.append(canonical)
+        return True
+
+
+async def _run_and_wait(walker, paths, **kw):
+    """`probe_paths` is FIRE AND FORGET: it create_task()s and returns the
+    WalkState immediately. Asserting on that state without awaiting the task
+    reads it before anything ran, and the loop closing then cancels it -- which
+    looks exactly like "the cache was honoured". Await the task."""
+    state = await walker.probe_paths(paths, **kw)
+    task = walker._tasks.get(state.id)
+    if task is not None:
+        await task
+    return state
+
+
+@pytest.mark.asyncio
+async def test_force_bypasses_the_cache_read(tmp_path, monkeypatch):
+    """With force, a cached-and-matching file must still be probed."""
+    from subarr import probe_walker as pw
+
+    store = _FakeStore()
+    walker = pw.ProbeWalker(store)
+
+    f = tmp_path / "ep.mkv"
+    f.write_bytes(b"x")
+    monkeypatch.setattr(pw, "canonical_to_fs", lambda c: f)
+
+    probed: list[str] = []
+
+    async def _fake_probe_and_record(state, canonical, p, st):
+        probed.append(canonical)
+        state.processed += 1
+
+    monkeypatch.setattr(walker, "_probe_and_record", _fake_probe_and_record)
+
+    state = await _run_and_wait(walker, ["TV/S/ep.mkv"], force=True)
+    assert probed == ["TV/S/ep.mkv"], "force must probe even on a cache hit"
+    assert state.cached_hits == 0
+
+
+@pytest.mark.asyncio
+async def test_without_force_a_cache_hit_still_short_circuits(tmp_path, monkeypatch):
+    """Unchanged default. The existing eager-probe caller must not start
+    re-probing the whole library because this option was added."""
+    from subarr import probe_walker as pw
+
+    store = _FakeStore()
+    walker = pw.ProbeWalker(store)
+
+    f = tmp_path / "ep.mkv"
+    f.write_bytes(b"x")
+    monkeypatch.setattr(pw, "canonical_to_fs", lambda c: f)
+
+    probed: list[str] = []
+
+    async def _fake_probe_and_record(state, canonical, p, st):
+        probed.append(canonical)
+        state.processed += 1
+
+    monkeypatch.setattr(walker, "_probe_and_record", _fake_probe_and_record)
+
+    state = await _run_and_wait(walker, ["TV/S/ep.mkv"])
+    assert store.get_calls == 1, "the walk must actually have consulted the cache"
+    assert probed == [], "default must still honour the cache"
+    assert state.cached_hits == 1
+
+
+@pytest.mark.asyncio
+async def test_force_does_not_delete_the_cached_entry_up_front(tmp_path, monkeypatch):
+    """The old entry must survive until a new probe replaces it, so a failed
+    re-probe does not leave the row with nothing."""
+    from subarr import probe_walker as pw
+
+    store = _FakeStore()
+    walker = pw.ProbeWalker(store)
+
+    f = tmp_path / "ep.mkv"
+    f.write_bytes(b"x")
+    monkeypatch.setattr(pw, "canonical_to_fs", lambda c: f)
+
+    async def _boom(state, canonical, p, st):
+        state.errors.append({"path": canonical, "error": "ffprobe exploded"})
+        state.processed += 1
+
+    monkeypatch.setattr(walker, "_probe_and_record", _boom)
+
+    await _run_and_wait(walker, ["TV/S/ep.mkv"], force=True)
+    assert store.deleted == [], "force must not pre-delete the cached entry"

--- a/tests/test_probe_router.py
+++ b/tests/test_probe_router.py
@@ -337,3 +337,64 @@ def test_coverage_attaches_embedded_en_from_probe_cache(app_with_stub, monkeypat
     # Score: −3000 from embedded, +100 non-english, +50 monitored = −2850.
     assert item["score"] <= -2000
     assert any("embedded" in reason for reason in item["score_reasons"])
+
+
+# ── #506: POST /api/probe/reprobe ────────────────────────────────────────────
+# Force a re-probe of specific files, bypassing the (path, mtime, size) cache.
+# The cache self-invalidates when mtime or size moves, which covers most edits,
+# but a language-tag correction can leave both untouched ('und' -> 'eng' is the
+# same byte length), so Review keeps showing the old language with no way to
+# refresh it. Reported by AztecGuyGDL after correcting files with Tdarr.
+
+
+def _plant(name="ReprobeMe.mkv"):
+    from subarr.config import settings
+
+    folder = settings.media_root / "Movies" / "Reprobe"
+    folder.mkdir(parents=True, exist_ok=True)
+    f = folder / name
+    f.write_bytes(b"x" * 64)
+    return "Movies/Reprobe/" + name
+
+
+def test_reprobe_requires_at_least_one_path(app_with_stub):
+    r = app_with_stub.post("/api/probe/reprobe", json={"canonical_paths": []})
+    assert r.status_code == 400
+
+
+def test_reprobe_rejects_a_path_outside_the_media_root(app_with_stub):
+    r = app_with_stub.post("/api/probe/reprobe", json={"canonical_paths": ["../../etc/passwd"]})
+    assert r.status_code == 400
+    assert "root" in r.json()["detail"].lower()
+
+
+def test_reprobe_caps_the_batch_size(app_with_stub):
+    """An unbounded list would let one click queue the whole library."""
+    r = app_with_stub.post(
+        "/api/probe/reprobe",
+        json={"canonical_paths": [f"Movies/Reprobe/f{i}.mkv" for i in range(5000)]},
+    )
+    assert r.status_code == 400
+    assert "too many" in r.json()["detail"].lower()
+
+
+def test_reprobe_starts_a_forced_walk_and_returns_its_id(app_with_stub, monkeypatch):
+    canonical = _plant()
+    seen = {}
+
+    async def _fake_probe_paths(paths, force=False):
+        seen["paths"] = list(paths)
+        seen["force"] = force
+
+        class _S:
+            def to_dict(self):
+                return {"id": "abc123", "status": "running"}
+
+        return _S()
+
+    monkeypatch.setattr(app_with_stub.app.state.probe_walker, "probe_paths", _fake_probe_paths)
+    r = app_with_stub.post("/api/probe/reprobe", json={"canonical_paths": [canonical]})
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == "abc123"
+    assert seen["paths"] == [canonical]
+    assert seen["force"] is True, "the whole point is that it bypasses the cache"


### PR DESCRIPTION
Implements the backend for #506, requested by @AztecGuyGDL after correcting audio-language tags with Tdarr and finding Review still showing `audio: und`.

## The gap is narrower and more specific than "the cache is stale"

The probe cache is keyed on `(canonical_path, mtime, size)` and **already self-invalidates** when either moves. The walker uses that strict check, so an ordinary re-walk picks up most edits. The report's description of it as "cache-aware" is accurate, but worth pinning down what it actually misses.

The case it cannot see is precisely the one hit here: **`und` → `eng` is the same byte length.** An in-place tag edit can leave size identical, and a tool that preserves mtime leaves both matching. The entry then stands forever with no way to refresh it.

## Design: skip the read, don't delete the entry

`probe_paths()` and `_run_targeted()` take `force`, which skips the cache **read**.

Deliberately **not** delete-then-probe. Deleting up front destroys good data if the re-probe then fails, leaving the row with nothing. This way the old entry survives until a new one replaces it. A test pins it by failing the probe and asserting nothing was deleted.

**Only the targeted path takes `force`.** The full walk is untouched and I verified that, because a forced full walk would re-ffprobe an entire library on one click.

## The endpoint

`POST /api/probe/reprobe` returns the same `WalkState` shape as `/probe/walk`, so the existing `/probe/walk/{id}` and `/events` endpoints track it with **no new surface**.

- batch capped at **500** so one click cannot queue a whole library
- every path containment-checked **up front**: one bad path fails the request rather than silently probing the rest and leaving the caller guessing which of their selection was dropped
- deduped, blanks dropped

A path list covers all three scopes the reporter asked for (one file, a selection, a whole series) without inventing new server-side semantics — the caller supplies the members.

## UI deliberately excluded

The request asks for buttons in Review. #496 is a **1,667-line rewrite of `review.jsx`** currently awaiting a bundle rebuild. Adding a button there now would conflict head-on. Backend first is the right order; the UI follows once #496 lands.

## Testing

Tests written first, all failing for the right reason.

```
153 passed, 1885 deselected in 136.55s
```

Two traps worth recording, both caught by tests failing for the *wrong* reason:

**`probe_paths` is fire-and-forget.** It `create_task`s and returns. Asserting on the returned state without awaiting reads it before anything ran, and the loop closing cancels the task — which looks **identical** to "the cache was honoured". The default-path test now asserts the cache was actually consulted (`store.get_calls == 1`) so it cannot pass vacuously.

**The cache-check block is textually identical in `_run` and `_run_targeted`.** My first patch anchor matched both and correctly refused rather than silently making the full walk forceable.

## Migration / compat / telemetry impact

None, none, and none. New endpoint; the default `force=False` leaves every existing caller unchanged.