### PR TITLE
feat(#506): re-probe a file when a verification disagrees with its cache

### DIFF
--- a/src/subarr/routers/audio_lang.py
+++ b/src/subarr/routers/audio_lang.py
@@ -10,6 +10,7 @@ GET  /api/audio-lang/pending-review?search=&limit=&offset= — coverage rows nee
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -48,6 +49,81 @@ async def list_verifications(request: Request) -> dict[str, Any]:
     store = request.app.state.audio_lang
     rows = [v.to_dict() for v in store.list_all()]
     return {"count": len(rows), "verifications": rows}
+
+
+# [#506 follow-up] Strong refs to in-flight auto-reprobe tasks. CPython keeps
+# only a WEAK ref to a bare create_task, so a backgrounded ffprobe can be
+# GC-cancelled mid-flight and the row silently never refreshes -- the same trap
+# documented on the #364 forced-segment scans in completion_watcher.
+_REPROBE_TASKS: set = set()
+
+
+def verification_contradicts_probe(probe, lang_code) -> bool:
+    """[#506 follow-up] True when a user-verified language is not already what
+    the cached probe reports, i.e. re-reading the file could tell us something
+    new.
+
+    Covers both directions that matter:
+      - cache has NO language (und/None/empty) -> the encoder never tagged it,
+        and the user may have since corrected the file externally (#506).
+      - cache has a DIFFERENT definite language -> the file may have been
+        retagged externally; a cached `eng` on a file now tagged `jpn` reads
+        exactly the same as one that was never touched.
+
+    Returns False when the verified language is already present on any track,
+    because there is nothing to learn and a verification on a correctly-tagged
+    file is the common case -- it must not cost an ffprobe.
+
+    Both sides are normalised first: ffprobe emits ISO-639-2 (`jpn`) while the
+    store holds ISO-639-1 (`ja`), so a raw comparison would report a
+    contradiction on every file and re-probe the entire library one
+    verification at a time.
+    """
+    from ..langs import normalize_lang
+
+    want = normalize_lang((lang_code or "").strip()) or (lang_code or "").strip().lower()
+    if not want:
+        return False
+    if probe is None:
+        return True
+    have = set()
+    for track in getattr(probe, "audio", None) or []:
+        raw = (getattr(track, "language", None) or "").strip()
+        if not raw:
+            continue
+        have.add(normalize_lang(raw) or raw.lower())
+    have.discard("und")
+    if not have:
+        return True
+    return want not in have
+
+
+async def _reprobe_then_refresh(request: Request, canonical: str) -> None:
+    """Force one file through ffprobe, then ask for a coverage rebuild.
+
+    Ordering matters: the rebuild reads the probe cache, so refreshing before the
+    probe lands would just re-read the stale entry.
+
+    Failures are non-fatal by design. The verification itself has already
+    persisted and is the authoritative answer regardless of what the file says.
+    """
+    try:
+        walker = getattr(request.app.state, "probe_walker", None)
+        if walker is None:
+            return
+        state = await walker.probe_paths([canonical], force=True)
+        task = getattr(walker, "_tasks", {}).get(getattr(state, "id", None))
+        if task is not None:
+            await task
+        cov = getattr(request.app.state, "coverage_cache", None)
+        if cov is not None:
+            cov.request_refresh(
+                request.app.state.integrations,
+                request.app.state.probe_store,
+                request.app.state.audio_lang,
+            )
+    except Exception as e:  # noqa: BLE001 - a background refresh must never escalate
+        log.warning("auto-reprobe after verification failed for %s: %s", scrub(canonical), e)
 
 
 @router.post("/verifications")
@@ -93,6 +169,26 @@ async def upsert_verification(req: VerifyRequest, request: Request) -> dict[str,
 
     # v1.1 ARCH fix #197: kick a background coverage refresh so the
     # corresponding row's chip turns green within a few seconds, not 30.
+    # [#506 follow-up] The manual Force Re-probe only helps someone who already
+    # SUSPECTS the cache is stale. A user verification that disagrees with the
+    # cached probe is subarr being TOLD its cache is wrong, so look at the file
+    # again: it may have been retagged externally since it was probed, and a tag
+    # edit can leave mtime and size untouched, which is the one change the cache
+    # cannot detect on its own.
+    #
+    # Only for `user` source -- an automatic or Whisper verdict must not spend
+    # disk IO. Multi-language verdicts are skipped: no single language to compare,
+    # same reasoning as the Sonarr propagation guard above.
+    if req.source == "user" and req.lang_class != "multi":
+        try:
+            cached_probe = request.app.state.probe_store.get(req.canonical_path)
+        except Exception:  # noqa: BLE001 - a cache read must not fail a verification
+            cached_probe = None
+        if verification_contradicts_probe(cached_probe, lang):
+            _t = asyncio.create_task(_reprobe_then_refresh(request, req.canonical_path))
+            _REPROBE_TASKS.add(_t)
+            _t.add_done_callback(_REPROBE_TASKS.discard)
+
     # #104: route through the coalescing entry point so a burst of
     # verifications collapses into a single debounced rebuild.
     cov_cache = getattr(request.app.state, "coverage_cache", None)

--- a/tests/test_auto_reprobe_on_verify_506.py
+++ b/tests/test_auto_reprobe_on_verify_506.py
@@ -1,0 +1,220 @@
+"""#506 follow-up: a manual verification that disagrees with the cached probe
+triggers a forced re-probe of that one file.
+
+Why this is worth doing at all: the manual Force Re-probe added in #506 only
+helps someone who already SUSPECTS the cache is stale. AztecGuyGDL knew because
+he had just run Tdarr. Jorman is about to reach the same state from the other
+direction, after tagging silent films `zxx`, and nothing would tell him the
+cache is now lying.
+
+Why the trigger is "differs from the cache" and not something narrower: it is
+tempting to only re-probe when the cache has NO language (und), on the reasoning
+that a definite cached language means the user is merely overriding it. That is
+wrong. A file tagged `eng` that the user has since retagged to `jpn` externally
+still reads `eng` from the cache, and verifying `ja` is exactly the moment to
+go and look again.
+
+Equally, when the verified language is ALREADY what the cache reports there is
+nothing to learn, so that case must not spend an ffprobe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _probe(langs):
+    from subarr.media_probe import AudioStream, ProbeResult
+
+    r = ProbeResult(canonical_path="TV/S/ep.mkv")
+    r.audio = [
+        AudioStream(index=i, language=lang, codec="aac", title=None, default=(i == 0))
+        for i, lang in enumerate(langs)
+    ]
+    return r
+
+
+def test_untagged_cache_plus_a_verified_language_wants_a_reprobe():
+    """The #506 case: encoder never tagged it, user corrected the file
+    externally, cache still reports und."""
+    from subarr.routers.audio_lang import verification_contradicts_probe
+
+    assert verification_contradicts_probe(_probe(["und"]), "en") is True
+    assert verification_contradicts_probe(_probe([None]), "en") is True
+    assert verification_contradicts_probe(_probe([]), "en") is True
+    assert verification_contradicts_probe(None, "en") is True
+
+
+def test_a_different_definite_language_also_wants_a_reprobe():
+    """The retag case. Cache says English, user says Japanese: the file may
+    have been corrected to jpn externally, and this is the moment to look."""
+    from subarr.routers.audio_lang import verification_contradicts_probe
+
+    assert verification_contradicts_probe(_probe(["eng"]), "ja") is True
+
+
+def test_agreement_must_not_spend_a_probe():
+    """Nothing to learn. Must be cheap, because most verifications on a
+    correctly-tagged file agree with it."""
+    from subarr.routers.audio_lang import verification_contradicts_probe
+
+    assert verification_contradicts_probe(_probe(["eng"]), "en") is False
+    assert verification_contradicts_probe(_probe(["en"]), "en") is False
+
+
+def test_agreement_with_any_track_counts_as_agreement():
+    """A multi-track file whose Japanese track is present should not re-probe
+    when the user confirms Japanese."""
+    from subarr.routers.audio_lang import verification_contradicts_probe
+
+    assert verification_contradicts_probe(_probe(["eng", "jpn"]), "ja") is False
+
+
+def test_three_letter_and_two_letter_forms_are_the_same_answer():
+    """ffprobe emits ISO-639-2 ('jpn'), the store holds ISO-639-1 ('ja').
+    Comparing them raw would report a contradiction on every single file."""
+    from subarr.routers.audio_lang import verification_contradicts_probe
+
+    assert verification_contradicts_probe(_probe(["jpn"]), "ja") is False
+    assert verification_contradicts_probe(_probe(["fre"]), "fr") is False
+    assert verification_contradicts_probe(_probe(["ger"]), "de") is False
+
+
+def test_blank_verification_never_triggers_work():
+    from subarr.routers.audio_lang import verification_contradicts_probe
+
+    assert verification_contradicts_probe(_probe(["und"]), "") is False
+    assert verification_contradicts_probe(_probe(["und"]), None) is False
+
+
+# ── The consumption tests ────────────────────────────────────────────────────
+# #505 shipped a flag that was computed, serialised, rendered and covered by a
+# dozen assertions, and nothing consumed it. Every one of those tests asserted
+# the FLAG. These assert that POST /api/verifications actually fires the probe,
+# which is the part that can silently rot.
+
+
+def _install_spy(app_with_stub, monkeypatch):
+    """Record at CALL time, not at task-run time.
+
+    `_reprobe_then_refresh` is fired with asyncio.create_task, so its body does
+    not run until the loop next yields -- well after the response returns and
+    the assertion has already read an empty spy. Patching it with a SYNC
+    recorder that returns a throwaway coroutine records the moment the endpoint
+    decides to fire, which is exactly the wiring under test.
+    """
+    calls = {}
+    from subarr.routers import audio_lang as mod
+
+    def _spy(request, canonical):
+        calls["canonical"] = canonical
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+    monkeypatch.setattr(mod, "_reprobe_then_refresh", _spy)
+    return calls
+
+
+def _seed_probe(app_with_stub, canonical, langs):
+    from subarr.media_probe import AudioStream, ProbeResult
+
+    r = ProbeResult(canonical_path=canonical)
+    r.audio = [
+        AudioStream(index=i, language=lg, codec="aac", title=None, default=(i == 0))
+        for i, lg in enumerate(langs)
+    ]
+    app_with_stub.app.state.probe_store.upsert(canonical_path=canonical, mtime=1.0, size=1, result=r)
+
+
+def _verify(app_with_stub, canonical, lang="en", source="user"):
+    return app_with_stub.post(
+        "/api/audio-lang/verifications",
+        json={
+            "canonical_path": canonical,
+            "lang_code": lang,
+            "source": source,
+            "confidence": 1.0,
+        },
+    )
+
+
+def test_verifying_against_an_untagged_probe_fires_a_reprobe(app_with_stub, monkeypatch):
+    calls = _install_spy(app_with_stub, monkeypatch)
+    canonical = "TV/AutoReprobe/ep.mkv"
+    _seed_probe(app_with_stub, canonical, ["und"])
+    r = _verify(app_with_stub, canonical)
+    assert r.status_code == 200, r.text
+    assert calls.get("canonical") == canonical, "the endpoint never fired the re-probe"
+
+
+def test_verifying_a_different_language_fires_a_reprobe(app_with_stub, monkeypatch):
+    """The retag case: cache says English, user says Japanese."""
+    calls = _install_spy(app_with_stub, monkeypatch)
+    canonical = "TV/AutoReprobe/retag.mkv"
+    _seed_probe(app_with_stub, canonical, ["eng"])
+    r = _verify(app_with_stub, canonical, lang="ja")
+    assert r.status_code == 200, r.text
+    assert calls.get("canonical") == canonical
+
+
+def test_agreeing_verification_does_not_fire_a_reprobe(app_with_stub, monkeypatch):
+    calls = _install_spy(app_with_stub, monkeypatch)
+    canonical = "TV/AutoReprobe/agree.mkv"
+    _seed_probe(app_with_stub, canonical, ["eng"])
+    r = _verify(app_with_stub, canonical, lang="en")
+    assert r.status_code == 200, r.text
+    assert calls == {}, "an agreeing verification must not spend an ffprobe"
+
+
+def test_non_user_source_does_not_fire_a_reprobe(app_with_stub, monkeypatch):
+    """An automatic or Whisper verdict must never trigger disk IO."""
+    calls = _install_spy(app_with_stub, monkeypatch)
+    canonical = "TV/AutoReprobe/auto.mkv"
+    _seed_probe(app_with_stub, canonical, ["und"])
+    r = _verify(app_with_stub, canonical, source="whisper-robust")
+    assert r.status_code == 200, r.text
+    assert calls == {}
+
+
+@pytest.mark.asyncio
+async def test_the_worker_forces_the_probe_and_awaits_it_before_refreshing():
+    """Separately from the wiring: the worker itself must pass force=True and
+    must await the probe BEFORE asking for a rebuild, or the rebuild re-reads
+    the stale cache entry it was meant to replace."""
+    from subarr.routers.audio_lang import _reprobe_then_refresh
+
+    order = []
+
+    class _Walker:
+        _tasks: dict = {}
+
+        async def probe_paths(self, paths, force=False):
+            order.append(("probe", list(paths), force))
+
+            class _S:
+                id = "w1"
+
+            return _S()
+
+    class _Cov:
+        def request_refresh(self, *a):
+            order.append(("refresh",))
+
+    class _State:
+        probe_walker = _Walker()
+        coverage_cache = _Cov()
+        integrations = object()
+        probe_store = object()
+        audio_lang = object()
+
+    class _App:
+        state = _State()
+
+    class _Req:
+        app = _App()
+
+    await _reprobe_then_refresh(_Req(), "TV/x/ep.mkv")
+    assert order == [("probe", ["TV/x/ep.mkv"], True), ("refresh",)]


### PR DESCRIPTION
Follow-up to the manual Force Re-probe in #509. Relates to #506 and #500.

## Why a manual button isn't enough

Force Re-probe only helps someone who already **suspects** the cache is stale. @AztecGuyGDL knew because he had just run Tdarr. @Jorman is about to reach the identical state from the other direction — I advised him to tag silent films `zxx` — and nothing would tell him the cache is now lying to him.

A user verification that disagrees with the cached probe is subarr being **told** its cache is wrong. That is a free, precise signal, and it was going unused.

## The trigger rule, and why my first instinct was wrong

I initially reasoned that contradiction was the *wrong* signal: if the cache holds a definite language, the user is merely overriding it, so re-reading returns the same thing. **That is only true if the file hasn't changed** — and detecting external changes is the entire point. A file tagged `eng` that the user has since retagged to `jpn` reads *identically* to one that was never touched.

So the rule is "the verified language isn't already what the cache reports":

| cache | verified | re-probe |
|---|---|---|
| `und` / none | `en` | **yes** — may have been tagged since |
| `eng` | `ja` | **yes** — may have been retagged |
| `eng` / `jpn` | `en` / `ja` | **no** — nothing to learn |

That last row is a cost decision as much as a correctness one: verifying a correctly-tagged file is common and must not spend an ffprobe.

## Three things that had to be right

**Normalisation is load-bearing.** ffprobe emits ISO-639-2 (`jpn`); the store holds ISO-639-1 (`ja`). A raw comparison would report a contradiction on *every file* and re-probe the whole library one verification at a time.

**The task needs a strong reference.** CPython holds only a weak ref to a bare `create_task`, so it can be GC-cancelled mid-flight and the row silently never refreshes. This repo already documents that trap on the #364 forced-segment scans. Held in a module-level set with a done-callback.

**Ordering.** The probe is awaited *before* requesting the coverage rebuild, because the rebuild reads the probe cache and would otherwise re-read the very entry it was meant to replace. A test pins it.

## Scope guards

`source == "user"` only, so automatic and Whisper verdicts never spend disk IO. Multi-language verdicts skipped — no single language to compare — matching the Sonarr propagation guard beside it. Failures are non-fatal: the verification has already persisted and is authoritative regardless of what the file says.

## Testing: the helper *and* the consumption

#505 shipped a flag that was computed, serialised, rendered in the UI and covered by a dozen assertions, with **nothing consuming it** — because every one of those tests asserted the flag. I was one step from repeating that here, having tested only the pure helper.

Three mutations confirmed red before shipping:

```
RED   wiring removed (guard never fires)
RED   force dropped in the worker
RED   refresh before probe (stale re-read)
restored: green
```

One test-design note: the endpoint fires via `create_task`, so a spy on the worker records nothing by assertion time — the body runs after the response returns. The wiring test patches `_reprobe_then_refresh` with a **sync** recorder returning a throwaway coroutine, so it records the moment the endpoint decides to fire. The worker's own behaviour is covered separately and awaited directly.

```
11 passed
```

## Migration / compat / telemetry impact

None, none, and none. One extra ffprobe per disagreeing user verification, backgrounded and concurrency-limited by the existing walker.