### PR TITLE
fix(#505): stop queueing rows this subgen cannot produce the language for

### DIFF
--- a/src/subarr/auto_queue.py
+++ b/src/subarr/auto_queue.py
@@ -201,6 +201,17 @@ def _filter_reason(item: CoverageItem, rules: AutoQueueRules) -> str | None:
     # itself the moment the operator turns IGNORE_FORCED_SUBTITLES on.
     if item.forced_only_subgen_will_skip:
         return "embedded English is forced-only; subgen will skip it"
+
+    # [#505] The second cause in the same report, and the one that needed a
+    # new subgen capability to see. Whisper writes ONE language per job:
+    # translate always emits English, transcribe emits the file's own audio
+    # language. A row wanting Spanish from a translate-mode instance can never
+    # be satisfied, so queueing it is an infinite submit-refuse-requeue loop
+    # in which BOTH sides are behaving correctly. Set during scoring from the
+    # instance's advertised mode, so it clears itself if that mode changes,
+    # and never set at all against a subgen too old to advertise it.
+    if item.wanted_lang_subgen_cannot_produce:
+        return "subgen cannot produce the wanted language for this row; it would be refused"
     if rules.require_monitored and item.monitored is False:
         return "not monitored"
     if item.score < rules.min_score:

--- a/src/subarr/coverage_engine.py
+++ b/src/subarr/coverage_engine.py
@@ -153,6 +153,12 @@ class CoverageItem:
     # connected subgen will not transcribe it. Same shape as the field above:
     # a distinct non-actionable state, not a hidden row.
     image_only_subgen_will_skip: bool = False
+    # [#505] The wanted language is one THIS subgen cannot produce at all.
+    # Whisper writes one language per job: translate always emits English,
+    # transcribe emits the file's own audio language. A row wanting Spanish
+    # from a translate-mode instance is unsatisfiable no matter how often it
+    # is queued, and queueing it anyway is an infinite refuse-requeue loop.
+    wanted_lang_subgen_cannot_produce: bool = False
     # #159: the default/first audio track isn't the show's original language but
     # a track that IS exists — transcribing the default double-translates a dub
     # (e.g. Russian show, German dub default, original Russian on track 2). The
@@ -218,6 +224,7 @@ class CoverageItem:
             "verification_state": self.verification_state,
             "forced_only_subgen_will_skip": self.forced_only_subgen_will_skip,
             "image_only_subgen_will_skip": self.image_only_subgen_will_skip,
+            "wanted_lang_subgen_cannot_produce": self.wanted_lang_subgen_cannot_produce,
             "default_track_mismatch": self.default_track_mismatch,
             "mismatch_default_track_lang": self.mismatch_default_track_lang,
             "mismatch_native_track_lang": self.mismatch_native_track_lang,
@@ -1396,6 +1403,9 @@ def _score(
     transcoding_titles: set[str] | None = None,
     ignore_forced_subtitles: bool = False,
     ignore_image_subtitles: bool = False,
+    # [#505] subgen's global TRANSCRIBE_OR_TRANSLATE, as advertised by v4.29+.
+    # None means not advertised, which must gate nothing.
+    subgen_output_task: str | None = None,
 ) -> None:
     s = 0
     reasons: list[str] = []
@@ -1488,6 +1498,25 @@ def _score(
             reasons.append(
                 "subgen will skip this (English subs are image-based, PGS/VobSub)"
                 " — enable IGNORE_IMAGE_SUBTITLES on subgen to transcribe it"
+            )
+    # [#505] Can this subgen produce ANY language this row is waiting for?
+    # Only gates when the answer is knowable: an instance that does not
+    # advertise its mode, or a file whose audio language is untagged in
+    # transcribe mode, both read as unknown and are left alone. A row wanting
+    # several languages is NOT gated if even one is producible, because the
+    # producible half is real work worth queueing.
+    from .subgen_client import producible_subtitle_languages
+
+    _producible = producible_subtitle_languages(subgen_output_task, item.audio_langs)
+    if _producible is not None and item.missing_subtitles:
+        from .langs import normalize_lang
+
+        _wanted = {c for c in (normalize_lang(x) for x in item.missing_subtitles if x) if c}
+        if _wanted and not (_wanted & _producible):
+            item.wanted_lang_subgen_cannot_produce = True
+            reasons.append(
+                f"subgen cannot produce {sorted(_wanted)} (it writes "
+                f"{sorted(_producible)} only) - queueing this would be refused"
             )
     item.score = s
     item.score_reasons = reasons
@@ -1631,6 +1660,9 @@ async def build_coverage(
     # IGNORE_IMAGE_SUBTITLES. Independent of the forced cap: they govern
     # different defects, and subgen defaults this one OFF.
     ignore_image = bool(getattr(subgen_caps, "ignore_image_subtitles", False))
+    # [#505] The instance's global TRANSCRIBE_OR_TRANSLATE, advertised from
+    # v4.29. None on anything older, which reads as unknown and gates nothing.
+    subgen_task = getattr(subgen_caps, "transcribe_or_translate", None)
 
     # ── Bazarr: fan out across ALL instances; each wanted item is tagged with
     #    its source instance id (_bazarr_instance) for routing (#161 Phase 2).
@@ -1893,6 +1925,7 @@ async def build_coverage(
                 airing_soon_eps=airing_soon_ids,
                 ignore_forced_subtitles=ignore_forced,
                 ignore_image_subtitles=ignore_image,
+                subgen_output_task=subgen_task,
             )
             inst_ep_rows.append(item)
 
@@ -1923,6 +1956,7 @@ async def build_coverage(
                     plex_hints=plex_audio_hints,
                     ignore_forced_subtitles=ignore_forced,
                     ignore_image_subtitles=ignore_image,
+                    subgen_output_task=subgen_task,
                 )
             )
         ep_rows.extend(inst_ep_rows)
@@ -1987,6 +2021,7 @@ async def build_coverage(
                 just_imported_movies=radarr_recent_ids,
                 ignore_forced_subtitles=ignore_forced,
                 ignore_image_subtitles=ignore_image,
+                subgen_output_task=subgen_task,
             )
             inst_movie_rows.append(item)
 
@@ -2013,6 +2048,7 @@ async def build_coverage(
                     sources=sources,
                     ignore_forced_subtitles=ignore_forced,
                     ignore_image_subtitles=ignore_image,
+                    subgen_output_task=subgen_task,
                 )
             )
         movie_rows.extend(inst_movie_rows)
@@ -2098,6 +2134,8 @@ async def _add_bazarr_blind_synthetic_rows(
     plex_hints: dict[str, str] | None = None,
     ignore_forced_subtitles: bool = False,
     ignore_image_subtitles: bool = False,
+    # [#505] forwarded to _score so synthetic rows are gated too.
+    subgen_output_task: str | None = None,
 ) -> list[CoverageItem]:
     """Build synthetic CoverageItem rows for episodes Bazarr can't see —
     foreign-language series where the file metadata lies and Bazarr's
@@ -2296,6 +2334,7 @@ async def _add_bazarr_blind_synthetic_rows(
                 airing_soon_eps=airing_soon_ids,
                 ignore_forced_subtitles=ignore_forced_subtitles,
                 ignore_image_subtitles=ignore_image_subtitles,
+                subgen_output_task=subgen_output_task,
             )
             new_rows.append(item)
             seen_ep_ids.add(ep_id)
@@ -2332,6 +2371,8 @@ async def _add_radarr_blind_movie_rows(
     sources: dict,
     ignore_forced_subtitles: bool,
     ignore_image_subtitles: bool,
+    # [#505] forwarded to _score so blind movie rows are gated too.
+    subgen_output_task: str | None = None,
 ) -> list[CoverageItem]:
     """Surface Radarr movies missing English subtitle coverage.
 
@@ -2407,6 +2448,7 @@ async def _add_radarr_blind_movie_rows(
             just_imported_movies=radarr_recent_ids,
             ignore_forced_subtitles=ignore_forced_subtitles,
             ignore_image_subtitles=ignore_image_subtitles,
+            subgen_output_task=subgen_output_task,
         )
         new_rows.append(item)
         seen_files.add(file_canonical)

--- a/src/subarr/subgen_client.py
+++ b/src/subarr/subgen_client.py
@@ -103,6 +103,40 @@ def classify_probe_failure(exc: Exception | None = None, *, status: int | None =
     return "transport"
 
 
+def producible_subtitle_languages(mode: str | None, audio_langs: list[str] | None) -> set[str] | None:
+    """[#505] Which subtitle languages a subgen instance can produce for ONE file.
+
+    Whisper writes exactly one language per job:
+
+      translate  -> English, always, whatever the file contains
+      transcribe -> the file's own audio language
+
+    Returns None for UNKNOWN, which is different from an empty set, and the
+    distinction is load-bearing. An empty set would mean 'can produce nothing'
+    and would gate every affected row out of the queue; None means subarr
+    cannot answer and must not gate at all. Unknown covers an instance that
+    does not advertise the setting (anything below v4.29), a value we do not
+    recognise, and transcribe mode on a file whose audio language is untagged,
+    since subgen detects that itself and subarr genuinely does not know.
+
+    Deliberately NOT widened by capabilities.per_request_task. subgen accepts
+    a per-request task override, so it looks as though subarr could always ask
+    for the other mode and therefore produce either language. It cannot: the
+    production queue path (scan_runner) calls batch() with no task at all, so
+    the global setting is what runs. Counting per_request_task here would let
+    rows through that then fail in exactly the way this function exists to
+    prevent."""
+    from .langs import normalize_lang
+
+    m = (mode or "").strip().lower()
+    if m == "translate":
+        return {"en"}
+    if m != "transcribe":
+        return None
+    codes = {c for c in (normalize_lang(x) for x in (audio_langs or []) if x) if c and c not in ("und", "")}
+    return codes or None
+
+
 @dataclass(frozen=True)
 class SubgenCapabilities:
     """What this subgen build supports. Computed once at app boot.
@@ -166,6 +200,17 @@ class SubgenCapabilities:
     # for that batch only. The tuning-lab arena gates on this to drive a
     # source-transcribe AND candidate-translate through one path-based channel.
     per_request_task: bool = False
+    # [v4.29 / #505] What this instance can PRODUCE, as opposed to what it
+    # will skip. Whisper writes exactly ONE language per job: 'translate'
+    # always emits English regardless of the file, 'transcribe' emits the
+    # file's own audio language. None means the instance did not advertise
+    # it (older subgen), which must read as UNKNOWN and gate nothing.
+    transcribe_or_translate: str | None = None
+    # Renames the OUTPUT FILE without changing the language of its contents,
+    # so it is NOT the producible language and must never be used as one.
+    # Carried so a contradiction (translate mode writing a .es.srt) is
+    # visible rather than inferred from the filename.
+    subtitle_language_name: str | None = None
     # v4.10 capability: POST /asr accepts ?path= (read audio from a subgen-
     # visible path — no upload) + ?kwargs= (per-request override, folded into
     # the dedup hash) and returns the sub over HTTP. The tuning-lab arena gates
@@ -261,6 +306,8 @@ class SubgenCapabilities:
             "async_config": self.async_config,
             "per_request_kwargs": self.per_request_kwargs,
             "per_request_task": self.per_request_task,
+            "transcribe_or_translate": self.transcribe_or_translate,
+            "subtitle_language_name": self.subtitle_language_name,
             "asr_arena": self.asr_arena,
             "asr_vanilla_base": self.asr_vanilla_base,
             "asr_detected_language": self.asr_detected_language,
@@ -447,6 +494,8 @@ class SubgenClient:
         async_config = False
         per_request_kwargs = False
         per_request_task = False
+        transcribe_or_translate = None
+        subtitle_language_name = None
         asr_arena = False
         asr_vanilla_base = False
         asr_detected_language = False
@@ -485,6 +534,10 @@ class SubgenClient:
                             async_config = bool(caps_block.get("async_config"))
                             per_request_kwargs = bool(caps_block.get("per_request_kwargs"))
                             per_request_task = bool(caps_block.get("per_request_task"))
+                            _tot = caps_block.get("transcribe_or_translate")
+                            transcribe_or_translate = str(_tot).strip().lower() if _tot else None
+                            _sln = caps_block.get("subtitle_language_name")
+                            subtitle_language_name = str(_sln).strip() if _sln else None
                             asr_arena = bool(caps_block.get("asr_arena"))
                             asr_vanilla_base = bool(caps_block.get("asr_vanilla_base"))
                             asr_detected_language = bool(caps_block.get("asr_detected_language"))
@@ -534,6 +587,8 @@ class SubgenClient:
             async_config=async_config,
             per_request_kwargs=per_request_kwargs,
             per_request_task=per_request_task,
+            transcribe_or_translate=transcribe_or_translate,
+            subtitle_language_name=subtitle_language_name,
             asr_arena=asr_arena,
             asr_vanilla_base=asr_vanilla_base,
             asr_detected_language=asr_detected_language,

--- a/tests/test_unproducible_language_505.py
+++ b/tests/test_unproducible_language_505.py
@@ -1,0 +1,168 @@
+"""#505 (second cause): subarr queued rows whose language its subgen cannot make.
+
+Whisper writes exactly ONE subtitle language per job. In translate mode that is
+always English regardless of the file; in transcribe mode it is the file's own
+audio language. subarr could see neither, which produced a loop where BOTH
+sides were behaving correctly and nothing connected them:
+
+  1. subarr sees a row wanting Spanish with no Spanish subtitle. Correct.
+  2. subarr queues it.
+  3. subgen, in translate mode, sees the English subtitle it would have written
+     already on disk and refuses. Also correct.
+  4. Next scheduled walk, repeat. Forever.
+
+AztecGuyGDL measured about fifteen files cycling on a fifteen minute schedule.
+
+The gate is DELIBERATELY NOT built on `per_request_task`. subgen can accept a
+per-request transcribe/translate override, so it is tempting to say subarr
+could always ask for the other mode and therefore both languages are
+producible. It cannot: the production queue path in scan_runner calls
+`batch()` with no `task=` at all, so the global setting is what runs. Counting
+per_request_task here would let rows through that then fail exactly as before.
+"""
+
+from __future__ import annotations
+
+
+# ── the pure question: what can this instance produce for this file? ─────────
+
+
+def test_translate_mode_can_only_ever_produce_english():
+    from subarr.subgen_client import producible_subtitle_languages
+
+    assert producible_subtitle_languages("translate", ["jpn"]) == {"en"}
+    assert producible_subtitle_languages("translate", ["spa", "eng"]) == {"en"}
+    assert producible_subtitle_languages("translate", []) == {"en"}
+
+
+def test_transcribe_mode_produces_the_files_own_audio_language():
+    from subarr.subgen_client import producible_subtitle_languages
+
+    assert producible_subtitle_languages("transcribe", ["jpn"]) == {"ja"}
+    assert producible_subtitle_languages("transcribe", ["spa", "eng"]) == {"es", "en"}
+
+
+def test_transcribe_with_unknown_audio_is_UNKNOWN_not_empty():
+    """An empty set would mean 'can produce nothing' and would gate every
+    untagged file out of the queue. subgen detects the language itself in that
+    case, so subarr genuinely does not know: the honest answer is None."""
+    from subarr.subgen_client import producible_subtitle_languages
+
+    assert producible_subtitle_languages("transcribe", ["und"]) is None
+    assert producible_subtitle_languages("transcribe", []) is None
+    assert producible_subtitle_languages("transcribe", [None, ""]) is None
+
+
+def test_an_unadvertised_or_unrecognised_mode_never_gates():
+    """Backward compatibility is the whole reason this is capability-gated. An
+    older subgen advertises nothing, and must behave exactly as it does today."""
+    from subarr.subgen_client import producible_subtitle_languages
+
+    assert producible_subtitle_languages(None, ["jpn"]) is None
+    assert producible_subtitle_languages("", ["jpn"]) is None
+    assert producible_subtitle_languages("something-new", ["jpn"]) is None
+
+
+# ── the capability actually being read off the wire ──────────────────────────
+
+
+def test_capabilities_carry_the_output_configuration():
+    from subarr.subgen_client import SubgenCapabilities
+
+    caps = SubgenCapabilities(
+        reachable=True,
+        version="2026.08.1",
+        has_queue=True,
+        has_batch=True,
+        is_subarr_subgen=True,
+    )
+    assert caps.transcribe_or_translate is None, "must default to unknown, not to a mode"
+    assert caps.subtitle_language_name is None
+
+
+# ── the flag, and then the thing that actually matters: its consumption ──────
+
+
+def _item(*, missing, audio, score=9999):
+    from subarr.coverage_engine import CoverageItem
+
+    it = CoverageItem(
+        title="Dragon Ball Super",
+        media_type="episode",
+        canonical_path="TV/Dragon Ball Super",
+        file_canonical_path="TV/Dragon Ball Super/S03E12.mkv",
+    )
+    it.missing_subtitles = list(missing)
+    it.audio_langs = list(audio)
+    it.score = score
+    it.monitored = True
+    it.verification_state = "verified"
+    return it
+
+
+def test_scoring_flags_a_row_this_instance_cannot_satisfy():
+    from subarr.coverage_engine import _score
+
+    it = _item(missing=["es"], audio=["jpn"])
+    _score(it, {}, subgen_output_task="translate")
+    assert it.wanted_lang_subgen_cannot_produce is True
+    assert any("spanish" in r.lower() or "es" in r.lower() for r in it.score_reasons)
+
+
+def test_scoring_leaves_a_satisfiable_row_alone():
+    from subarr.coverage_engine import _score
+
+    it = _item(missing=["en"], audio=["jpn"])
+    _score(it, {}, subgen_output_task="translate")
+    assert it.wanted_lang_subgen_cannot_produce is False
+
+
+def test_scoring_does_not_gate_when_the_mode_is_unknown():
+    from subarr.coverage_engine import _score
+
+    it = _item(missing=["es"], audio=["jpn"])
+    _score(it, {}, subgen_output_task=None)
+    assert it.wanted_lang_subgen_cannot_produce is False
+
+
+def test_a_partially_satisfiable_row_is_not_gated():
+    """Wanting English AND Spanish from an English-only instance is still worth
+    queueing: the English half is real work this instance can do."""
+    from subarr.coverage_engine import _score
+
+    it = _item(missing=["en", "es"], audio=["jpn"])
+    _score(it, {}, subgen_output_task="translate")
+    assert it.wanted_lang_subgen_cannot_produce is False
+
+
+# THE consumption test. #505's first cause was a flag that was computed,
+# serialised, rendered in Coverage and covered by a dozen assertions while
+# NOTHING consulted it when deciding what to queue. Asserting the flag is not
+# enough; this asserts the auto-queue actually acts on it.
+
+
+def test_the_auto_queue_actually_refuses_the_flagged_row():
+    from subarr.auto_queue import evaluate
+    from subarr.schedule_store import AutoQueueRules
+
+    it = _item(missing=["es"], audio=["jpn"])
+    it.wanted_lang_subgen_cannot_produce = True
+    rules = AutoQueueRules(mode="auto", min_score=0, require_monitored=False)
+
+    decisions = evaluate([it], rules)
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d.action == "skip", f"the flagged row was queued anyway: {d.reason}"
+    assert "produce" in d.reason.lower() or "cannot" in d.reason.lower()
+
+
+def test_an_unflagged_row_is_still_queued():
+    """The guard must not swallow everything: this is the negative control."""
+    from subarr.auto_queue import evaluate
+    from subarr.schedule_store import AutoQueueRules
+
+    it = _item(missing=["en"], audio=["jpn"])
+    rules = AutoQueueRules(mode="auto", min_score=0, require_monitored=False)
+
+    decisions = evaluate([it], rules)
+    assert decisions[0].action == "queue", decisions[0].reason


### PR DESCRIPTION
Closes #505.

The second and larger cause in AztecGuyGDL's report. The first (a forced-only English subtitle) shipped in v2.7.0; this is the one that needed a new subgen capability to see at all.

## The loop

Whisper writes exactly **one** subtitle language per job. In translate mode that is always English regardless of the file; in transcribe mode it is the file's own audio language. subarr could see neither, which produces a cycle where **both sides are behaving correctly**:

1. subarr sees a row wanting Spanish with no Spanish subtitle, and queues it. Correct.
2. subgen, in translate mode, sees the English subtitle it would have written already on disk, and refuses. Also correct.
3. Next scheduled walk, repeat. Forever.

The reporter measured about fifteen files cycling on a fifteen minute schedule.

## The fix

subarr now asks what the instance can **produce**, and holds back a row it cannot satisfy, saying why, instead of submitting it to be refused.

Gated on subarr-subgen **v4.29** (`2026.08.1-r9`), which advertises `transcribe_or_translate` and `subtitle_language_name`. Against anything older the mode reads as unknown and behaviour is exactly as it is today.

## Three decisions worth reviewing

**Unknown is not the same as "produces nothing".** `producible_subtitle_languages` returns `None` for unknown and a set otherwise. An empty set would mean the instance can produce nothing and would gate every affected row out of the queue. Unknown covers three real cases: an instance too old to advertise, a value we do not recognise, and transcribe mode on a file whose audio language is untagged, where subgen detects the language itself and subarr genuinely does not know. All three must gate nothing.

**Deliberately not widened by `per_request_task`.** subgen accepts a per-request transcribe/translate override, so it looks as though subarr could always ask for the other mode and therefore produce either language. It cannot: the production queue path in `scan_runner` calls `batch()` with **no `task=` at all**, so the global setting is what runs. Counting that capability here would let rows through that then fail in exactly the way this change exists to prevent. I checked the caller rather than the capability.

**A partially satisfiable row is not gated.** Wanting English *and* Spanish from an English-only instance is still worth queueing, because the English half is real work. Only a row where *nothing* wanted is producible is held back.

## Verification

Eleven tests, red before green.

The one that matters is `test_the_auto_queue_actually_refuses_the_flagged_row`. #505's *first* cause was a flag that was computed, serialised, rendered in Coverage and covered by a dozen assertions while nothing consulted it when deciding what to queue. Asserting the flag again would have repeated that exactly. Mutation-verified: deleting the consumption from `_filter_reason` turns that test red, restoring it turns it green.

Also verified end to end against the **live r9 instance** rather than a fixture, since the wire format is the thing that can differ:

```
transcribe_or_translate: 'translate'
subtitle_language_name : 'en'

audio=['jpn'] wants=es  producible={'en'}  -> HELD BACK
audio=['jpn'] wants=en  producible={'en'}  -> queued
audio=['eng'] wants=es  producible={'en'}  -> HELD BACK
```

**Blast radius on the reference deployment: zero.** That box is `translate`/`en`, the same shape as the reporter's, so it was the case to check. It has exactly one Bazarr language profile, English only, so no row on it can be gated by this change.

## What this does not do

It does not make Spanish appear. That instance cannot produce it, and `TRANSCRIBE_OR_TRANSLATE=translate` means English-only output regardless of anything else. The honest outcome for the reporter is that subarr stops queueing those rows and explains why, and getting Spanish is a subgen configuration question. I said that plainly on the issue rather than letting the fix imply otherwise.
