### PR TITLE
fix(#529): PLEX_URL has no default; it was a private LAN address

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Set only the ones for services you use. subarr reads these at boot; most also be
 | `BAZARR_URL` / `BAZARR_API_KEY` | `http://bazarr:6767` / — | Bazarr endpoint + key; subarr's gaps/coverage mirrors Bazarr's wanted list. Core. |
 | `SONARR_URL` / `SONARR_API_KEY` | `http://sonarr:8989` / — | Series metadata, original language, mediainfo. |
 | `RADARR_URL` / `RADARR_API_KEY` | `http://radarr:7878` / — | Movie metadata. |
-| `PLEX_URL` / `PLEX_TOKEN` | your Plex URL / — | Targeted library refresh after a sub lands. |
+| `PLEX_URL` / `PLEX_TOKEN` | — / — | Targeted library refresh after a sub lands. Optional; unset means Plex is not configured. |
 | `JELLYFIN_URL` / `JELLYFIN_API_KEY` | your Jellyfin URL / — | Targeted library refresh after a sub lands. Optional; coexists with Plex (subtitles fan out to both). Create the key in Jellyfin Dashboard → API Keys. |
 | `TAUTULLI_URL` / `TAUTULLI_API_KEY` | `http://tautulli:8181` / — | Audio-track hints from your Plex history. |
 | `OLLAMA_URL` | `http://ollama:11434` | Ollama endpoint (optional AI features). |

--- a/src/subarr/config.py
+++ b/src/subarr/config.py
@@ -320,7 +320,11 @@ def load() -> Settings:
         subgen_media_prefix=_env_or("SUBGEN_MEDIA_PREFIX", "/media"),
         db_path=Path(_env_or("SUBARR_DB_PATH", "/data/subarr.db")),
         port=int(_env_or("SUBARR_PORT", "9922")),
-        plex_url=_env_or("PLEX_URL", "http://192.168.1.105:32400"),
+        # #529: no default. This carried a private LAN address from the dev box
+        # for two years; there is no sensible default for a Plex URL, and an
+        # empty one means "not configured", exactly like JELLYFIN_URL. Read
+        # directly (not _env_or) so an explicit PLEX_URL= stays empty too.
+        plex_url=os.environ.get("PLEX_URL", "").strip(),
         plex_token=os.environ.get("PLEX_TOKEN", ""),
         plex_section=_env_or("PLEX_SECTION", "all"),
         plex_path_prefix=os.environ.get("PLEX_PATH_PREFIX", ""),

--- a/tests/test_plex_url_default.py
+++ b/tests/test_plex_url_default.py
@@ -1,0 +1,62 @@
+"""#529: `PLEX_URL` defaulted to `http://192.168.1.105:32400`, a private LAN
+address from the development machine, baked into the product. Every other
+optional media-server setting defaults to empty. Found during the README
+audit (#528): Settings and the onboarding prefill showed that address to every
+fresh install as if it were a suggestion.
+
+An unset PLEX_URL must mean "not configured", exactly as JELLYFIN_URL does."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _reload_config(monkeypatch, **env):
+    for name in ("PLEX_URL", "PLEX_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    from subarr import config
+
+    importlib.reload(config)
+    return config
+
+
+def test_unset_plex_url_is_empty_not_a_lan_address(monkeypatch):
+    config = _reload_config(monkeypatch)
+    assert config.settings.plex_url == ""
+    assert "192.168" not in config.settings.plex_url
+
+
+def test_an_explicitly_empty_plex_url_stays_empty(monkeypatch):
+    # _env_or maps "" to the default; an explicit PLEX_URL= must not resurrect
+    # any default, because there is no sensible default for a LAN address.
+    config = _reload_config(monkeypatch, PLEX_URL="")
+    assert config.settings.plex_url == ""
+
+
+def test_a_set_plex_url_is_honoured(monkeypatch):
+    config = _reload_config(monkeypatch, PLEX_URL="http://plex.lan:32400")
+    assert config.settings.plex_url == "http://plex.lan:32400"
+
+
+def test_plex_client_built_from_an_unset_url_reports_not_configured(monkeypatch):
+    config = _reload_config(monkeypatch)
+    from subarr.integrations.plex import PlexClient
+
+    client = PlexClient(
+        base_url=config.settings.plex_url,
+        token=config.settings.plex_token,
+        default_section=config.settings.plex_section,
+        path_prefix=config.settings.plex_path_prefix,
+        media_root=str(config.settings.media_root),
+    )
+    assert client.is_configured() is False
+
+
+def test_no_private_address_is_baked_into_config_source():
+    import inspect
+
+    from subarr import config
+
+    assert "192.168." not in inspect.getsource(config)


### PR DESCRIPTION
Closes #529, found during the README audit (#528).

`config.py` defaulted `PLEX_URL` to `http://192.168.1.105:32400`, a private LAN address from the development machine, and Settings plus the onboarding prefill showed it to every fresh install as if it were a suggestion. Every other optional media-server setting (`JELLYFIN_URL`, `PLEX_TOKEN`, `PLEX_PATH_PREFIX`) defaults to empty.

**Change:** `plex_url` is read directly from the environment with an empty default. Unset and an explicit `PLEX_URL=` both mean "not configured", the same contract as `JELLYFIN_URL`. `PlexClient.is_configured()` already keys on URL and token both being present, so an install without Plex now reports not configured instead of carrying a stranger's address. The README env table's default column updated to match.

**Tests** (`tests/test_plex_url_default.py`): unset is empty; explicit empty stays empty (the `_env_or` helper would have resurrected a default); a set value is honoured; the Plex client built from the unset value is not configured; and `config.py` contains no `192.168.` literal, so the address cannot come back quietly.

Ran alongside every config, integration-credential, health-probe, media-server-bundle, onboarding and smoke suite; all green. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
