### PR TITLE
fix(#524): a mounted docker socket enables auto-detect without an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Set only the ones for services you use. subarr reads these at boot; most also be
 | `SUBARR_VAD_DIR` / `SUBARR_LID_DIR` | beside DB | Override VAD / LID model directories. |
 | `NVIDIA_SMI_PATH` | — | Path to `nvidia-smi` for the GPU card. |
 | `SUBGEN_CONTAINER` / `SUBGEN_COMPOSE_PATH` | `subgen` / path | subgen container name + compose path for guided setup. |
-| `SUBARR_DOCKER_PROXY_URL` / `SUBARR_DOCKER_SOCKET_PATH` | — | Docker access for guided setup. |
+| `SUBARR_DOCKER_PROXY_URL` / `SUBARR_DOCKER_SOCKET_PATH` | — | Docker access for guided setup's auto-detect. Neither is needed when `/var/run/docker.sock` is mounted into the container; set the proxy URL to use a socket proxy instead. |
 | `SUBARR_TELEMETRY_ENDPOINT` | `https://telemetry.subarr.com/v1/ping` | Anonymous telemetry receiver (see [Telemetry](#telemetry)). Set to empty to opt out. |
 
 ## Known limitations (v2.7)

--- a/src/subarr/app.py
+++ b/src/subarr/app.py
@@ -1053,17 +1053,17 @@ async def lifespan(app_: FastAPI):
     # disabled if neither SUBARR_DOCKER_PROXY_URL nor a socket path
     # is configured. The wizard probes via GET /api/discovery and
     # gracefully falls back to manual entry when unavailable.
-    if settings.docker_proxy_url or settings.docker_socket_path:
-        from .docker_discovery import DockerDiscovery
+    # #524: a mounted /var/run/docker.sock counts too. It already made the
+    # Logs page work; auto-detect said "not configured" on the same mount.
+    from .docker_discovery import DockerDiscovery, resolve_discovery_endpoint
 
+    ep = resolve_discovery_endpoint(settings)
+    if ep is not None:
         app_.state.docker_discovery = DockerDiscovery(
-            base_url=settings.docker_proxy_url or None,
-            unix_socket=settings.docker_socket_path or None,
+            base_url=ep["endpoint"] if ep["kind"] == "proxy" else None,
+            unix_socket=ep["endpoint"] if ep["kind"] == "socket" else None,
         )
-        log.info(
-            "docker discovery enabled (transport=%s)",
-            "proxy" if settings.docker_proxy_url else "socket",
-        )
+        log.info("docker discovery enabled (transport=%s, via %s)", ep["kind"], ep["source"])
     else:
         app_.state.docker_discovery = None
 

--- a/src/subarr/docker_discovery.py
+++ b/src/subarr/docker_discovery.py
@@ -39,6 +39,37 @@ import httpx
 
 from .config import settings
 
+# The conventional docker socket path. A bind-mount of this into the container
+# is the most common way people give subarr docker access (the Logs page
+# already finds it by itself through the docker SDK).
+DEFAULT_SOCKET = "/var/run/docker.sock"
+
+
+def resolve_discovery_endpoint(cfg, socket_exists=None) -> dict[str, Any] | None:
+    """Where discovery should talk to, or None when there is nowhere.
+
+    #524: this used to be decided inline in app.py as "either env var is
+    set", so a mounted /var/run/docker.sock enabled the Logs page (docker SDK
+    finds it) but left onboarding auto-detect saying "discovery not
+    configured", while the router's own advice said "or mount
+    /var/run/docker.sock". Precedence: explicit proxy URL, explicit socket
+    path (reported even if absent, so a wrong setting fails loudly rather than
+    silently switching), then the conventional socket if it is present.
+    """
+    import os
+
+    exists = socket_exists or os.path.exists
+    proxy = (getattr(cfg, "docker_proxy_url", "") or "").strip()
+    if proxy:
+        return {"kind": "proxy", "endpoint": proxy, "source": "SUBARR_DOCKER_PROXY_URL"}
+    sock = (getattr(cfg, "docker_socket_path", "") or "").strip()
+    if sock:
+        return {"kind": "socket", "endpoint": sock, "source": "SUBARR_DOCKER_SOCKET_PATH"}
+    if exists(DEFAULT_SOCKET):
+        return {"kind": "socket", "endpoint": DEFAULT_SOCKET, "source": "mounted"}
+    return None
+
+
 log = logging.getLogger(__name__)
 
 

--- a/src/subarr/routers/onboarding.py
+++ b/src/subarr/routers/onboarding.py
@@ -426,9 +426,25 @@ async def auto_detect(request: Request) -> dict[str, Any]:
     """
     disc = getattr(request.app.state, "docker_discovery", None)
     if disc is None:
-        return {"available": False, "reason": "discovery not configured", "services": {}}
+        return {
+            "available": False,
+            "reason": (
+                "no Docker access: mount /var/run/docker.sock into the subarr container "
+                "(read-only is fine) or set SUBARR_DOCKER_PROXY_URL to a socket proxy"
+            ),
+            "services": {},
+        }
     if not await disc.reachable():
-        return {"available": False, "reason": "docker not reachable", "services": {}}
+        # #524: the socket is there but the app cannot use it. As a non-root
+        # process (PUID) the usual cause is the socket's group/mode.
+        return {
+            "available": False,
+            "reason": (
+                f"docker not reachable via {getattr(disc, '_endpoint', 'the configured endpoint')}; "
+                "if that is a mounted socket, subarr runs as PUID/PGID and needs read access to it"
+            ),
+            "services": {},
+        }
 
     candidates = await disc.discover()
     # Group by service — wizard picks one candidate per service (or

--- a/tests/test_docker_discovery_endpoint.py
+++ b/tests/test_docker_discovery_endpoint.py
@@ -1,0 +1,50 @@
+"""#524: a mounted Docker socket enabled the Logs page (docker SDK finds
+/var/run/docker.sock by itself) but NOT onboarding auto-detect, which the app
+only constructed when SUBARR_DOCKER_PROXY_URL or SUBARR_DOCKER_SOCKET_PATH was
+set, even though the discovery client already had a fallback to the
+conventional socket path that nothing ever reached. One feature worked and
+the other said "discovery not configured" on the same mount.
+
+The decision of where discovery should talk to is now one pure function."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from subarr.docker_discovery import DEFAULT_SOCKET, resolve_discovery_endpoint
+
+
+def _settings(proxy="", sock=""):
+    return SimpleNamespace(docker_proxy_url=proxy, docker_socket_path=sock)
+
+
+def test_proxy_url_wins():
+    ep = resolve_discovery_endpoint(_settings(proxy="http://proxy:2375"), socket_exists=lambda p: True)
+    assert ep == {"kind": "proxy", "endpoint": "http://proxy:2375", "source": "SUBARR_DOCKER_PROXY_URL"}
+
+
+def test_explicit_socket_path_is_used_even_if_it_does_not_exist_yet():
+    # An explicit setting is the operator's statement; report it, let the
+    # probe fail loudly rather than silently choosing something else.
+    ep = resolve_discovery_endpoint(_settings(sock="/run/docker.sock"), socket_exists=lambda p: False)
+    assert ep == {"kind": "socket", "endpoint": "/run/docker.sock", "source": "SUBARR_DOCKER_SOCKET_PATH"}
+
+
+def test_mounted_conventional_socket_enables_discovery_with_no_env_at_all():
+    seen = []
+
+    def exists(p):
+        seen.append(p)
+        return p == DEFAULT_SOCKET
+
+    ep = resolve_discovery_endpoint(_settings(), socket_exists=exists)
+    assert ep == {"kind": "socket", "endpoint": DEFAULT_SOCKET, "source": "mounted"}
+    assert DEFAULT_SOCKET in seen
+
+
+def test_nothing_configured_and_no_socket_means_no_discovery():
+    assert resolve_discovery_endpoint(_settings(), socket_exists=lambda p: False) is None
+
+
+def test_default_socket_is_the_conventional_path():
+    assert DEFAULT_SOCKET == "/var/run/docker.sock"


### PR DESCRIPTION
Refs #524, where a user with the Docker socket mounted had a working Logs page and an auto-detect that said "discovery not configured".

## The mismatch

Two features, two ways of finding Docker. The Logs page uses the docker SDK, which finds a mounted `/var/run/docker.sock` on its own. Onboarding auto-detect uses `DockerDiscovery`, which the app only constructed when `SUBARR_DOCKER_PROXY_URL` or `SUBARR_DOCKER_SOCKET_PATH` was set. `DockerDiscovery` even carries a fallback to the conventional socket path, but the app never reached it, and the discovery router's own error text told people to "mount /var/run/docker.sock", which on its own did nothing.

## Change

- `resolve_discovery_endpoint(settings)`: proxy URL first, then an explicit socket path (reported even if the file is absent, so a wrong setting fails loudly instead of silently switching), then the conventional socket when it exists. `app.py` uses it and logs which source won.
- Auto-detect's two failure reasons now say what to do: mount the socket or set the proxy URL; and when the endpoint exists but does not answer, that subarr runs as `PUID` and needs read access to it, which is the usual cause on a non-root container.
- README env row: neither variable is needed with a mounted socket.

## Tests

`tests/test_docker_discovery_endpoint.py`: proxy wins; an explicit socket path is honoured even when absent; a mounted conventional socket enables discovery with no env at all (and the resolver actually checked that path); nothing configured and no socket means none. Watched failing first. Discovery, onboarding, smoke and live-reload suites green (61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)