### PR TITLE
fix(#540, #541): show subgen's reason on a 403 batch refusal; document SUBGEN_PATH_ALLOWLIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The most-asked question. Quick answer.
 | Vanilla `mccloud/subgen` | Keep it. Add subarr next to it. Subarr detects vanilla and runs in compat mode. Coverage, provenance, scheduling, audio-language review all work. You miss calibrated multi-chunk detection and queue cancel, both require our subgen patches. |
 | `mccloud/subgen` and you want everything | Swap to `ghcr.io/coaxk/subarr-subgen`. Same upstream image plus 49 small auditable patches. Pull, change one line in your compose, restart. No data loss, no config rewrite. |
 | No subgen yet | Start with `ghcr.io/coaxk/subarr-subgen`. Everything works on day one. |
+
+> **One variable on the subgen side.** `ghcr.io/coaxk/subarr-subgen` refuses any path outside `SUBGEN_PATH_ALLOWLIST` (default `/media`). If your media is mounted at `/data` in the subgen container, set `SUBGEN_PATH_ALLOWLIST=/data` there, or every job comes back 403 "outside the allowed media root".
 | You run Bazarr only | Subarr adds a coordination layer beside Bazarr. Bazarr keeps doing what it does. Subarr surfaces what is actually missing, schedules the work, and writes results back. |
 
 You do not need to decide at install. Subarr re-probes subgen every 30 seconds and adopts new capabilities the moment you upgrade.
@@ -374,6 +376,7 @@ Set only the ones for services you use. subarr reads these at boot; most also be
 | `SUBARR_VAD_DIR` / `SUBARR_LID_DIR` | beside DB | Override VAD / LID model directories. |
 | `NVIDIA_SMI_PATH` | — | Path to `nvidia-smi` for the GPU card. |
 | `SUBGEN_CONTAINER` / `SUBGEN_COMPOSE_PATH` | `subgen` / path | subgen container name + compose path for guided setup. |
+| `SUBGEN_PATH_ALLOWLIST` (on the **subgen** container) | `/media` | subarr-subgen only accepts paths under these colon-separated roots (`/batch`, `/asr`, `/detect_language_robust`), because they answer unauthenticated on the LAN. Set it to wherever your media is mounted inside subgen, e.g. `/data`, or every transcription is refused with 403. |
 | `SUBARR_DOCKER_PROXY_URL` / `SUBARR_DOCKER_SOCKET_PATH` | — | Docker access for guided setup's auto-detect. Neither is needed when `/var/run/docker.sock` is mounted into the container; set the proxy URL to use a socket proxy instead. |
 | `SUBARR_TELEMETRY_ENDPOINT` | `https://telemetry.subarr.com/v1/ping` | Anonymous telemetry receiver (see [Telemetry](#telemetry)). Set to empty to opt out. |
 

--- a/docs/first-run.md
+++ b/docs/first-run.md
@@ -32,6 +32,13 @@ mounts the same host directory at the same container path in every app.
 
 **Mount media `:rw`.** Everything else works `:ro`, but nothing lands.
 
+**Tell subgen where media lives.** `ghcr.io/coaxk/subarr-subgen` only accepts
+paths under `SUBGEN_PATH_ALLOWLIST` (default `/media`), a guard against its
+unauthenticated endpoints walking the whole container. If your media is
+mounted anywhere else inside the subgen container, set that variable on the
+**subgen** service, colon-separated for several roots: `SUBGEN_PATH_ALLOWLIST=/data`.
+Otherwise the first transcription fails with 403 "outside the allowed media root".
+
 ## 2. Auto-detect: what it needs and what it cannot do
 
 The Welcome step has a **Detect my stack** button. It asks Docker which
@@ -122,6 +129,7 @@ auto-queue are for later, and nothing forces them.
 | Logs page: "No container named X" | `SUBGEN_CONTAINER` does not match a container | `docker ps --format '{{.Names}}'` and copy the name exactly, or unset the variable |
 | subgen tuning: "not allowed to read /path" | the compose file is root-only and subarr runs as `PUID` | `chmod o+r` the file, or `chown` it to `PUID` |
 | Queue: job finishes but no `.srt` appears | media mounted `:ro`, or paths differ between subarr and subgen | `docker exec subarr touch /media/library/.w && rm` the same; compare `SUBGEN_MEDIA_PREFIX` |
+| Queue: "subgen refused the path (403): directory is outside the allowed media root" | subgen's `SUBGEN_PATH_ALLOWLIST` does not cover your media mount | set it on the subgen container to the mount root, e.g. `/data`, and recreate subgen |
 | Every tile red after a reboot | the Docker network came up after subarr | `docker restart subarr` |
 
 When none of these fit, the Logs page (subarr's own log, no socket needed)

--- a/src/subarr/docker_client.py
+++ b/src/subarr/docker_client.py
@@ -26,6 +26,15 @@ log = logging.getLogger(__name__)
 #   INFO:root:[ Cette nuit-là - S01E02 - TBA WEBDL-72.. ]  78% | 2040/2610 s [06:43<01:52,  5.06s/s] | Jobs: 1 processing, 0 queued
 # Filename in brackets is left-truncated to ~38 chars + ".." when long.
 # Capture: filename_prefix, pct, current_sec, total_sec, elapsed, eta, speed.
+# #540: uvicorn colours its access log; the Logs page showed the escapes
+# verbatim. CSI sequences (ESC [ ... final byte) and lone ESC + one char.
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]|\x1b.")
+
+
+def strip_ansi(line: str) -> str:
+    return _ANSI_RE.sub("", line)
+
+
 _PROGRESS_RE = re.compile(
     r"\[\s*(?P<name>.+?)\s*\.{0,2}\s*\]\s+"
     r"(?P<pct>\d+)%\s+\|\s+"
@@ -268,12 +277,12 @@ class DockerOps:
                         raw, buf = buf[:nl], buf[nl + 1 :]
                         if stop.is_set():
                             break
-                        _post(raw.decode("utf-8", errors="replace").rstrip("\r"))
+                        _post(strip_ansi(raw.decode("utf-8", errors="replace").rstrip("\r")))
             except Exception as e:  # noqa: BLE001 - a closed socket surfaces as a variety of errors; all mean "done"
                 log.debug("log pump exited: %s", e)
             finally:
                 if buf and not stop.is_set():
-                    _post(buf.decode("utf-8", errors="replace").rstrip("\r"))
+                    _post(strip_ansi(buf.decode("utf-8", errors="replace").rstrip("\r")))
                 _post(None)
 
         worker = asyncio.create_task(asyncio.to_thread(_pump))

--- a/src/subarr/scan_runner.py
+++ b/src/subarr/scan_runner.py
@@ -70,9 +70,23 @@ def classify_batch_outcome(status_code: int, body) -> "tuple[str, str]":
     if status_code == 200 and walked > 0 and queued == 0 and already_q > 0:
         return PATH_STATUS_OK, ""  # already in subgen's queue — it'll process
     if status_code in (401, 403):
-        return PATH_STATUS_ERROR, (
+        # #540: subgen usually SAYS why (its containment guard answers 403 with
+        # {"error": "directory is outside the allowed media root"}). Show that,
+        # and name the variable that fixes it, instead of guessing at auth.
+        reason = body.get("error") if isinstance(body, dict) else None
+        if isinstance(reason, str) and reason.strip():
+            if "allowed media root" in reason:
+                return (
+                    PATH_STATUS_ERROR,
+                    f"subgen refused the path ({status_code}): {reason}. subgen only accepts paths under "
+                    "SUBGEN_PATH_ALLOWLIST (default /media). Set it on the subgen container to the "
+                    "root(s) where your media is mounted there, e.g. /data, and recreate subgen.",
+                )
+            return PATH_STATUS_ERROR, f"subgen rejected POST /batch ({status_code}): {reason}"
+        return (
+            PATH_STATUS_ERROR,
             f"subgen rejected POST /batch ({status_code}) — check subgen auth / API key, "
-            f"or a reverse proxy in front of subgen blocking write requests"
+            "or a reverse proxy in front of subgen blocking write requests",
         )
     if status_code == 404 or (status_code == 200 and walked == 0):
         return PATH_STATUS_EMPTY, ""  # subgen walked and found nothing = file gone

--- a/tests/test_batch_403_reason.py
+++ b/tests/test_batch_403_reason.py
@@ -1,0 +1,37 @@
+"""#540: subgen's containment guard answers POST /batch with 403 and a body
+naming the reason ("directory is outside the allowed media root"). subarr
+replaced it with a guess about auth and reverse proxies (#524). Show what
+subgen said, and name the variable that fixes it."""
+
+from __future__ import annotations
+
+from subarr.scan_runner import classify_batch_outcome
+from subarr.scan_store import PATH_STATUS_ERROR
+
+
+def test_containment_403_names_the_allowlist_variable():
+    status, err = classify_batch_outcome(
+        403, {"walked": 0, "error": "directory is outside the allowed media root"}
+    )
+    assert status == PATH_STATUS_ERROR
+    assert "outside the allowed media root" in err
+    assert "SUBGEN_PATH_ALLOWLIST" in err
+    assert "auth" not in err.lower() and "proxy" not in err.lower()
+
+
+def test_403_with_another_error_body_shows_that_error():
+    status, err = classify_batch_outcome(403, {"error": "model is loading"})
+    assert status == PATH_STATUS_ERROR
+    assert "model is loading" in err
+    assert "SUBGEN_PATH_ALLOWLIST" not in err
+
+
+def test_403_without_a_body_keeps_the_auth_proxy_wording():
+    status, err = classify_batch_outcome(403, {})
+    assert status == PATH_STATUS_ERROR
+    assert "403" in err and ("auth" in err.lower() or "proxy" in err.lower())
+
+
+def test_401_with_error_body_shows_it_too():
+    _, err = classify_batch_outcome(401, {"error": "api key required"})
+    assert "api key required" in err

--- a/tests/test_docker_log_pump.py
+++ b/tests/test_docker_log_pump.py
@@ -240,3 +240,11 @@ def test_trailing_partial_line_is_delivered_when_the_stream_ends():
         return got
 
     assert asyncio.run(asyncio.wait_for(go(), timeout=2.0)) == ["complete", "no newline at end"]
+
+
+# #540: uvicorn colours its access log; a TTY-less container still carries the
+# escapes, and the Logs page showed `^[[32mINFO^[[0m` verbatim (#524).
+def test_ansi_escapes_are_stripped_from_lines():
+    raw = b'\x1b[32mINFO\x1b[0m:     1.2.3.4:1 - "\x1b[1mGET /queue HTTP/1.1\x1b[0m" \x1b[32m200 OK\x1b[0m\n'
+    stream = ChunkStream([raw])
+    assert _collect(stream, 1) == ['INFO:     1.2.3.4:1 - "GET /queue HTTP/1.1" 200 OK']


### PR DESCRIPTION
Closes #540, closes #541. From Jorman's 403 on #524.

**#540** `classify_batch_outcome` shows subgen's `error` body on 401/403. For the containment guard's "outside the allowed media root" it names `SUBGEN_PATH_ALLOWLIST`, its default, and what to set. A bare 401/403 keeps the auth/proxy wording. The log pump strips ANSI CSI sequences (uvicorn's coloured access log was rendered verbatim).

**#541** `SUBGEN_PATH_ALLOWLIST` documented in the README env table, the "I already have subgen" section, and `docs/first-run.md` (paths paragraph and a red-state row). The subarr-subgen README quickstart gets the same paragraph in its own commit.

Tests: 4 new classifier cases, 1 new pump case; `test_scan`, `test_skip_outcome_propagation` and the pump suite pass together (36). README freshness guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
